### PR TITLE
default constructor MP4::Tag::Tag()

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -47,6 +47,11 @@ public:
   ItemListMap items;
 };
 
+MP4::Tag::Tag()
+{
+  d = new TagPrivate;
+}
+
 MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms)
 {
   d = new TagPrivate;

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -44,6 +44,7 @@ namespace TagLib {
     class TAGLIB_EXPORT Tag: public TagLib::Tag
     {
     public:
+        Tag();
         Tag(TagLib::File *file, Atoms *atoms);
         ~Tag();
         bool save();


### PR DESCRIPTION
All other tags has default constructors.

To keep tags in memory when source file closed
