### PR TITLE
Added removePicture() to FLAC::File

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -493,6 +493,17 @@ void FLAC::File::addPicture(Picture *picture)
   d->blocks.append(picture);
 }
 
+void FLAC::File::removePicture(Picture *picture, bool del)
+{
+  MetadataBlock *block = picture;
+  List<MetadataBlock *>::Iterator it = d->blocks.find(block);
+  if(it != d->blocks.end())
+    d->blocks.erase(it);
+
+  if(del)
+    delete picture;
+}
+
 void FLAC::File::removePictures()
 {
   List<MetadataBlock *> newBlocks;

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -201,6 +201,12 @@ namespace TagLib {
        * Returns a list of pictures attached to the FLAC file.
        */
       List<Picture *> pictureList();
+      
+      /*!
+       * Removes an attached picture. If \a del is true the picture's memory
+       * will be freed; if it is false, it must be deleted by the user.
+       */
+      void removePicture(Picture *picture, bool del = true);
 
       /*!
        * Remove all attached images.


### PR DESCRIPTION
The current TagLib API doesn't contain a method for removing an individual FLAC picture block. This commit adds such a method.
