### PR TITLE
MPEG::File::save() ignores tag()->header()->setMajorVersion()

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -47,6 +47,11 @@ public:
   ItemListMap items;
 };
 
+MP4::Tag::Tag()
+{
+  d = new TagPrivate;
+}
+
 MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms)
 {
   d = new TagPrivate;

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -44,6 +44,7 @@ namespace TagLib {
     class TAGLIB_EXPORT Tag: public TagLib::Tag
     {
     public:
+        Tag();
         Tag(TagLib::File *file, Atoms *atoms);
         ~Tag();
         bool save();

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -331,7 +331,7 @@ void ID3v2::Tag::removeFrames(const ByteVector &id)
 
 ByteVector ID3v2::Tag::render() const
 {
-  return render(4);
+  return render(0);
 }
 
 void ID3v2::Tag::downgradeFrames(FrameList *frames, FrameList *newFrames) const
@@ -437,6 +437,9 @@ ByteVector ID3v2::Tag::render(int version) const
   // padding, but does not include the tag's header or footer.
 
   ByteVector tagData;
+	
+  if(version == 0)
+    version = header()->majorVersion();
 
   if(version != 3 && version != 4) {
     debug("Unknown ID3v2 version, using ID3v2.4");

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -269,7 +269,8 @@ namespace TagLib {
        * Render the tag back to binary data, suitable to be written to disk.
        *
        * The \a version parameter specifies the version of the rendered
-       * ID3v2 tag. It can be either 4 or 3.
+       * ID3v2 tag. It can be either 4 or 3. Set it to zero to get version 
+       * from header
        */
       // BIC: combine with the above method
       ByteVector render(int version) const;

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -150,7 +150,7 @@ bool MPEG::File::save(int tags)
 
 bool MPEG::File::save(int tags, bool stripOthers)
 {
-  return save(tags, stripOthers, 4);
+  return save(tags, stripOthers, 0);
 }
 
 bool MPEG::File::save(int tags, bool stripOthers, int id3v2Version)

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -184,7 +184,7 @@ namespace TagLib {
        * use of these tags will remain valid.  This also strips empty tags.
        *
        * The \a id3v2Version parameter specifies the version of the saved
-       * ID3v2 tag. It can be either 4 or 3.
+       * ID3v2 tag. It can be either 4 or 3. Set it to zero to get version from header.
        */
       // BIC: combine with the above method
       bool save(int tags, bool stripOthers, int id3v2Version);


### PR DESCRIPTION
Save tags in latest available version realy not good idea. For example windows media player and windows explorer can't read ID3v2.4 tags. 

Fixed realy strange behavior.

TagLib::MPEG::FileRef fref(filename); // .mp3 file without any tags
TagLib::MPEG::File\* file = fref.file();
TagLib::ID3v2::Tag *tag = file->ID3v2Tag();
ASSERT(tag);
tag->header()->setMajorVersion(3); // !!!
// set other tag fields
fref.save();

Got ID3v2.4 tags in file.

PS. Also added constructor MP4::Tag::Tag()
