### PR TITLE
Adding visibility=hidden to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ else()
 endif()
 OPTION(ENABLE_STATIC_RUNTIME "Visual Studio, link with runtime statically"  OFF)
 
+option(VISIBILITY_HIDDEN "Build with -fvisibility=hidden"  OFF)
+if(VISIBILITY_HIDDEN)
+  add_definitions (-fvisibility=hidden)
+endif()
+
 option(BUILD_TESTS "Build the test suite"  OFF)
 option(BUILD_EXAMPLES "Build the examples"  OFF)
 


### PR DESCRIPTION
Adds to the cmake command line, e.g.

   cmake -DENABLE_STATIC=ON -DVISIBILITY_HIDDEN=ON

I'm building a static library and get errors linking with libtag.a when other libraries have been built with this visibilty flag and libtag has not.

I'm not enough of a GCC expert to know if this is better done in say taglib_export.h (or if it can be done there). This change works nicely though.
