### PR TITLE
Read-only support

### DIFF
--- a/taglib/ape/apefile.cpp
+++ b/taglib/ape/apefile.cpp
@@ -85,8 +85,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-APE::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+APE::File::File(FileName file, bool openReadOnly, bool readProperties,
+                Properties::ReadStyle propertiesStyle) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/ape/apefile.h
+++ b/taglib/ape/apefile.h
@@ -88,7 +88,7 @@ namespace TagLib {
        * file's audio properties will also be read using \a propertiesStyle.  If
        * false, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -362,8 +362,8 @@ ByteVector ASF::File::HeaderExtensionObject::render(ASF::File *file)
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-ASF::File::File(FileName file, bool readProperties, Properties::ReadStyle propertiesStyle) 
-  : TagLib::File(file)
+ASF::File::File(FileName file, bool openReadOnly, bool readProperties, Properties::ReadStyle propertiesStyle) 
+  : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/asf/asffile.h
+++ b/taglib/asf/asffile.h
@@ -55,7 +55,7 @@ namespace TagLib {
        * \note In the current implementation, both \a readProperties and
        * \a propertiesStyle are ignored.
        */
-      File(FileName file, bool readProperties = true, Properties::ReadStyle propertiesStyle = Properties::Average);
+      File(FileName file, bool openReadOnly = false, bool readProperties = true, Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
        * Destroys this instance of the File.

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -75,10 +75,10 @@ FileRef::FileRef()
   d = new FileRefPrivate(0);
 }
 
-FileRef::FileRef(FileName fileName, bool readAudioProperties,
+FileRef::FileRef(FileName fileName, bool openReadOnly, bool readAudioProperties,
                  AudioProperties::ReadStyle audioPropertiesStyle)
 {
-  d = new FileRefPrivate(create(fileName, readAudioProperties, audioPropertiesStyle));
+  d = new FileRefPrivate(create(fileName, openReadOnly, readAudioProperties, audioPropertiesStyle));
 }
 
 FileRef::FileRef(File *file)
@@ -195,14 +195,14 @@ bool FileRef::operator!=(const FileRef &ref) const
   return ref.d->file != d->file;
 }
 
-File *FileRef::create(FileName fileName, bool readAudioProperties,
+File *FileRef::create(FileName fileName, bool openReadOnly, bool readAudioProperties,
                       AudioProperties::ReadStyle audioPropertiesStyle) // static
 {
 
   List<const FileTypeResolver *>::ConstIterator it = FileRefPrivate::fileTypeResolvers.begin();
 
   for(; it != FileRefPrivate::fileTypeResolvers.end(); ++it) {
-    File *file = (*it)->createFile(fileName, readAudioProperties, audioPropertiesStyle);
+    File *file = (*it)->createFile(fileName, openReadOnly, readAudioProperties, audioPropertiesStyle);
     if(file)
       return file;
   }

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -102,7 +102,7 @@ namespace TagLib {
        * deleted.  Deletion will happen automatically when the FileRef passes
        * out of scope.
        */
-      virtual File *createFile(FileName fileName,
+      virtual File *createFile(FileName fileName, bool openReadOnly = false,
                                bool readAudioProperties = true,
                                AudioProperties::ReadStyle
                                audioPropertiesStyle = AudioProperties::Average) const = 0;
@@ -122,7 +122,7 @@ namespace TagLib {
      * Also see the note in the class documentation about why you may not want to
      * use this method in your application.
      */
-    explicit FileRef(FileName fileName,
+    explicit FileRef(FileName fileName, bool openReadOnly = false,
                      bool readAudioProperties = true,
                      AudioProperties::ReadStyle
                      audioPropertiesStyle = AudioProperties::Average);
@@ -248,7 +248,7 @@ namespace TagLib {
      *
      * \deprecated
      */
-    static File *create(FileName fileName,
+    static File *create(FileName fileName, bool openReadOnly = false,
                         bool readAudioProperties = true,
                         AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
 

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -102,17 +102,17 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-FLAC::File::File(FileName file, bool readProperties,
+FLAC::File::File(FileName file, bool openReadOnly, bool readProperties,
                  Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);
 }
 
-FLAC::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
+FLAC::File::File(FileName file, ID3v2::FrameFactory *frameFactory, bool openReadOnly, 
                  bool readProperties, Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   d->ID3v2FrameFactory = frameFactory;

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -74,7 +74,7 @@ namespace TagLib {
        * \deprecated This constructor will be dropped in favor of the one below
        * in a future version.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
@@ -86,7 +86,7 @@ namespace TagLib {
        * \a frameFactory.
        */
       // BIC: merge with the above constructor
-      File(FileName file, ID3v2::FrameFactory *frameFactory,
+      File(FileName file, ID3v2::FrameFactory *frameFactory, bool openReadOnly = false, 
            bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -65,8 +65,8 @@ public:
   MP4::Properties *properties;
 };
 
-MP4::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
-    : TagLib::File(file)
+MP4::File::File(FileName file, bool openReadOnly, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
+    : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, audioPropertiesStyle);

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -56,7 +56,7 @@ namespace TagLib {
        * \note In the current implementation, both \a readProperties and
        * \a propertiesStyle are ignored.
        */
-      File(FileName file, bool readProperties = true, Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+      File(FileName file, bool openReadOnly = false, bool readProperties = true, Properties::ReadStyle audioPropertiesStyle = Properties::Average);
 
       /*!
        * Destroys this instance of the File.

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -89,8 +89,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-MPC::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+MPC::File::File(FileName file, bool openReadOnly, bool readProperties,
+                Properties::ReadStyle propertiesStyle) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/mpc/mpcfile.h
+++ b/taglib/mpc/mpcfile.h
@@ -85,7 +85,7 @@ namespace TagLib {
        * file's audio properties will also be read using \a propertiesStyle.  If
        * false, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -94,8 +94,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-MPEG::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+MPEG::File::File(FileName file, bool openReadOnly, bool readProperties,
+                 Properties::ReadStyle propertiesStyle) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
 
@@ -103,9 +103,9 @@ MPEG::File::File(FileName file, bool readProperties,
     read(readProperties, propertiesStyle);
 }
 
-MPEG::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
+MPEG::File::File(FileName file, ID3v2::FrameFactory *frameFactory, bool openReadOnly,
                  bool readProperties, Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate(frameFactory);
 

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -77,7 +77,7 @@ namespace TagLib {
        * \deprecated This constructor will be dropped in favor of the one below
        * in a future version.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
@@ -87,7 +87,7 @@ namespace TagLib {
        * \a frameFactory.
        */
       // BIC: merge with the above constructor
-      File(FileName file, ID3v2::FrameFactory *frameFactory,
+      File(FileName file, ID3v2::FrameFactory *frameFactory, bool openReadOnly = false,
            bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -68,8 +68,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Ogg::FLAC::File::File(FileName file, bool readProperties,
-                      Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+Ogg::FLAC::File::File(FileName file, bool openReadOnly, bool readProperties,
+                      Properties::ReadStyle propertiesStyle) : Ogg::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/ogg/flac/oggflacfile.h
+++ b/taglib/ogg/flac/oggflacfile.h
@@ -68,7 +68,7 @@ namespace TagLib {
        * the file's audio properties will also be read using \a propertiesStyle.
        * If false, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -208,7 +208,7 @@ bool Ogg::File::save()
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
 
-Ogg::File::File(FileName file) : TagLib::File(file)
+Ogg::File::File(FileName file, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
 }

--- a/taglib/ogg/oggfile.h
+++ b/taglib/ogg/oggfile.h
@@ -90,7 +90,7 @@ namespace TagLib {
        * instantiated directly but rather should be used through the codec
        * specific subclasses.
        */
-      File(FileName file);
+      File(FileName file, bool openReadOnly);
 
     private:
       File(const File &);

--- a/taglib/ogg/speex/speexfile.cpp
+++ b/taglib/ogg/speex/speexfile.cpp
@@ -58,8 +58,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Speex::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+Speex::File::File(FileName file, bool openReadOnly, bool readProperties,
+                   Properties::ReadStyle propertiesStyle) : Ogg::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/ogg/speex/speexfile.h
+++ b/taglib/ogg/speex/speexfile.h
@@ -60,7 +60,7 @@ namespace TagLib {
          * file's audio properties will also be read using \a propertiesStyle.  If
          * false, \a propertiesStyle is ignored.
          */
-        File(FileName file, bool readProperties = true,
+        File(FileName file, bool openReadOnly = false, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!

--- a/taglib/ogg/vorbis/vorbisfile.cpp
+++ b/taglib/ogg/vorbis/vorbisfile.cpp
@@ -61,8 +61,8 @@ namespace TagLib {
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Vorbis::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+Vorbis::File::File(FileName file, bool openReadOnly, bool readProperties,
+                   Properties::ReadStyle propertiesStyle) : Ogg::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/ogg/vorbis/vorbisfile.h
+++ b/taglib/ogg/vorbis/vorbisfile.h
@@ -67,7 +67,7 @@ namespace TagLib {
        * file's audio properties will also be read using \a propertiesStyle.  If
        * false, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -57,8 +57,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::AIFF::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, BigEndian)
+RIFF::AIFF::File::File(FileName file, bool openReadOnly, bool readProperties,
+                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, openReadOnly, BigEndian)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -62,7 +62,7 @@ namespace TagLib {
          * file's audio properties will also be read using \a propertiesStyle.  If
          * false, \a propertiesStyle is ignored.
          */
-        File(FileName file, bool readProperties = true,
+        File(FileName file, bool openReadOnly = false, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!

--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -70,7 +70,7 @@ RIFF::File::~File()
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::File::File(FileName file, Endianness endianness) : TagLib::File(file)
+RIFF::File::File(FileName file, bool openReadOnly, Endianness endianness) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   d->endianness = endianness;

--- a/taglib/riff/rifffile.h
+++ b/taglib/riff/rifffile.h
@@ -55,7 +55,7 @@ namespace TagLib {
 
       enum Endianness { BigEndian, LittleEndian };
 
-      File(FileName file, Endianness endianness);
+      File(FileName file, bool openReadOnly, Endianness endianness);
 
       /*!
        * \return The size of the main RIFF chunk.

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -57,8 +57,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::WAV::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, LittleEndian)
+RIFF::WAV::File::File(FileName file, bool openReadOnly, bool readProperties,
+                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, openReadOnly, LittleEndian)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -62,7 +62,7 @@ namespace TagLib {
          * file's audio properties will also be read using \a propertiesStyle.  If
          * false, \a propertiesStyle is ignored.
          */
-        File(FileName file, bool readProperties = true,
+        File(FileName file, bool openReadOnly = false, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!

--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -68,7 +68,7 @@ struct FileNameHandle : public std::string
 class File::FilePrivate
 {
 public:
-  FilePrivate(FileName fileName);
+  FilePrivate(FileName fileName, bool openReadOnly);
 
   FILE *file;
 
@@ -80,7 +80,7 @@ public:
   static const uint bufferSize = 1024;
 };
 
-File::FilePrivate::FilePrivate(FileName fileName) :
+File::FilePrivate::FilePrivate(FileName fileName, bool openReadOnly) :
   file(0),
   name(fileName),
   readOnly(true),
@@ -93,12 +93,16 @@ File::FilePrivate::FilePrivate(FileName fileName) :
 
   if(wcslen((const wchar_t *) fileName) > 0) {
 
-    file = _wfopen(name, L"rb+");
-
-    if(file)
-      readOnly = false;
-    else
+    if(openReadOnly)
       file = _wfopen(name, L"rb");
+    else {
+      file = _wfopen(name, L"rb+");
+
+      if(file)
+        readOnly = false;
+      else
+        file = _wfopen(name, L"rb");
+    }
 
     if(file)
       return;
@@ -107,12 +111,16 @@ File::FilePrivate::FilePrivate(FileName fileName) :
 
 #endif
 
-  file = fopen(name, "rb+");
-
-  if(file)
-    readOnly = false;
-  else
+  if(openReadOnly)
     file = fopen(name, "rb");
+  else {
+    file = fopen(name, "rb+");
+
+    if(file)
+      readOnly = false;
+    else
+      file = fopen(name, "rb");
+  }
 
   if(!file)
   {
@@ -124,9 +132,9 @@ File::FilePrivate::FilePrivate(FileName fileName) :
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-File::File(FileName file)
+File::File(FileName file, bool openReadOnly)
 {
-  d = new FilePrivate(file);
+  d = new FilePrivate(file, openReadOnly);
 }
 
 File::~File()

--- a/taglib/toolkit/tfile.h
+++ b/taglib/toolkit/tfile.h
@@ -238,7 +238,7 @@ namespace TagLib {
      * \note Constructor is protected since this class should only be
      * instantiated through subclasses.
      */
-    File(FileName file);
+    File(FileName file, bool openReadOnly = false);
 
     /*!
      * Marks the file as valid or invalid.

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -82,8 +82,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-TrueAudio::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+TrueAudio::File::File(FileName file, bool openReadOnly, bool readProperties,
+                 Properties::ReadStyle propertiesStyle) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -83,7 +83,7 @@ namespace TagLib {
        * file's audio properties will also be read using \a propertiesStyle.  If
        * false, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -81,8 +81,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-WavPack::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+WavPack::File::File(FileName file, bool openReadOnly, bool readProperties,
+                Properties::ReadStyle propertiesStyle) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -84,7 +84,7 @@ namespace TagLib {
        * file's audio properties will also be read using \a propertiesStyle.  If
        * false, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true,
+      File(FileName file, bool openReadOnly = false, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!


### PR DESCRIPTION
This patch implements explicit read-only support for taglib.  I'm not sure how you'll feel about it, but certain draconian organizations (AKA the Mac App Store) don't let applications open just any old file with read/write access.  This will allow taglib to be used in such environments.
