### PR TITLE
Find APE tags even if there's a Lyrics3v2 tag present

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ TagLib 1.8 (In Development)
  * Support for writing ID3v2.3 tags.
  * Added methods for checking if WMA and MP4 files are DRM-protected.
  * Started using atomic int operations for reference counting.
+ * Find APE tags even if there's a Lyrics3v2 tag present (BUG:254223).
 
 TagLib 1.7 (Mar 11, 2011)
 =========================

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -607,54 +607,8 @@ void MPEG::File::findLyrics3v2()
       seek(offset, End);
       
       ByteVector sizeVector = readBlock(6);
-      long size = 15;
-      int exp = 1;
-      int value = 0;
-      for(int i=sizeVector.size(); i>0; i--) {
-        switch(sizeVector.at(i-1)) {
-          case '1': {
-            value = 1;
-            break;
-          }
-          case '2': {
-            value = 2;
-            break;
-          }
-          case '3': {
-            value = 3;
-            break;
-          }
-          case '4': {
-            value = 4;
-            break;
-          }
-          case '5': {
-            value = 5;
-            break;
-          }
-          case '6': {
-            value = 6;
-            break;
-          }
-          case '7': {
-            value = 7;
-            break;
-          }
-          case '8': {
-            value = 8;
-            break;
-          }
-          case '9': {
-            value = 9;
-            break;
-          }
-          default:
-            value = 0;
-        }
-        size += value * exp;
-        exp *= 10;
-      }
-      d->lyrics3v2Size = size;
+      d->lyrics3v2Size = 15 + readNumber(sizeVector);
+      
       return;
     }
   }
@@ -688,6 +642,58 @@ void MPEG::File::findAPE()
 
   d->APELocation = -1;
   d->APEFooterLocation = -1;
+}
+
+long MPEG::File::readNumber(ByteVector vector)
+{
+  long number = 0;
+  int exp = 1;
+  int value = 0;
+  for(int i=vector.size(); i>0; i--) {
+    switch(vector.at(i-1)) {
+      case '1': {
+        value = 1;
+        break;
+      }
+      case '2': {
+        value = 2;
+        break;
+      }
+      case '3': {
+        value = 3;
+        break;
+      }
+      case '4': {
+        value = 4;
+        break;
+      }
+      case '5': {
+        value = 5;
+        break;
+      }
+      case '6': {
+        value = 6;
+        break;
+      }
+      case '7': {
+        value = 7;
+        break;
+      }
+      case '8': {
+        value = 8;
+        break;
+      }
+      case '9': {
+        value = 9;
+        break;
+      }
+      default:
+        value = 0;
+    }
+    number += value * exp;
+    exp *= 10;
+  }
+  return number;
 }
 
 bool MPEG::File::secondSynchByte(char byte)

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -287,6 +287,7 @@ namespace TagLib {
       void read(bool readProperties, Properties::ReadStyle propertiesStyle);
       long findID3v2();
       long findID3v1();
+      void findLyrics3v2();
       void findAPE();
 
       /*!

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -291,6 +291,11 @@ namespace TagLib {
       void findAPE();
 
       /*!
+       * Extracts a number from a ByteVector
+       */
+      long readNumber(ByteVector vector);
+
+      /*!
        * MPEG frames can be recognized by the bit pattern 11111111 111, so the
        * first byte is easy to check for, however checking to see if the second byte
        * starts with \e 111 is a bit more tricky, hence this member function.


### PR DESCRIPTION
Currently taglib can't find APE tags if there's a Lyrics3v2 tag present.
I wrote a patch some time ago but it didn't get noticed, so I hope that requesting a pull here is the proper way.

If you need test files, please write me a mail or private message.

http://bugs.kde.org/show_bug.cgi?id=254223