### PR TITLE
Added sampleFrames() to AIFFProperties and WAVProperties

### DIFF
--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -85,7 +85,8 @@ public:
     bitrate(0),
     sampleRate(0),
     channels(0),
-    sampleWidth(0)
+    sampleWidth(0),
+	sampleFrames(0)
   {
 
   }
@@ -95,6 +96,7 @@ public:
   int sampleRate;
   int channels;
   int sampleWidth;
+  uint sampleFrames;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -137,6 +139,11 @@ int RIFF::AIFF::Properties::sampleWidth() const
   return d->sampleWidth;
 }
 
+uint RIFF::AIFF::Properties::sampleFrames() const
+{
+	return d->sampleFrames;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // private members
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,10 +151,10 @@ int RIFF::AIFF::Properties::sampleWidth() const
 void RIFF::AIFF::Properties::read(const ByteVector &data)
 {
   d->channels       = data.mid(0, 2).toShort();
-  uint sampleFrames = data.mid(2, 4).toUInt();
+  d->sampleFrames   = data.mid(2, 4).toUInt();
   d->sampleWidth    = data.mid(6, 2).toShort();
   double sampleRate = ConvertFromIeeeExtended(reinterpret_cast<unsigned char *>(data.mid(8, 10).data()));
   d->sampleRate     = sampleRate;
   d->bitrate        = (sampleRate * d->sampleWidth * d->channels) / 1000.0;
-  d->length         = sampleFrames / d->sampleRate;
+  d->length         = d->sampleFrames / d->sampleRate;
 }

--- a/taglib/riff/aiff/aiffproperties.h
+++ b/taglib/riff/aiff/aiffproperties.h
@@ -65,6 +65,7 @@ namespace TagLib {
 	virtual int channels() const;
 
 	int sampleWidth() const;
+	uint sampleFrames() const;
 
       private:
 	Properties(const Properties &);

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -42,6 +42,7 @@ public:
     sampleRate(0),
     channels(0),
     sampleWidth(0),
+	sampleFrames(0),
     streamLength(streamLength)
   {
 
@@ -53,6 +54,7 @@ public:
   int sampleRate;
   int channels;
   int sampleWidth;
+  uint sampleFrames;
   uint streamLength;
 };
 
@@ -102,6 +104,11 @@ int RIFF::WAV::Properties::sampleWidth() const
   return d->sampleWidth;
 }
 
+uint RIFF::WAV::Properties::sampleFrames() const
+{
+	return d->sampleFrames;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // private members
 ////////////////////////////////////////////////////////////////////////////////
@@ -117,4 +124,5 @@ void RIFF::WAV::Properties::read(const ByteVector &data)
   d->bitrate = byteRate * 8 / 1000;
 
   d->length = byteRate > 0 ? d->streamLength / byteRate : 0;
+  d->sampleFrames = d->streamLength / (d->channels * (d->sampleWidth / 8));
 }

--- a/taglib/riff/wav/wavproperties.h
+++ b/taglib/riff/wav/wavproperties.h
@@ -74,6 +74,7 @@ namespace TagLib {
 	virtual int channels() const;
 
 	int sampleWidth() const;
+	uint sampleFrames() const;
 
       private:
 	Properties(const Properties &);


### PR DESCRIPTION
I added methods to get the total number of frames for AIFF and WAVE files.
