### PR TITLE
ByteVector::replace performance improvements

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -463,7 +463,7 @@ ByteVector &ByteVector::replace(const ByteVector &pattern, const ByteVector &wit
 
   // new private data of appropriate size:
   ByteVectorPrivate *newData = new ByteVectorPrivate(newSize, 0);
-  char *target = &newData->data[0];
+  char *target = DATA(newData);
   const char *source = data();
 
   // copy modified data into new private data:


### PR DESCRIPTION
This should change performance of `ByteVector::replace` from O(n^2) (quadratic) to O(n) (linear). At least I think it was quadratic before. Before it needed to potentially resize the vector for each replacement and unless the `pattern` and `with` where the same size it also needed to move a lot of the vectors contents for each replacement. This patch first searches all patterns and thus calculates how big the new vector has to be (linear). Then it creates a new `ByteVectorPrivate` at the exact size needed and copies everything to that (also linear). This means all the bytes in the vector are only written once and looked at twice. No areas have to be moved at all.

There are also optimizations included for when `pattern.size() == with.size()` (no new `ByteVectorPrivate` is needed but all replacements are done in place) or when `pattern` is not included at all in the vector (return from function early).
