### PR TITLE
Some non-PCM wave files can cause SIG_ARITHMETIC

### DIFF
--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -156,5 +156,5 @@ void RIFF::AIFF::Properties::read(const ByteVector &data)
   double sampleRate = ConvertFromIeeeExtended(reinterpret_cast<unsigned char *>(data.mid(8, 10).data()));
   d->sampleRate     = sampleRate;
   d->bitrate        = (sampleRate * d->sampleWidth * d->channels) / 1000.0;
-  d->length         = d->sampleFrames / d->sampleRate;
+  d->length         = d->sampleRate > 0 ? d->sampleFrames / d->sampleRate : 0;
 }

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -124,5 +124,6 @@ void RIFF::WAV::Properties::read(const ByteVector &data)
   d->bitrate = byteRate * 8 / 1000;
 
   d->length = byteRate > 0 ? d->streamLength / byteRate : 0;
-  d->sampleFrames = d->streamLength / (d->channels * (d->sampleWidth / 8));
+  if(d->channels > 0 && d->sampleWidth > 0)
+    d->sampleFrames = d->streamLength / (d->channels * (d->sampleWidth / 8));
 }


### PR DESCRIPTION
In a previous patch I submitted code to read the sample width and frame count for wav and aiff files.  There was a bug in that code that leads to a crash on certain wav files.  I've seen this in a wav that has an audio format of MP3 (0x55).  Since the wav header indicates that the bit depth is 0 (compressed), a divide by zero error occurs when calculating the total audio frames.  I've no idea why you would put MP3 data in a wav, but regardless, the code shouldn't crash.

I went ahead and added checks to the aiff code as well, although I haven't received any crash reports in the wild for those kind of files.
