### PR TITLE
Use wchar, uchar, ushort, uint, ulong in TagLib:: all the time to preven...

### DIFF
--- a/taglib/ape/apefile.cpp
+++ b/taglib/ape/apefile.cpp
@@ -66,7 +66,7 @@ public:
   }
 
   long APELocation;
-  uint APESize;
+  TagLib::uint APESize;
 
   long ID3v1Location;
 

--- a/taglib/ape/apefooter.cpp
+++ b/taglib/ape/apefooter.cpp
@@ -47,17 +47,17 @@ public:
 
   ~FooterPrivate() {}
 
-  uint version;
+  TagLib::uint version;
 
   bool footerPresent;
   bool headerPresent;
 
   bool isHeader;
 
-  uint itemCount;
-  uint tagSize;
+  TagLib::uint itemCount;
+  TagLib::uint tagSize;
 
-  static const uint size = 32;
+  static const TagLib::uint size = 32;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,7 +124,7 @@ TagLib::uint Footer::itemCount() const
   return d->itemCount;
 }
 
-void Footer::setItemCount(uint s)
+void Footer::setItemCount(TagLib::uint s)
 {
   d->itemCount = s;
 }
@@ -142,7 +142,7 @@ TagLib::uint Footer::completeTagSize() const
     return d->tagSize;
 }
 
-void Footer::setTagSize(uint s)
+void Footer::setTagSize(TagLib::uint s)
 {
   d->tagSize = s;
 }

--- a/taglib/ape/apeitem.cpp
+++ b/taglib/ape/apeitem.cpp
@@ -183,8 +183,8 @@ void APE::Item::parse(const ByteVector &data)
     return;
   }
 
-  uint valueLength  = data.mid(0, 4).toUInt(false);
-  uint flags        = data.mid(4, 4).toUInt(false);
+  TagLib::uint valueLength  = data.mid(0, 4).toUInt(false);
+  TagLib::uint flags        = data.mid(4, 4).toUInt(false);
 
   d->key = String(data.mid(8), String::UTF8);
 

--- a/taglib/ape/apeproperties.cpp
+++ b/taglib/ape/apeproperties.cpp
@@ -175,7 +175,7 @@ void APE::Properties::analyzeCurrent()
   // Read the descriptor
   d->file->seek(2, File::Current);
   ByteVector descriptor = d->file->readBlock(44);
-  uint descriptorBytes = descriptor.mid(0,4).toUInt(false);
+  TagLib::uint descriptorBytes = descriptor.mid(0,4).toUInt(false);
 
   if ((descriptorBytes - 52) > 0)
     d->file->seek(descriptorBytes - 52, File::Current);
@@ -189,10 +189,10 @@ void APE::Properties::analyzeCurrent()
   d->bitsPerSample = header.mid(16, 2).toShort(false);
   //d->compressionLevel =
 
-  uint totalFrames = header.mid(12, 4).toUInt(false);
-  uint blocksPerFrame = header.mid(4, 4).toUInt(false);
-  uint finalFrameBlocks = header.mid(8, 4).toUInt(false);
-  uint totalBlocks = totalFrames > 0 ? (totalFrames -  1) * blocksPerFrame + finalFrameBlocks : 0;
+  TagLib::uint totalFrames = header.mid(12, 4).toUInt(false);
+  TagLib::uint blocksPerFrame = header.mid(4, 4).toUInt(false);
+  TagLib::uint finalFrameBlocks = header.mid(8, 4).toUInt(false);
+  TagLib::uint totalBlocks = totalFrames > 0 ? (totalFrames -  1) * blocksPerFrame + finalFrameBlocks : 0;
   d->length = totalBlocks / d->sampleRate;
   d->bitrate = d->length > 0 ? ((d->streamLength * 8L) / d->length) / 1000 : 0;
 }
@@ -200,14 +200,14 @@ void APE::Properties::analyzeCurrent()
 void APE::Properties::analyzeOld()
 {
   ByteVector header = d->file->readBlock(26);
-  uint totalFrames = header.mid(18, 4).toUInt(false);
+  TagLib::uint totalFrames = header.mid(18, 4).toUInt(false);
 
   // Fail on 0 length APE files (catches non-finalized APE files)
   if(totalFrames == 0)
     return;
 
   short compressionLevel = header.mid(0, 2).toShort(false);
-  uint blocksPerFrame;
+  TagLib::uint blocksPerFrame;
   if(d->version >= 3950)
     blocksPerFrame = 73728 * 4;
   else if(d->version >= 3900 || (d->version >= 3800 && compressionLevel == 4000))
@@ -216,8 +216,8 @@ void APE::Properties::analyzeOld()
     blocksPerFrame = 9216;
   d->channels = header.mid(4, 2).toShort(false);
   d->sampleRate = header.mid(6, 4).toUInt(false);
-  uint finalFrameBlocks = header.mid(22, 4).toUInt(false);
-  uint totalBlocks = totalFrames > 0 ? (totalFrames - 1) * blocksPerFrame + finalFrameBlocks : 0;
+  TagLib::uint finalFrameBlocks = header.mid(22, 4).toUInt(false);
+  TagLib::uint totalBlocks = totalFrames > 0 ? (totalFrames - 1) * blocksPerFrame + finalFrameBlocks : 0;
   d->length = totalBlocks / d->sampleRate;
   d->bitrate = d->length > 0 ? ((d->streamLength * 8L) / d->length) / 1000 : 0;
 }

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -158,7 +158,7 @@ void APE::Tag::setGenre(const String &s)
   addValue("GENRE", s, true);
 }
 
-void APE::Tag::setYear(uint i)
+void APE::Tag::setYear(TagLib::uint i)
 {
   if(i <= 0)
     removeItem("YEAR");
@@ -166,7 +166,7 @@ void APE::Tag::setYear(uint i)
     addValue("YEAR", String::number(i), true);
 }
 
-void APE::Tag::setTrack(uint i)
+void APE::Tag::setTrack(TagLib::uint i)
 {
   if(i <= 0)
     removeItem("TRACK");
@@ -225,7 +225,7 @@ void APE::Tag::read()
     d->footer.setData(d->file->readBlock(Footer::size()));
 
     if(d->footer.tagSize() <= Footer::size() ||
-       d->footer.tagSize() > uint(d->file->length()))
+       d->footer.tagSize() > TagLib::uint(d->file->length()))
       return;
 
     d->file->seek(d->footerLocation + Footer::size() - d->footer.tagSize());
@@ -236,7 +236,7 @@ void APE::Tag::read()
 ByteVector APE::Tag::render() const
 {
   ByteVector data;
-  uint itemCount = 0;
+  TagLib::uint itemCount = 0;
 
   {
     for(Map<const String, Item>::ConstIterator it = d->itemListMap.begin();
@@ -256,11 +256,11 @@ ByteVector APE::Tag::render() const
 
 void APE::Tag::parse(const ByteVector &data)
 {
-  uint pos = 0;
+  TagLib::uint pos = 0;
 
   // 11 bytes is the minimum size for an APE item
 
-  for(uint i = 0; i < d->footer.itemCount() && pos <= data.size() - 11; i++) {
+  for(TagLib::uint i = 0; i < d->footer.itemCount() && pos <= data.size() - 11; i++) {
     APE::Item item;
     item.parse(data.mid(pos));
 

--- a/taglib/asf/asfattribute.cpp
+++ b/taglib/asf/asfattribute.cpp
@@ -179,7 +179,7 @@ ASF::Picture ASF::Attribute::toPicture() const
 
 String ASF::Attribute::parse(ASF::File &f, int kind)
 {
-  uint size, nameLength;
+  TagLib::uint size, nameLength;
   String name;
   d->pictureValue = Picture::fromInvalid();
   // extended content descriptor

--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -93,21 +93,21 @@ class ASF::File::FilePropertiesObject : public ASF::File::BaseObject
 {
 public:
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
 };
 
 class ASF::File::StreamPropertiesObject : public ASF::File::BaseObject
 {
 public:
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
 };
 
 class ASF::File::ContentDescriptionObject : public ASF::File::BaseObject
 {
 public:
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
   ByteVector render(ASF::File *file);
 };
 
@@ -116,7 +116,7 @@ class ASF::File::ExtendedContentDescriptionObject : public ASF::File::BaseObject
 public:
   ByteVectorList attributeData;
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
   ByteVector render(ASF::File *file);
 };
 
@@ -125,7 +125,7 @@ class ASF::File::MetadataObject : public ASF::File::BaseObject
 public:
   ByteVectorList attributeData;
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
   ByteVector render(ASF::File *file);
 };
 
@@ -134,7 +134,7 @@ class ASF::File::MetadataLibraryObject : public ASF::File::BaseObject
 public:
   ByteVectorList attributeData;
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
   ByteVector render(ASF::File *file);
 };
 
@@ -143,7 +143,7 @@ class ASF::File::HeaderExtensionObject : public ASF::File::BaseObject
 public:
   List<ASF::File::BaseObject *> objects;
   ByteVector guid();
-  void parse(ASF::File *file, uint size);
+  void parse(ASF::File *file, TagLib::uint size);
   ByteVector render(ASF::File *file);
 };
 
@@ -175,7 +175,7 @@ ByteVector ASF::File::FilePropertiesObject::guid()
   return filePropertiesGuid;
 }
 
-void ASF::File::FilePropertiesObject::parse(ASF::File *file, uint size)
+void ASF::File::FilePropertiesObject::parse(ASF::File *file, TagLib::uint size)
 {
   BaseObject::parse(file, size);
   file->d->properties->setLength((int)(data.mid(40, 8).toLongLong(false) / 10000000L - data.mid(56, 8).toLongLong(false) / 1000L));
@@ -186,7 +186,7 @@ ByteVector ASF::File::StreamPropertiesObject::guid()
   return streamPropertiesGuid;
 }
 
-void ASF::File::StreamPropertiesObject::parse(ASF::File *file, uint size)
+void ASF::File::StreamPropertiesObject::parse(ASF::File *file, TagLib::uint size)
 {
   BaseObject::parse(file, size);
   file->d->properties->setChannels(data.mid(56, 2).toShort(false));
@@ -199,7 +199,7 @@ ByteVector ASF::File::ContentDescriptionObject::guid()
   return contentDescriptionGuid;
 }
 
-void ASF::File::ContentDescriptionObject::parse(ASF::File *file, uint /*size*/)
+void ASF::File::ContentDescriptionObject::parse(ASF::File *file, TagLib::uint /*size*/)
 {
   file->d->contentDescriptionObject = this;
   int titleLength = file->readWORD();
@@ -240,7 +240,7 @@ ByteVector ASF::File::ExtendedContentDescriptionObject::guid()
   return extendedContentDescriptionGuid;
 }
 
-void ASF::File::ExtendedContentDescriptionObject::parse(ASF::File *file, uint /*size*/)
+void ASF::File::ExtendedContentDescriptionObject::parse(ASF::File *file, TagLib::uint /*size*/)
 {
   file->d->extendedContentDescriptionObject = this;
   int count = file->readWORD();
@@ -264,7 +264,7 @@ ByteVector ASF::File::MetadataObject::guid()
   return metadataGuid;
 }
 
-void ASF::File::MetadataObject::parse(ASF::File *file, uint /*size*/)
+void ASF::File::MetadataObject::parse(ASF::File *file, TagLib::uint /*size*/)
 {
   file->d->metadataObject = this;
   int count = file->readWORD();
@@ -288,7 +288,7 @@ ByteVector ASF::File::MetadataLibraryObject::guid()
   return metadataLibraryGuid;
 }
 
-void ASF::File::MetadataLibraryObject::parse(ASF::File *file, uint /*size*/)
+void ASF::File::MetadataLibraryObject::parse(ASF::File *file, TagLib::uint /*size*/)
 {
   file->d->metadataLibraryObject = this;
   int count = file->readWORD();
@@ -312,7 +312,7 @@ ByteVector ASF::File::HeaderExtensionObject::guid()
   return headerExtensionGuid;
 }
 
-void ASF::File::HeaderExtensionObject::parse(ASF::File *file, uint /*size*/)
+void ASF::File::HeaderExtensionObject::parse(ASF::File *file, TagLib::uint /*size*/)
 {
   file->d->headerExtensionObject = this;
   file->seek(18, File::Current);

--- a/taglib/asf/asfpicture.cpp
+++ b/taglib/asf/asfpicture.cpp
@@ -149,7 +149,7 @@ void ASF::Picture::parse(const ByteVector& bytes)
     return;
   int pos = 0;
   d->type = (Type)bytes[0]; ++pos;
-  uint dataLen = bytes.mid(pos, 4).toUInt(false); pos+=4;
+  TagLib::uint dataLen = bytes.mid(pos, 4).toUInt(false); pos+=4;
 
   const ByteVector nullStringTerminator(2, 0);
 

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -149,12 +149,12 @@ void ASF::Tag::setGenre(const String &value)
   setAttribute("WM/Genre", value);
 }
 
-void ASF::Tag::setYear(uint value)
+void ASF::Tag::setYear(TagLib::uint value)
 {
   setAttribute("WM/Year", String::number(value));
 }
 
-void ASF::Tag::setTrack(uint value)
+void ASF::Tag::setTrack(TagLib::uint value)
 {
   setAttribute("WM/TrackNumber", String::number(value));
 }

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -220,7 +220,7 @@ File *FileRef::create(FileName fileName, bool readAudioProperties,
   String s;
 
 #ifdef _WIN32
-  s = (wcslen((const wchar_t *) fileName) > 0) ? String((const wchar_t *) fileName) : String((const char *) fileName);
+  s = (wcslen((const TagLib::wchar *) fileName) > 0) ? String((const TagLib::wchar *) fileName) : String((const char *) fileName);
 #else
   s = fileName;
 #endif

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -69,7 +69,7 @@ public:
 
   ~FilePrivate()
   {
-    for(uint i = 0; i < blocks.size(); i++) {
+    for(TagLib::uint i = 0; i < blocks.size(); i++) {
       delete blocks[i];
     }
     delete properties;
@@ -77,7 +77,7 @@ public:
 
   const ID3v2::FrameFactory *ID3v2FrameFactory;
   long ID3v2Location;
-  uint ID3v2OriginalSize;
+  TagLib::uint ID3v2OriginalSize;
 
   long ID3v1Location;
 
@@ -166,7 +166,7 @@ bool FLAC::File::save()
 
   bool foundVorbisCommentBlock = false;
   List<MetadataBlock *> newBlocks;
-  for(uint i = 0; i < d->blocks.size(); i++) {
+  for(TagLib::uint i = 0; i < d->blocks.size(); i++) {
     MetadataBlock *block = d->blocks[i];
     if(block->code() == MetadataBlock::VorbisComment) {
       // Set the new Vorbis Comment block
@@ -189,7 +189,7 @@ bool FLAC::File::save()
   // Render data for the metadata blocks
 
   ByteVector data;
-  for(uint i = 0; i < newBlocks.size(); i++) {
+  for(TagLib::uint i = 0; i < newBlocks.size(); i++) {
     FLAC::MetadataBlock *block = newBlocks[i];
     ByteVector blockData = block->render();
     ByteVector blockHeader = ByteVector::fromUInt(blockData.size());
@@ -366,7 +366,7 @@ void FLAC::File::scan()
 
   char blockType = header[0] & 0x7f;
   bool isLastBlock = (header[0] & 0x80) != 0;
-  uint length = header.mid(1, 3).toUInt();
+  TagLib::uint length = header.mid(1, 3).toUInt();
 
   // First block should be the stream_info metadata
 
@@ -479,7 +479,7 @@ long FLAC::File::findID3v2()
 List<FLAC::Picture *> FLAC::File::pictureList()
 {
   List<Picture *> pictures;
-  for(uint i = 0; i < d->blocks.size(); i++) {
+  for(TagLib::uint i = 0; i < d->blocks.size(); i++) {
     Picture *picture = dynamic_cast<Picture *>(d->blocks[i]);
     if(picture) {
       pictures.append(picture);
@@ -507,7 +507,7 @@ void FLAC::File::removePicture(Picture *picture, bool del)
 void FLAC::File::removePictures()
 {
   List<MetadataBlock *> newBlocks;
-  for(uint i = 0; i < d->blocks.size(); i++) {
+  for(TagLib::uint i = 0; i < d->blocks.size(); i++) {
     Picture *picture = dynamic_cast<Picture *>(d->blocks[i]);
     if(picture) {
       delete picture;

--- a/taglib/flac/flacpicture.cpp
+++ b/taglib/flac/flacpicture.cpp
@@ -85,7 +85,7 @@ bool FLAC::Picture::parse(const ByteVector &data)
   int pos = 0;
   d->type = FLAC::Picture::Type(data.mid(pos, 4).toUInt());
   pos += 4;
-  uint mimeTypeLength = data.mid(pos, 4).toUInt();
+  TagLib::uint mimeTypeLength = data.mid(pos, 4).toUInt();
   pos += 4;
   if(pos + mimeTypeLength + 24 > data.size()) {
     debug("Invalid picture block.");
@@ -93,7 +93,7 @@ bool FLAC::Picture::parse(const ByteVector &data)
   }
   d->mimeType = String(data.mid(pos, mimeTypeLength), String::UTF8);
   pos += mimeTypeLength;
-  uint descriptionLength = data.mid(pos, 4).toUInt();
+  TagLib::uint descriptionLength = data.mid(pos, 4).toUInt();
   pos += 4;
   if(pos + descriptionLength + 20 > data.size()) {
     debug("Invalid picture block.");
@@ -109,7 +109,7 @@ bool FLAC::Picture::parse(const ByteVector &data)
   pos += 4;
   d->numColors = data.mid(pos, 4).toUInt();
   pos += 4;
-  uint dataLength = data.mid(pos, 4).toUInt();
+  TagLib::uint dataLength = data.mid(pos, 4).toUInt();
   pos += 4;
   if(pos + dataLength > data.size()) {
     debug("Invalid picture block.");

--- a/taglib/flac/flacproperties.cpp
+++ b/taglib/flac/flacproperties.cpp
@@ -131,7 +131,7 @@ void FLAC::Properties::read()
   // Maximum frame size (in bytes)
   pos += 3;
 
-  uint flags = d->data.mid(pos, 4).toUInt(true);
+  TagLib::uint flags = d->data.mid(pos, 4).toUInt(true);
   d->sampleRate = flags >> 12;
   d->channels = ((flags >> 9) & 7) + 1;
   d->sampleWidth = ((flags >> 4) & 31) + 1;
@@ -139,7 +139,7 @@ void FLAC::Properties::read()
   // The last 4 bits are the most significant 4 bits for the 36 bit
   // stream length in samples. (Audio files measured in days)
 
-  uint highLength =d->sampleRate > 0 ? (((flags & 0xf) << 28) / d->sampleRate) << 4 : 0;
+  TagLib::uint highLength =d->sampleRate > 0 ? (((flags & 0xf) << 28) / d->sampleRate) << 4 : 0;
   pos += 4;
 
   d->length = d->sampleRate > 0 ?

--- a/taglib/it/itfile.cpp
+++ b/taglib/it/itfile.cpp
@@ -83,9 +83,9 @@ bool IT::File::save()
 
   seek(2, Current);
 
-  ushort length = 0;
-  ushort instrumentCount = 0;
-  ushort sampleCount = 0;
+  TagLib::ushort length = 0;
+  TagLib::ushort instrumentCount = 0;
+  TagLib::ushort sampleCount = 0;
 
   if(!readU16L(length) || !readU16L(instrumentCount) || !readU16L(sampleCount))
     return false;
@@ -94,9 +94,9 @@ bool IT::File::save()
 
   // write comment as instrument and sample names:
   StringList lines = d->tag.comment().split("\n");
-  for(ushort i = 0; i < instrumentCount; ++ i) {
+  for(TagLib::ushort i = 0; i < instrumentCount; ++ i) {
     seek(192L + length + ((long)i << 2));
-    ulong instrumentOffset = 0;
+    TagLib::ulong instrumentOffset = 0;
     if(!readU32L(instrumentOffset))
       return false;
 
@@ -109,9 +109,9 @@ bool IT::File::save()
     writeByte(0);
   }
 
-  for(ushort i = 0; i < sampleCount; ++ i) {
+  for(TagLib::ushort i = 0; i < sampleCount; ++ i) {
     seek(192L + length + ((long)instrumentCount << 2) + ((long)i << 2));
-    ulong sampleOffset = 0;
+    TagLib::ulong sampleOffset = 0;
     if(!readU32L(sampleOffset))
       return false;
     
@@ -126,7 +126,7 @@ bool IT::File::save()
 
   // write rest as message:
   StringList messageLines;
-  for(uint i = instrumentCount + sampleCount; i < lines.size(); ++ i)
+  for(TagLib::uint i = instrumentCount + sampleCount; i < lines.size(); ++ i)
     messageLines.append(lines[i]);
   ByteVector message = messageLines.toString("\r").data(String::Latin1);
 
@@ -136,15 +136,15 @@ bool IT::File::save()
     message.resize(7999);
   message.append((char)0);
 
-  ushort special = 0;
-  ushort messageLength = 0;
-  ulong  messageOffset = 0;
+  TagLib::ushort special = 0;
+  TagLib::ushort messageLength = 0;
+  TagLib::ulong  messageOffset = 0;
 
   seek(46);
   if(!readU16L(special))
     return false;
 
-  ulong fileSize = File::length();
+  TagLib::ulong fileSize = File::length();
   if(special & Properties::MessageAttached) {
     seek(54);
     if(!readU16L(messageLength) || !readU32L(messageOffset))
@@ -246,8 +246,8 @@ void IT::File::read(bool)
   d->properties.setChannels(channels);
   
   // real length might be shorter because of skips and terminator
-  ushort realLength = 0;
-  for(ushort i = 0; i < length; ++ i) {
+  TagLib::ushort realLength = 0;
+  for(TagLib::ushort i = 0; i < length; ++ i) {
     READ_BYTE_AS(order);
     if(order == 255) break;
     if(order != 254) ++ realLength;
@@ -261,7 +261,7 @@ void IT::File::read(bool)
   //       Currently I just discard anything after a nil, but
   //       e.g. VLC seems to interprete a nil as a space. I
   //       don't know what is the proper behaviour.
-  for(ushort i = 0; i < instrumentCount; ++ i) {
+  for(TagLib::ushort i = 0; i < instrumentCount; ++ i) {
     seek(192L + length + ((long)i << 2));
     READ_U32L_AS(instrumentOffset);
     seek(instrumentOffset);
@@ -277,7 +277,7 @@ void IT::File::read(bool)
     comment.append(instrumentName);
   }
   
-  for(ushort i = 0; i < sampleCount; ++ i) {
+  for(TagLib::ushort i = 0; i < sampleCount; ++ i) {
     seek(192L + length + ((long)instrumentCount << 2) + ((long)i << 2));
     READ_U32L_AS(sampleOffset);
     

--- a/taglib/it/itproperties.cpp
+++ b/taglib/it/itproperties.cpp
@@ -47,20 +47,20 @@ public:
   }
 
   int    channels;
-  ushort lengthInPatterns;
-  ushort instrumentCount;
-  ushort sampleCount;
-  ushort patternCount;
-  ushort version;
-  ushort compatibleVersion;
-  ushort flags;
-  ushort special;
-  uchar  globalVolume;
-  uchar  mixVolume;
-  uchar  tempo;
-  uchar  bpmSpeed;
-  uchar  panningSeparation;
-  uchar  pitchWheelDepth;
+  TagLib::ushort lengthInPatterns;
+  TagLib::ushort instrumentCount;
+  TagLib::ushort sampleCount;
+  TagLib::ushort patternCount;
+  TagLib::ushort version;
+  TagLib::ushort compatibleVersion;
+  TagLib::ushort flags;
+  TagLib::ushort special;
+  TagLib::uchar  globalVolume;
+  TagLib::uchar  mixVolume;
+  TagLib::uchar  tempo;
+  TagLib::uchar  bpmSpeed;
+  TagLib::uchar  panningSeparation;
+  TagLib::uchar  pitchWheelDepth;
 };
 
 IT::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
@@ -94,7 +94,7 @@ int IT::Properties::channels() const
   return d->channels;
 }
 
-ushort IT::Properties::lengthInPatterns() const
+TagLib::ushort IT::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
@@ -104,67 +104,67 @@ bool IT::Properties::stereo() const
   return d->flags & Stereo;
 }
 
-ushort IT::Properties::instrumentCount() const
+TagLib::ushort IT::Properties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-ushort IT::Properties::sampleCount() const
+TagLib::ushort IT::Properties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-ushort IT::Properties::patternCount() const
+TagLib::ushort IT::Properties::patternCount() const
 {
   return d->patternCount;
 }
 
-ushort IT::Properties::version() const
+TagLib::ushort IT::Properties::version() const
 {
   return d->version;
 }
 
-ushort IT::Properties::compatibleVersion() const
+TagLib::ushort IT::Properties::compatibleVersion() const
 {
   return d->compatibleVersion;
 }
 
-ushort IT::Properties::flags() const
+TagLib::ushort IT::Properties::flags() const
 {
   return d->flags;
 }
 
-ushort IT::Properties::special() const
+TagLib::ushort IT::Properties::special() const
 {
   return d->special;
 }
 
-uchar IT::Properties::globalVolume() const
+TagLib::uchar IT::Properties::globalVolume() const
 {
   return d->globalVolume;
 }
 
-uchar IT::Properties::mixVolume() const
+TagLib::uchar IT::Properties::mixVolume() const
 {
   return d->mixVolume;
 }
 
-uchar IT::Properties::tempo() const
+TagLib::uchar IT::Properties::tempo() const
 {
   return d->tempo;
 }
 
-uchar IT::Properties::bpmSpeed() const
+TagLib::uchar IT::Properties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }
 
-uchar IT::Properties::panningSeparation() const
+TagLib::uchar IT::Properties::panningSeparation() const
 {
   return d->panningSeparation;
 }
 
-uchar IT::Properties::pitchWheelDepth() const
+TagLib::uchar IT::Properties::pitchWheelDepth() const
 {
   return d->pitchWheelDepth;
 }
@@ -174,72 +174,72 @@ void IT::Properties::setChannels(int channels)
   d->channels = channels;
 }
 
-void IT::Properties::setLengthInPatterns(ushort lengthInPatterns)
+void IT::Properties::setLengthInPatterns(TagLib::ushort lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }
 
-void IT::Properties::setInstrumentCount(ushort instrumentCount)
+void IT::Properties::setInstrumentCount(TagLib::ushort instrumentCount)
 {
   d->instrumentCount = instrumentCount;
 }
 
-void IT::Properties::setSampleCount(ushort sampleCount)
+void IT::Properties::setSampleCount(TagLib::ushort sampleCount)
 {
   d->sampleCount = sampleCount;
 }
 
-void IT::Properties::setPatternCount(ushort patternCount)
+void IT::Properties::setPatternCount(TagLib::ushort patternCount)
 {
   d->patternCount = patternCount;
 }
 
-void IT::Properties::setFlags(ushort flags)
+void IT::Properties::setFlags(TagLib::ushort flags)
 {
   d->flags = flags;
 }
 
-void IT::Properties::setSpecial(ushort special)
+void IT::Properties::setSpecial(TagLib::ushort special)
 {
   d->special = special;
 }
 
-void IT::Properties::setCompatibleVersion(ushort compatibleVersion)
+void IT::Properties::setCompatibleVersion(TagLib::ushort compatibleVersion)
 {
   d->compatibleVersion = compatibleVersion;
 }
 
-void IT::Properties::setVersion(ushort version)
+void IT::Properties::setVersion(TagLib::ushort version)
 {
   d->version = version;
 }
 
-void IT::Properties::setGlobalVolume(uchar globalVolume)
+void IT::Properties::setGlobalVolume(TagLib::uchar globalVolume)
 {
   d->globalVolume = globalVolume;
 }
 
-void IT::Properties::setMixVolume(uchar mixVolume)
+void IT::Properties::setMixVolume(TagLib::uchar mixVolume)
 {
   d->mixVolume = mixVolume;
 }
 
-void IT::Properties::setTempo(uchar tempo)
+void IT::Properties::setTempo(TagLib::uchar tempo)
 {
   d->tempo = tempo;
 }
 
-void IT::Properties::setBpmSpeed(uchar bpmSpeed)
+void IT::Properties::setBpmSpeed(TagLib::uchar bpmSpeed)
 {
   d->bpmSpeed = bpmSpeed;
 }
 
-void IT::Properties::setPanningSeparation(uchar panningSeparation)
+void IT::Properties::setPanningSeparation(TagLib::uchar panningSeparation)
 {
   d->panningSeparation = panningSeparation;
 }
 
-void IT::Properties::setPitchWheelDepth(uchar pitchWheelDepth)
+void IT::Properties::setPitchWheelDepth(TagLib::uchar pitchWheelDepth)
 {
   d->pitchWheelDepth = pitchWheelDepth;
 }

--- a/taglib/mod/modfile.cpp
+++ b/taglib/mod/modfile.cpp
@@ -79,13 +79,13 @@ bool Mod::File::save()
   seek(0);
   writeString(d->tag.title(), 20);
   StringList lines = d->tag.comment().split("\n");
-  uint n = std::min(lines.size(), d->properties.instrumentCount());
-  for(uint i = 0; i < n; ++ i) {
+  TagLib::uint n = std::min(lines.size(), d->properties.instrumentCount());
+  for(TagLib::uint i = 0; i < n; ++ i) {
     writeString(lines[i], 22);
     seek(8, Current);
   }
 
-  for(uint i = n; i < d->properties.instrumentCount(); ++ i) {
+  for(TagLib::uint i = n; i < d->properties.instrumentCount(); ++ i) {
     writeString(String::null, 22);
     seek(8, Current);
   }
@@ -102,7 +102,7 @@ void Mod::File::read(bool)
   READ_ASSERT(modId.size() == 4);
 
   int  channels    =  4;
-  uint instruments = 31;
+  TagLib::uint instruments = 31;
   if(modId == "M.K." || modId == "M!K!" || modId == "M&K!" || modId == "N.T.") {
     d->tag.setTrackerName("ProTracker");
     channels = 4;
@@ -146,7 +146,7 @@ void Mod::File::read(bool)
   READ_STRING(d->tag.setTitle, 20);
 
   StringList comment;
-  for(uint i = 0; i < instruments; ++ i) {
+  for(TagLib::uint i = 0; i < instruments; ++ i) {
     READ_STRING_AS(instrumentName, 22);
     // value in words, * 2 (<< 1) for bytes:
     READ_U16B_AS(sampleLength);

--- a/taglib/mod/modfilebase.cpp
+++ b/taglib/mod/modfilebase.cpp
@@ -33,14 +33,14 @@ Mod::FileBase::FileBase(IOStream *stream) : TagLib::File(stream)
 {
 }
 
-void Mod::FileBase::writeString(const String &s, ulong size, char padding)
+void Mod::FileBase::writeString(const String &s, TagLib::ulong size, char padding)
 {
   ByteVector data(s.data(String::Latin1));
   data.resize(size, padding);
   writeBlock(data);
 }
 
-bool Mod::FileBase::readString(String &s, ulong size)
+bool Mod::FileBase::readString(String &s, TagLib::ulong size)
 {
   ByteVector data(readBlock(size));
   if(data.size() < size) return false;
@@ -55,33 +55,33 @@ bool Mod::FileBase::readString(String &s, ulong size)
   return true;
 }
 
-void Mod::FileBase::writeByte(uchar byte)
+void Mod::FileBase::writeByte(TagLib::uchar byte)
 {
   ByteVector data(1, byte);
   writeBlock(data);
 }
 
-void Mod::FileBase::writeU16L(ushort number)
+void Mod::FileBase::writeU16L(TagLib::ushort number)
 {
   writeBlock(ByteVector::fromShort(number, false));
 }
 
-void Mod::FileBase::writeU32L(ulong number)
+void Mod::FileBase::writeU32L(TagLib::ulong number)
 {
   writeBlock(ByteVector::fromUInt(number, false));
 }
 
-void Mod::FileBase::writeU16B(ushort number)
+void Mod::FileBase::writeU16B(TagLib::ushort number)
 {
   writeBlock(ByteVector::fromShort(number, true));
 }
 
-void Mod::FileBase::writeU32B(ulong number)
+void Mod::FileBase::writeU32B(TagLib::ulong number)
 {
   writeBlock(ByteVector::fromUInt(number, true));
 }
 
-bool Mod::FileBase::readByte(uchar &byte)
+bool Mod::FileBase::readByte(TagLib::uchar &byte)
 {
   ByteVector data(readBlock(1));
   if(data.size() < 1) return false;
@@ -89,7 +89,7 @@ bool Mod::FileBase::readByte(uchar &byte)
   return true;
 }
 
-bool Mod::FileBase::readU16L(ushort &number)
+bool Mod::FileBase::readU16L(TagLib::ushort &number)
 {
   ByteVector data(readBlock(2));
   if(data.size() < 2) return false;
@@ -97,14 +97,14 @@ bool Mod::FileBase::readU16L(ushort &number)
   return true;
 }
 
-bool Mod::FileBase::readU32L(ulong &number) {
+bool Mod::FileBase::readU32L(TagLib::ulong &number) {
   ByteVector data(readBlock(4));
   if(data.size() < 4) return false;
   number = data.toUInt(false);
   return true;
 }
 
-bool Mod::FileBase::readU16B(ushort &number)
+bool Mod::FileBase::readU16B(TagLib::ushort &number)
 {
   ByteVector data(readBlock(2));
   if(data.size() < 2) return false;
@@ -112,7 +112,7 @@ bool Mod::FileBase::readU16B(ushort &number)
   return true;
 }
 
-bool Mod::FileBase::readU32B(ulong &number) {
+bool Mod::FileBase::readU32B(TagLib::ulong &number) {
   ByteVector data(readBlock(4));
   if(data.size() < 4) return false;
   number = data.toUInt(true);

--- a/taglib/mod/modproperties.cpp
+++ b/taglib/mod/modproperties.cpp
@@ -35,8 +35,8 @@ public:
   }
   
   int   channels;
-  uint  instrumentCount;
-  uchar lengthInPatterns;
+  TagLib::uint  instrumentCount;
+  TagLib::uchar lengthInPatterns;
 };
 
 Mod::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
@@ -70,12 +70,12 @@ int Mod::Properties::channels() const
   return d->channels;
 }
 
-uint Mod::Properties::instrumentCount() const
+TagLib::uint Mod::Properties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-uchar Mod::Properties::lengthInPatterns() const
+TagLib::uchar Mod::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
@@ -85,12 +85,12 @@ void Mod::Properties::setChannels(int channels)
   d->channels = channels;
 }
 
-void Mod::Properties::setInstrumentCount(uint instrumentCount)
+void Mod::Properties::setInstrumentCount(TagLib::uint instrumentCount)
 {
   d->instrumentCount = instrumentCount;
 }
 
-void Mod::Properties::setLengthInPatterns(uchar lengthInPatterns)
+void Mod::Properties::setLengthInPatterns(TagLib::uchar lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }

--- a/taglib/mod/modtag.cpp
+++ b/taglib/mod/modtag.cpp
@@ -71,12 +71,12 @@ String Mod::Tag::genre() const
   return String::null;
 }
 
-uint Mod::Tag::year() const
+TagLib::uint Mod::Tag::year() const
 {
   return 0;
 }
 
-uint Mod::Tag::track() const
+TagLib::uint Mod::Tag::track() const
 {
   return 0;
 }
@@ -108,11 +108,11 @@ void Mod::Tag::setGenre(const String &)
 {
 }
 
-void Mod::Tag::setYear(uint)
+void Mod::Tag::setYear(TagLib::uint)
 {
 }
 
-void Mod::Tag::setTrack(uint)
+void Mod::Tag::setTrack(TagLib::uint)
 {
 }
 

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -97,7 +97,7 @@ MP4::File::audioProperties() const
 bool
 MP4::File::checkValid(const MP4::AtomList &list)
 {
-  for(uint i = 0; i < list.size(); i++) {
+  for(TagLib::uint i = 0; i < list.size(); i++) {
     if(list[i]->length == 0)
       return false;
     if(!checkValid(list[i]->children))

--- a/taglib/mp4/mp4item.cpp
+++ b/taglib/mp4/mp4item.cpp
@@ -43,8 +43,8 @@ public:
     bool m_bool;
     int m_int;
     IntPair m_intPair;
-    uchar m_byte;
-    uint m_uint;
+    TagLib::uchar m_byte;
+    TagLib::uint m_uint;
     long long m_longlong;
   };
   StringList m_stringList;
@@ -92,13 +92,13 @@ MP4::Item::Item(int value)
   d->m_int = value;
 }
 
-MP4::Item::Item(uchar value)
+MP4::Item::Item(TagLib::uchar value)
 {
   d = new ItemPrivate;
   d->m_byte = value;
 }
 
-MP4::Item::Item(uint value)
+MP4::Item::Item(TagLib::uint value)
 {
   d = new ItemPrivate;
   d->m_uint = value;
@@ -141,7 +141,7 @@ MP4::Item::toInt() const
   return d->m_int;
 }
 
-uchar
+TagLib::uchar
 MP4::Item::toByte() const
 {
   return d->m_byte;

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -174,7 +174,7 @@ MP4::Tag::parseByte(MP4::Atom *atom, TagLib::File *file)
 {
   ByteVectorList data = parseData(atom, file);
   if(data.size()) {
-    d->items.insert(atom->name, (uchar)data[0].at(0));
+    d->items.insert(atom->name, (TagLib::uchar)data[0].at(0));
   }
 }
 
@@ -691,13 +691,13 @@ MP4::Tag::setGenre(const String &value)
 }
 
 void
-MP4::Tag::setYear(uint value)
+MP4::Tag::setYear(TagLib::uint value)
 {
   d->items["\251day"] = StringList(String::number(value));
 }
 
 void
-MP4::Tag::setTrack(uint value)
+MP4::Tag::setTrack(TagLib::uint value)
 {
   d->items["trkn"] = MP4::Item(value, 0);
 }

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -64,13 +64,13 @@ public:
   }
 
   long APELocation;
-  uint APESize;
+  TagLib::uint APESize;
 
   long ID3v1Location;
 
   ID3v2::Header *ID3v2Header;
   long ID3v2Location;
-  uint ID3v2Size;
+  TagLib::uint ID3v2Size;
 
   TagUnion tag;
 

--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -118,7 +118,7 @@ void MPC::Properties::read()
     d->channels = 2;
   }
   else {
-    uint headerData = d->data.mid(0, 4).toUInt(false);
+    TagLib::uint headerData = d->data.mid(0, 4).toUInt(false);
 
     d->bitrate = (headerData >> 23) & 0x01ff;
     d->version = (headerData >> 11) & 0x03ff;
@@ -131,7 +131,7 @@ void MPC::Properties::read()
       frames = d->data.mid(6, 2).toUInt(false);
   }
 
-  uint samples = frames * 1152 - 576;
+  TagLib::uint samples = frames * 1152 - 576;
 
   d->length = d->sampleRate > 0 ? (samples + (d->sampleRate / 2)) / d->sampleRate : 0;
 

--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -45,8 +45,8 @@ public:
   String album;
   String year;
   String comment;
-  uchar track;
-  uchar genre;
+  TagLib::uchar track;
+  TagLib::uchar genre;
 
   static const StringHandler *stringHandler;
 };
@@ -177,12 +177,12 @@ void ID3v1::Tag::setGenre(const String &s)
   d->genre = ID3v1::genreIndex(s);
 }
 
-void ID3v1::Tag::setYear(uint i)
+void ID3v1::Tag::setYear(TagLib::uint i)
 {
   d->year = i > 0 ? String::number(i) : String::null;
 }
 
-void ID3v1::Tag::setTrack(uint i)
+void ID3v1::Tag::setTrack(TagLib::uint i)
 {
   d->track = i < 256 ? i : 0;
 }
@@ -237,12 +237,12 @@ void ID3v1::Tag::parse(const ByteVector &data)
     // ID3v1.1 detected
 
     d->comment = TagPrivate::stringHandler->parse(data.mid(offset, 28));
-    d->track = uchar(data[offset + 29]);
+    d->track = TagLib::uchar(data[offset + 29]);
   }
   else
     d->comment = data.mid(offset, 30);
 
   offset += 30;
 
-  d->genre = uchar(data[offset]);
+  d->genre = TagLib::uchar(data[offset]);
 }

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
@@ -137,7 +137,7 @@ void AttachedPictureFrame::parseFields(const ByteVector &data)
 
   d->mimeType = readStringField(data, String::Latin1, &pos);
   /* Now we need at least two more bytes available */
-  if (uint(pos) + 1 >= data.size()) {
+  if (TagLib::uint(pos) + 1 >= data.size()) {
     debug("Truncated picture frame.");
     return;
   }

--- a/taglib/mpeg/id3v2/id3v2extendedheader.cpp
+++ b/taglib/mpeg/id3v2/id3v2extendedheader.cpp
@@ -34,7 +34,7 @@ class ExtendedHeader::ExtendedHeaderPrivate
 public:
   ExtendedHeaderPrivate() : size(0) {}
 
-  uint size;
+  TagLib::uint size;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/id3v2footer.cpp
+++ b/taglib/mpeg/id3v2/id3v2footer.cpp
@@ -32,7 +32,7 @@ using namespace ID3v2;
 class Footer::FooterPrivate
 {
 public:
-  static const uint size = 10;
+  static const TagLib::uint size = 10;
 };
 
 Footer::Footer()

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -82,7 +82,7 @@ TagLib::uint Frame::headerSize()
   return Header::size();
 }
 
-TagLib::uint Frame::headerSize(uint version)
+TagLib::uint Frame::headerSize(TagLib::uint version)
 {
   return Header::size(version);
 }
@@ -180,10 +180,10 @@ void Frame::parse(const ByteVector &data)
 
 ByteVector Frame::fieldData(const ByteVector &frameData) const
 {
-  uint headerSize = Header::size(d->header->version());
+  TagLib::uint headerSize = Header::size(d->header->version());
 
-  uint frameDataOffset = headerSize;
-  uint frameDataLength = size();
+  TagLib::uint frameDataOffset = headerSize;
+  TagLib::uint frameDataLength = size();
 
   if(d->header->compression() || d->header->dataLengthIndicator()) {
     frameDataLength = SynchData::toUInt(frameData.mid(headerSize, 4));
@@ -233,7 +233,7 @@ String::Type Frame::checkEncoding(const StringList &fields, String::Type encodin
   return checkEncoding(fields, encoding, 4);
 }
 
-String::Type Frame::checkEncoding(const StringList &fields, String::Type encoding, uint version) // static
+String::Type Frame::checkEncoding(const StringList &fields, String::Type encoding, TagLib::uint version) // static
 {
   if((encoding == String::UTF8 || encoding == String::UTF16BE) && version != 4)
     return String::UTF16;
@@ -283,8 +283,8 @@ public:
     {}
 
   ByteVector frameID;
-  uint frameSize;
-  uint version;
+  TagLib::uint frameSize;
+  TagLib::uint version;
 
   // flags
 
@@ -307,7 +307,7 @@ TagLib::uint Frame::Header::size()
   return size(4);
 }
 
-TagLib::uint Frame::Header::size(uint version)
+TagLib::uint Frame::Header::size(TagLib::uint version)
 {
   switch(version) {
   case 0:
@@ -331,7 +331,7 @@ Frame::Header::Header(const ByteVector &data, bool synchSafeInts)
   setData(data, synchSafeInts);
 }
 
-Frame::Header::Header(const ByteVector &data, uint version)
+Frame::Header::Header(const ByteVector &data, TagLib::uint version)
 {
   d = new HeaderPrivate;
   setData(data, version);
@@ -344,10 +344,10 @@ Frame::Header::~Header()
 
 void Frame::Header::setData(const ByteVector &data, bool synchSafeInts)
 {
-  setData(data, uint(synchSafeInts ? 4 : 3));
+  setData(data, TagLib::uint(synchSafeInts ? 4 : 3));
 }
 
-void Frame::Header::setData(const ByteVector &data, uint version)
+void Frame::Header::setData(const ByteVector &data, TagLib::uint version)
 {
   d->version = version;
 
@@ -493,7 +493,7 @@ TagLib::uint Frame::Header::frameSize() const
   return d->frameSize;
 }
 
-void Frame::Header::setFrameSize(uint size)
+void Frame::Header::setFrameSize(TagLib::uint size)
 {
   d->frameSize = size;
 }

--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -80,10 +80,10 @@ FrameFactory *FrameFactory::instance()
 
 Frame *FrameFactory::createFrame(const ByteVector &data, bool synchSafeInts) const
 {
-  return createFrame(data, uint(synchSafeInts ? 4 : 3));
+  return createFrame(data, TagLib::uint(synchSafeInts ? 4 : 3));
 }
 
-Frame *FrameFactory::createFrame(const ByteVector &data, uint version) const
+Frame *FrameFactory::createFrame(const ByteVector &data, TagLib::uint version) const
 {
   Header tagHeader;
   tagHeader.setMajorVersion(version);
@@ -93,7 +93,7 @@ Frame *FrameFactory::createFrame(const ByteVector &data, uint version) const
 Frame *FrameFactory::createFrame(const ByteVector &origData, Header *tagHeader) const
 {
   ByteVector data = origData;
-  uint version = tagHeader->majorVersion();
+  TagLib::uint version = tagHeader->majorVersion();
   Frame::Header *header = new Frame::Header(data, version);
   ByteVector frameID = header->frameID();
 
@@ -101,7 +101,7 @@ Frame *FrameFactory::createFrame(const ByteVector &origData, Header *tagHeader) 
   // characters.  Also make sure that there is data in the frame.
 
   if(!frameID.size() == (version < 3 ? 3 : 4) ||
-     header->frameSize() <= uint(header->dataLengthIndicator() ? 4 : 0) ||
+     header->frameSize() <= TagLib::uint(header->dataLengthIndicator() ? 4 : 0) ||
      header->frameSize() > data.size())
   {
     delete header;

--- a/taglib/mpeg/id3v2/id3v2header.cpp
+++ b/taglib/mpeg/id3v2/id3v2header.cpp
@@ -49,17 +49,17 @@ public:
 
   ~HeaderPrivate() {}
 
-  uint majorVersion;
-  uint revisionNumber;
+  TagLib::uint majorVersion;
+  TagLib::uint revisionNumber;
 
   bool unsynchronisation;
   bool extendedHeader;
   bool experimentalIndicator;
   bool footerPresent;
 
-  uint tagSize;
+  TagLib::uint tagSize;
 
-  static const uint size = 10;
+  static const TagLib::uint size = 10;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -144,7 +144,7 @@ TagLib::uint Header::completeTagSize() const
     return d->tagSize + d->size;
 }
 
-void Header::setTagSize(uint s)
+void Header::setTagSize(TagLib::uint s)
 {
   d->tagSize = s;
 }
@@ -216,7 +216,7 @@ void Header::parse(const ByteVector &data)
   }
 
   for(ByteVector::Iterator it = sizeData.begin(); it != sizeData.end(); it++) {
-    if(uchar(*it) >= 128) {
+    if(TagLib::uchar(*it) >= 128) {
       d->tagSize = 0;
       debug("TagLib::ID3v2::Header::parse() - One of the size bytes in the id3v2 header was greater than the allowed 128.");
       return;

--- a/taglib/mpeg/id3v2/id3v2synchdata.cpp
+++ b/taglib/mpeg/id3v2/id3v2synchdata.cpp
@@ -32,7 +32,7 @@ using namespace ID3v2;
 
 TagLib::uint SynchData::toUInt(const ByteVector &data)
 {
-  uint sum = 0;
+  TagLib::uint sum = 0;
   bool notSynchSafe = false;
   int last = data.size() > 4 ? 3 : data.size() - 1;
 
@@ -55,12 +55,12 @@ TagLib::uint SynchData::toUInt(const ByteVector &data)
   return sum;
 }
 
-ByteVector SynchData::fromUInt(uint value)
+ByteVector SynchData::fromUInt(TagLib::uint value)
 {
   ByteVector v(4, 0);
 
   for(int i = 0; i < 4; i++)
-    v[i] = uchar(value >> ((3 - i) * 7) & 0x7f);
+    v[i] = TagLib::uchar(value >> ((3 - i) * 7) & 0x7f);
 
   return v;
 }

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -248,7 +248,7 @@ void ID3v2::Tag::setGenre(const String &s)
 #endif
 }
 
-void ID3v2::Tag::setYear(uint i)
+void ID3v2::Tag::setYear(TagLib::uint i)
 {
   if(i <= 0) {
     removeFrames("TDRC");
@@ -257,7 +257,7 @@ void ID3v2::Tag::setYear(uint i)
   setTextFrame("TDRC", String::number(i));
 }
 
-void ID3v2::Tag::setTrack(uint i)
+void ID3v2::Tag::setTrack(TagLib::uint i)
 {
   if(i <= 0) {
     removeFrames("TRCK");
@@ -410,14 +410,14 @@ void ID3v2::Tag::downgradeFrames(FrameList *frames, FrameList *newFrames) const
     StringList people;
     if(frameTMCL) {
       StringList v24People = frameTMCL->fieldList();
-      for(uint i = 0; i + 1 < v24People.size(); i += 2) {
+      for(TagLib::uint i = 0; i + 1 < v24People.size(); i += 2) {
         people.append(v24People[i]);
         people.append(v24People[i+1]);
       }
     }
     if(frameTIPL) {
       StringList v24People = frameTIPL->fieldList();
-      for(uint i = 0; i + 1 < v24People.size(); i += 2) {
+      for(TagLib::uint i = 0; i + 1 < v24People.size(); i += 2) {
         people.append(v24People[i]);
         people.append(v24People[i+1]);
       }
@@ -471,8 +471,8 @@ ByteVector ID3v2::Tag::render(int version) const
 
   // Compute the amount of padding, and append that to tagData.
 
-  uint paddingSize = 0;
-  uint originalSize = d->header.tagSize();
+  TagLib::uint paddingSize = 0;
+  TagLib::uint originalSize = d->header.tagSize();
 
   if(tagData.size() < originalSize)
     paddingSize = originalSize - tagData.size();
@@ -517,8 +517,8 @@ void ID3v2::Tag::parse(const ByteVector &origData)
   if(d->header.unsynchronisation() && d->header.majorVersion() <= 3)
     data = SynchData::decode(data);
 
-  uint frameDataPosition = 0;
-  uint frameDataLength = data.size();
+  TagLib::uint frameDataPosition = 0;
+  TagLib::uint frameDataLength = data.size();
 
   // check for extended header
 

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -70,11 +70,11 @@ public:
   const ID3v2::FrameFactory *ID3v2FrameFactory;
 
   long ID3v2Location;
-  uint ID3v2OriginalSize;
+  TagLib::uint ID3v2OriginalSize;
 
   long APELocation;
   long APEFooterLocation;
-  uint APEOriginalSize;
+  TagLib::uint APEOriginalSize;
 
   long ID3v1Location;
 
@@ -349,12 +349,12 @@ long MPEG::File::nextFrameOffset(long position)
     if(foundLastSyncPattern && secondSynchByte(buffer[0]))
       return position - 1;
 
-    for(uint i = 0; i < buffer.size() - 1; i++) {
-      if(uchar(buffer[i]) == 0xff && secondSynchByte(buffer[i + 1]))
+    for(TagLib::uint i = 0; i < buffer.size() - 1; i++) {
+      if(TagLib::uchar(buffer[i]) == 0xff && secondSynchByte(buffer[i + 1]))
         return position + i;
     }
 
-    foundLastSyncPattern = uchar(buffer[buffer.size() - 1]) == 0xff;
+    foundLastSyncPattern = TagLib::uchar(buffer[buffer.size() - 1]) == 0xff;
     position += buffer.size();
   }
 }
@@ -365,7 +365,7 @@ long MPEG::File::previousFrameOffset(long position)
   ByteVector buffer;
 
   while (position > 0) {
-    long size = ulong(position) < bufferSize() ? position : bufferSize();
+    long size = TagLib::ulong(position) < bufferSize() ? position : bufferSize();
     position -= size;
 
     seek(position);
@@ -374,11 +374,11 @@ long MPEG::File::previousFrameOffset(long position)
     if(buffer.size() <= 0)
       break;
 
-    if(foundFirstSyncPattern && uchar(buffer[buffer.size() - 1]) == 0xff)
+    if(foundFirstSyncPattern && TagLib::uchar(buffer[buffer.size() - 1]) == 0xff)
       return position + buffer.size() - 1;
 
     for(int i = buffer.size() - 2; i >= 0; i--) {
-      if(uchar(buffer[i]) == 0xff && secondSynchByte(buffer[i + 1]))
+      if(TagLib::uchar(buffer[i]) == 0xff && secondSynchByte(buffer[i + 1]))
         return position + i;
     }
 
@@ -516,7 +516,7 @@ long MPEG::File::findID3v2()
         return bufferOffset + location;
       }
 
-      int firstSynchByte = buffer.find(char(uchar(255)));
+      int firstSynchByte = buffer.find(char(TagLib::uchar(255)));
 
       // Here we have to loop because there could be several of the first
       // (11111111) byte, and we want to check all such instances until we find
@@ -544,7 +544,7 @@ long MPEG::File::findID3v2()
 
         // Check in the rest of the buffer.
 
-        firstSynchByte = buffer.find(char(uchar(255)), firstSynchByte + 1);
+        firstSynchByte = buffer.find(char(TagLib::uchar(255)), firstSynchByte + 1);
       }
 
       // (3) partial match
@@ -599,7 +599,7 @@ void MPEG::File::findAPE()
 
 bool MPEG::File::secondSynchByte(char byte)
 {
-  if(uchar(byte) == 0xff)
+  if(TagLib::uchar(byte) == 0xff)
     return false;
 
   std::bitset<8> b(byte);

--- a/taglib/mpeg/mpegheader.cpp
+++ b/taglib/mpeg/mpegheader.cpp
@@ -163,7 +163,7 @@ MPEG::Header &MPEG::Header::operator=(const Header &h)
 
 void MPEG::Header::parse(const ByteVector &data)
 {
-  if(data.size() < 4 || uchar(data[0]) != 0xff) {
+  if(data.size() < 4 || TagLib::uchar(data[0]) != 0xff) {
     debug("MPEG::Header::parse() -- First byte did not match MPEG synch.");
     return;
   }
@@ -218,7 +218,7 @@ void MPEG::Header::parse(const ByteVector &data)
   // The bitrate index is encoded as the first 4 bits of the 3rd byte,
   // i.e. 1111xxxx
 
-  int i = uchar(data[2]) >> 4;
+  int i = TagLib::uchar(data[2]) >> 4;
 
   d->bitrate = bitrates[versionIndex][layerIndex][i];
 
@@ -232,7 +232,7 @@ void MPEG::Header::parse(const ByteVector &data)
 
   // The sample rate index is encoded as two bits in the 3nd byte, i.e. xxxx11xx
 
-  i = uchar(data[2]) >> 2 & 0x03;
+  i = TagLib::uchar(data[2]) >> 2 & 0x03;
 
   d->sampleRate = sampleRates[d->version][i];
 
@@ -244,7 +244,7 @@ void MPEG::Header::parse(const ByteVector &data)
   // The channel mode is encoded as a 2 bit value at the end of the 3nd byte,
   // i.e. xxxxxx11
 
-  d->channelMode = ChannelMode((uchar(data[3]) & 0xC0) >> 6);
+  d->channelMode = ChannelMode((TagLib::uchar(data[3]) & 0xC0) >> 6);
 
   // TODO: Add mode extension for completeness
 

--- a/taglib/mpeg/xingheader.cpp
+++ b/taglib/mpeg/xingheader.cpp
@@ -40,8 +40,8 @@ public:
     valid(false)
     {}
 
-  uint frames;
-  uint size;
+  TagLib::uint frames;
+  TagLib::uint size;
   bool valid;
 };
 

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -228,7 +228,7 @@ void Ogg::FLAC::File::scan()
 
   char blockType = header[0] & 0x7f;
   bool lastBlock = (header[0] & 0x80) != 0;
-  uint length = header.mid(1, 3).toUInt();
+  TagLib::uint length = header.mid(1, 3).toUInt();
   overhead += length;
 
   // Sanity: First block should be the stream_info metadata

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -53,7 +53,7 @@ public:
     delete lastPageHeader;
   }
 
-  uint streamSerialNumber;
+  TagLib::uint streamSerialNumber;
   List<Page *> pages;
   PageHeader *firstPageHeader;
   PageHeader *lastPageHeader;
@@ -78,7 +78,7 @@ Ogg::File::~File()
   delete d;
 }
 
-ByteVector Ogg::File::packet(uint i)
+ByteVector Ogg::File::packet(TagLib::uint i)
 {
   // Check to see if we're called setPacket() for this packet since the last
   // save:
@@ -100,7 +100,7 @@ ByteVector Ogg::File::packet(uint i)
   // If the last read stopped at the packet that we're interested in, don't
   // reread its packet list.  (This should make sequential packet reads fast.)
 
-  uint pageIndex = d->packetToPageMap[i].front();
+  TagLib::uint pageIndex = d->packetToPageMap[i].front();
   if(d->currentPacketPage != d->pages[pageIndex]) {
     d->currentPacketPage = d->pages[pageIndex];
     d->currentPackets = d->currentPacketPage->packets();
@@ -136,7 +136,7 @@ ByteVector Ogg::File::packet(uint i)
   return packet;
 }
 
-void Ogg::File::setPacket(uint i, const ByteVector &p)
+void Ogg::File::setPacket(TagLib::uint i, const ByteVector &p)
 {
   while(d->packetToPageMap.size() <= i) {
     if(!nextPage()) {
@@ -265,8 +265,8 @@ bool Ogg::File::nextPage()
   // Loop through the packets in the page that we just read appending the
   // current page number to the packet to page map for each packet.
 
-  for(uint i = 0; i < d->currentPage->packetCount(); i++) {
-    uint currentPacket = d->currentPage->firstPacketIndex() + i;
+  for(TagLib::uint i = 0; i < d->currentPage->packetCount(); i++) {
+    TagLib::uint currentPacket = d->currentPage->firstPacketIndex() + i;
     if(d->packetToPageMap.size() <= currentPacket)
       d->packetToPageMap.push_back(List<int>());
     d->packetToPageMap[currentPacket].append(d->pages.size() - 1);
@@ -308,12 +308,12 @@ void Ogg::File::writePageGroup(const List<int> &thePageGroup)
   int originalSize = 0;
 
   for(List<int>::ConstIterator it = pageGroup.begin(); it != pageGroup.end(); ++it) {
-    uint firstPacket = d->pages[*it]->firstPacketIndex();
-    uint lastPacket = firstPacket + d->pages[*it]->packetCount() - 1;
+    TagLib::uint firstPacket = d->pages[*it]->firstPacketIndex();
+    TagLib::uint lastPacket = firstPacket + d->pages[*it]->packetCount() - 1;
 
     List<int>::ConstIterator last = --pageGroup.end();
 
-    for(uint i = firstPacket; i <= lastPacket; i++) {
+    for(TagLib::uint i = firstPacket; i <= lastPacket; i++) {
 
       if(it == last && i == lastPacket && !d->dirtyPages.contains(i))
         packets.append(d->pages[*it]->packets().back());

--- a/taglib/ogg/oggpage.cpp
+++ b/taglib/ogg/oggpage.cpp
@@ -197,7 +197,7 @@ ByteVector Ogg::Page::render() const
 
 List<Ogg::Page *> Ogg::Page::paginate(const ByteVectorList &packets,
                                       PaginationStrategy strategy,
-                                      uint streamSerialNumber,
+                                      TagLib::uint streamSerialNumber,
                                       int firstPage,
                                       bool firstPacketContinued,
                                       bool lastPacketCompleted,
@@ -310,7 +310,7 @@ Ogg::Page* Ogg::Page::getCopyWithNewPageSequenceNumber(int sequenceNumber)
 ////////////////////////////////////////////////////////////////////////////////
 
 Ogg::Page::Page(const ByteVectorList &packets,
-                uint streamSerialNumber,
+                TagLib::uint streamSerialNumber,
                 int pageNumber,
                 bool firstPacketContinued,
                 bool lastPacketCompleted,

--- a/taglib/ogg/oggpageheader.cpp
+++ b/taglib/ogg/oggpageheader.cpp
@@ -63,7 +63,7 @@ public:
   bool firstPageOfStream;
   bool lastPageOfStream;
   long long absoluteGranularPosition;
-  uint streamSerialNumber;
+  TagLib::uint streamSerialNumber;
   int pageSequenceNumber;
   int size;
   int dataSize;
@@ -165,7 +165,7 @@ TagLib::uint Ogg::PageHeader::streamSerialNumber() const
   return d->streamSerialNumber;
 }
 
-void Ogg::PageHeader::setStreamSerialNumber(uint n)
+void Ogg::PageHeader::setStreamSerialNumber(TagLib::uint n)
 {
   d->streamSerialNumber = n;
 }
@@ -222,7 +222,7 @@ ByteVector Ogg::PageHeader::render() const
 
   ByteVector pageSegments = lacingValues();
 
-  data.append(char(uchar(pageSegments.size())));
+  data.append(char(TagLib::uchar(pageSegments.size())));
   data.append(pageSegments);
 
   return data;
@@ -263,7 +263,7 @@ void Ogg::PageHeader::read()
   // length portion of the page header.  After reading the number of page
   // segments we'll then read in the corresponding data for this count.
 
-  int pageSegmentCount = uchar(data[26]);
+  int pageSegmentCount = TagLib::uchar(data[26]);
 
   ByteVector pageSegments = d->file->readBlock(pageSegmentCount);
 
@@ -279,10 +279,10 @@ void Ogg::PageHeader::read()
   int packetSize = 0;
 
   for(int i = 0; i < pageSegmentCount; i++) {
-    d->dataSize += uchar(pageSegments[i]);
-    packetSize += uchar(pageSegments[i]);
+    d->dataSize += TagLib::uchar(pageSegments[i]);
+    packetSize += TagLib::uchar(pageSegments[i]);
 
-    if(uchar(pageSegments[i]) < 255) {
+    if(TagLib::uchar(pageSegments[i]) < 255) {
       d->packetSizes.append(packetSize);
       packetSize = 0;
     }
@@ -313,10 +313,10 @@ ByteVector Ogg::PageHeader::lacingValues() const
     div_t n = div(*it, 255);
 
     for(int i = 0; i < n.quot; i++)
-      data.append(char(uchar(255)));
+      data.append(char(TagLib::uchar(255)));
 
     if(it != --sizes.end() || d->lastPacketCompleted)
-      data.append(char(uchar(n.rem)));
+      data.append(char(TagLib::uchar(n.rem)));
   }
 
   return data;

--- a/taglib/ogg/vorbis/vorbisproperties.cpp
+++ b/taglib/ogg/vorbis/vorbisproperties.cpp
@@ -145,7 +145,7 @@ void Vorbis::Properties::read()
   d->vorbisVersion = data.mid(pos, 4).toUInt(false);
   pos += 4;
 
-  d->channels = uchar(data[pos]);
+  d->channels = TagLib::uchar(data[pos]);
   pos += 1;
 
   d->sampleRate = data.mid(pos, 4).toUInt(false);

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -144,7 +144,7 @@ void Ogg::XiphComment::setGenre(const String &s)
   addField("GENRE", s);
 }
 
-void Ogg::XiphComment::setYear(uint i)
+void Ogg::XiphComment::setYear(TagLib::uint i)
 {
   removeField("YEAR");
   if(i == 0)
@@ -153,7 +153,7 @@ void Ogg::XiphComment::setYear(uint i)
     addField("DATE", String::number(i));
 }
 
-void Ogg::XiphComment::setTrack(uint i)
+void Ogg::XiphComment::setTrack(TagLib::uint i)
 {
   removeField("TRACKNUM");
   if(i == 0)
@@ -174,7 +174,7 @@ bool Ogg::XiphComment::isEmpty() const
 
 TagLib::uint Ogg::XiphComment::fieldCount() const
 {
-  uint count = 0;
+  TagLib::uint count = 0;
 
   FieldListMap::ConstIterator it = d->fieldListMap.begin();
   for(; it != d->fieldListMap.end(); ++it)
@@ -285,7 +285,7 @@ void Ogg::XiphComment::parse(const ByteVector &data)
   // The first thing in the comment data is the vendor ID length, followed by a
   // UTF8 string with the vendor ID.
 
-  uint pos = 0;
+  TagLib::uint pos = 0;
 
   int vendorLength = data.mid(0, 4).toUInt(false);
   pos += 4;
@@ -295,19 +295,19 @@ void Ogg::XiphComment::parse(const ByteVector &data)
 
   // Next the number of fields in the comment vector.
 
-  uint commentFields = data.mid(pos, 4).toUInt(false);
+  TagLib::uint commentFields = data.mid(pos, 4).toUInt(false);
   pos += 4;
 
   if(commentFields > (data.size() - 8) / 4) {
     return;
   }
 
-  for(uint i = 0; i < commentFields; i++) {
+  for(TagLib::uint i = 0; i < commentFields; i++) {
 
     // Each comment field is in the format "KEY=value" in a UTF8 string and has
     // 4 bytes before the text starts that gives the length.
 
-    uint commentLength = data.mid(pos, 4).toUInt(false);
+    TagLib::uint commentLength = data.mid(pos, 4).toUInt(false);
     pos += 4;
 
     String comment = String(data.mid(pos, commentLength), String::UTF8);

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -111,7 +111,7 @@ bool RIFF::AIFF::File::save()
 
 void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
 {
-  for(uint i = 0; i < chunkCount(); i++) {
+  for(TagLib::uint i = 0; i < chunkCount(); i++) {
     if(chunkName(i) == "ID3 " || chunkName(i) == "id3 ") {
       d->tagChunkID = chunkName(i);
       d->tag = new ID3v2::Tag(this, chunkOffset(i));

--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -96,7 +96,7 @@ public:
   int sampleRate;
   int channels;
   int sampleWidth;
-  uint sampleFrames;
+  TagLib::uint sampleFrames;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -139,7 +139,7 @@ int RIFF::AIFF::Properties::sampleWidth() const
   return d->sampleWidth;
 }
 
-uint RIFF::AIFF::Properties::sampleFrames() const
+TagLib::uint RIFF::AIFF::Properties::sampleFrames() const
 {
   return d->sampleFrames;
 }

--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -98,22 +98,22 @@ TagLib::uint RIFF::File::chunkCount() const
   return d->chunks.size();
 }
 
-TagLib::uint RIFF::File::chunkDataSize(uint i) const
+TagLib::uint RIFF::File::chunkDataSize(TagLib::uint i) const
 {
   return d->chunks[i].size;
 }
 
-TagLib::uint RIFF::File::chunkOffset(uint i) const
+TagLib::uint RIFF::File::chunkOffset(TagLib::uint i) const
 {
   return d->chunks[i].offset;
 }
 
-TagLib::uint RIFF::File::chunkPadding(uint i) const
+TagLib::uint RIFF::File::chunkPadding(TagLib::uint i) const
 {
   return d->chunks[i].padding;
 }
 
-ByteVector RIFF::File::chunkName(uint i) const
+ByteVector RIFF::File::chunkName(TagLib::uint i) const
 {
   if(i >= chunkCount())
     return ByteVector::null;
@@ -121,7 +121,7 @@ ByteVector RIFF::File::chunkName(uint i) const
   return d->chunks[i].name;
 }
 
-ByteVector RIFF::File::chunkData(uint i)
+ByteVector RIFF::File::chunkData(TagLib::uint i)
 {
   if(i >= chunkCount())
     return ByteVector::null;
@@ -130,7 +130,7 @@ ByteVector RIFF::File::chunkData(uint i)
 
   long begin = 12 + 8;
 
-  for(uint it = 0; it < i; it++)
+  for(TagLib::uint it = 0; it < i; it++)
     begin += 8 + d->chunks[it].size + d->chunks[it].padding;
 
   seek(begin);
@@ -145,7 +145,7 @@ void RIFF::File::setChunkData(const ByteVector &name, const ByteVector &data)
     return;
   }
 
-  for(uint i = 0; i < d->chunks.size(); i++) {
+  for(TagLib::uint i = 0; i < d->chunks.size(); i++) {
     if(d->chunks[i].name == name) {
 
       // First we update the global size
@@ -171,8 +171,8 @@ void RIFF::File::setChunkData(const ByteVector &name, const ByteVector &data)
 
   // Couldn't find an existing chunk, so let's create a new one.
 
-  uint i =  d->chunks.size() - 1;
-  ulong offset = d->chunks[i].offset + d->chunks[i].size;
+  TagLib::uint i =  d->chunks.size() - 1;
+  TagLib::ulong offset = d->chunks[i].offset + d->chunks[i].size;
 
   // First we update the global size
 
@@ -181,7 +181,7 @@ void RIFF::File::setChunkData(const ByteVector &name, const ByteVector &data)
 
   // Now add the chunk to the file
 
-  writeChunk(name, data, offset, std::max(ulong(0), length() - offset), (offset & 1) ? 1 : 0);
+  writeChunk(name, data, offset, std::max(TagLib::ulong(0), length() - offset), (offset & 1) ? 1 : 0);
 
   // And update our internal structure
 
@@ -227,7 +227,7 @@ void RIFF::File::read()
   // + 8: chunk header at least, fix for additional junk bytes
   while(tell() + 8 <= length()) {
     ByteVector chunkName = readBlock(4);
-    uint chunkSize = readBlock(4).toUInt(bigEndian);
+    TagLib::uint chunkSize = readBlock(4).toUInt(bigEndian);
 
     if(!isValidChunkID(chunkName)) {
       debug("RIFF::File::read() -- Chunk '" + chunkName + "' has invalid ID");
@@ -235,7 +235,7 @@ void RIFF::File::read()
       break;
     }
 
-    if(tell() + chunkSize > uint(length())) {
+    if(tell() + chunkSize > TagLib::uint(length())) {
       debug("RIFF::File::read() -- Chunk '" + chunkName + "' has invalid size (larger than the file size)");
       setValid(false);
       break;
@@ -267,7 +267,7 @@ void RIFF::File::read()
 }
 
 void RIFF::File::writeChunk(const ByteVector &name, const ByteVector &data,
-                            ulong offset, ulong replace, uint leadingPadding)
+                            TagLib::ulong offset, TagLib::ulong replace, TagLib::uint leadingPadding)
 {
   ByteVector combined;
   if(leadingPadding) {

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -112,8 +112,8 @@ bool RIFF::WAV::File::save()
 void RIFF::WAV::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
 {
   ByteVector formatData;
-  uint streamLength = 0;
-  for(uint i = 0; i < chunkCount(); i++) {
+  TagLib::uint streamLength = 0;
+  for(TagLib::uint i = 0; i < chunkCount(); i++) {
     if(chunkName(i) == "ID3 " || chunkName(i) == "id3 ") {
       d->tagChunkID = chunkName(i);
       d->tag = new ID3v2::Tag(this, chunkOffset(i));

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -35,7 +35,7 @@ using namespace TagLib;
 class RIFF::WAV::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate(uint streamLength = 0) :
+  PropertiesPrivate(TagLib::uint streamLength = 0) :
     format(0),
     length(0),
     bitrate(0),
@@ -54,8 +54,8 @@ public:
   int sampleRate;
   int channels;
   int sampleWidth;
-  uint sampleFrames;
-  uint streamLength;
+  TagLib::uint sampleFrames;
+  TagLib::uint streamLength;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +68,7 @@ RIFF::WAV::Properties::Properties(const ByteVector &data, ReadStyle style) : Aud
   read(data);
 }
 
-RIFF::WAV::Properties::Properties(const ByteVector &data, uint streamLength, ReadStyle style) : AudioProperties(style)
+RIFF::WAV::Properties::Properties(const ByteVector &data, TagLib::uint streamLength, ReadStyle style) : AudioProperties(style)
 {
   d = new PropertiesPrivate(streamLength);
   read(data);
@@ -104,7 +104,7 @@ int RIFF::WAV::Properties::sampleWidth() const
   return d->sampleWidth;
 }
 
-uint RIFF::WAV::Properties::sampleFrames() const
+TagLib::uint RIFF::WAV::Properties::sampleFrames() const
 {
   return d->sampleFrames;
 }
@@ -120,7 +120,7 @@ void RIFF::WAV::Properties::read(const ByteVector &data)
   d->sampleRate = data.mid(4, 4).toUInt(false);
   d->sampleWidth = data.mid(14, 2).toShort(false);
 
-  uint byteRate = data.mid(8, 4).toUInt(false);
+  TagLib::uint byteRate = data.mid(8, 4).toUInt(false);
   d->bitrate = byteRate * 8 / 1000;
 
   d->length = byteRate > 0 ? d->streamLength / byteRate : 0;

--- a/taglib/s3m/s3mfile.cpp
+++ b/taglib/s3m/s3mfile.cpp
@@ -87,8 +87,8 @@ bool S3M::File::save()
 
   seek(32);
 
-  ushort length = 0;
-  ushort sampleCount = 0;
+  TagLib::ushort length = 0;
+  TagLib::ushort sampleCount = 0;
 
   if(!readU16L(length) || !readU16L(sampleCount))
     return false;
@@ -97,7 +97,7 @@ bool S3M::File::save()
 
   int channels = 0;
   for(int i = 0; i < 32; ++ i) {
-    uchar setting = 0;
+    TagLib::uchar setting = 0;
     if(!readByte(setting))
       return false;
     // or if(setting >= 128)?
@@ -110,10 +110,10 @@ bool S3M::File::save()
   
   StringList lines = d->tag.comment().split("\n");
   // write comment as sample names:
-  for(ushort i = 0; i < sampleCount; ++ i) {
+  for(TagLib::ushort i = 0; i < sampleCount; ++ i) {
     seek(96L + length + ((long)i << 1));
 
-    ushort instrumentOffset = 0;
+    TagLib::ushort instrumentOffset = 0;
     if(!readU16L(instrumentOffset))
       return false;
     seek(((long)instrumentOffset << 4) + 48);
@@ -180,8 +180,8 @@ void S3M::File::read(bool)
   d->properties.setChannels(channels);
   
   seek(96);
-  ushort realLength = 0;
-  for(ushort i = 0; i < length; ++ i) {
+  TagLib::ushort realLength = 0;
+  for(TagLib::ushort i = 0; i < length; ++ i) {
 	  READ_BYTE_AS(order);
 	  if(order == 255) break;
 	  if(order != 254) ++ realLength;
@@ -195,7 +195,7 @@ void S3M::File::read(bool)
   //       However, there I never found instruments (SCRI) but
   //       instead samples (SCRS).
   StringList comment;
-  for(ushort i = 0; i < sampleCount; ++ i) {
+  for(TagLib::ushort i = 0; i < sampleCount; ++ i) {
     seek(96L + length + ((long)i << 1));
 
     READ_U16L_AS(sampleHeaderOffset);

--- a/taglib/s3m/s3mproperties.cpp
+++ b/taglib/s3m/s3mproperties.cpp
@@ -43,18 +43,18 @@ public:
   {
   }
   
-  ushort lengthInPatterns;
+  TagLib::ushort lengthInPatterns;
   int    channels;
   bool   stereo;
-  ushort sampleCount;
-  ushort patternCount;
-  ushort flags;
-  ushort trackerVersion;
-  ushort fileFormatVersion;
-  uchar  globalVolume;
-  uchar  masterVolume;
-  uchar  tempo;
-  uchar  bpmSpeed;
+  TagLib::ushort sampleCount;
+  TagLib::ushort patternCount;
+  TagLib::ushort flags;
+  TagLib::ushort trackerVersion;
+  TagLib::ushort fileFormatVersion;
+  TagLib::uchar  globalVolume;
+  TagLib::uchar  masterVolume;
+  TagLib::uchar  tempo;
+  TagLib::uchar  bpmSpeed;
 };
 
 S3M::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
@@ -88,7 +88,7 @@ int S3M::Properties::channels() const
   return d->channels;
 }
 
-ushort S3M::Properties::lengthInPatterns() const
+TagLib::ushort S3M::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
@@ -98,52 +98,52 @@ bool S3M::Properties::stereo() const
   return d->stereo;
 }
 
-ushort S3M::Properties::sampleCount() const
+TagLib::ushort S3M::Properties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-ushort S3M::Properties::patternCount() const
+TagLib::ushort S3M::Properties::patternCount() const
 {
   return d->patternCount;
 }
 
-ushort S3M::Properties::flags() const
+TagLib::ushort S3M::Properties::flags() const
 {
   return d->flags;
 }
 
-ushort S3M::Properties::trackerVersion() const
+TagLib::ushort S3M::Properties::trackerVersion() const
 {
   return d->trackerVersion;
 }
 
-ushort S3M::Properties::fileFormatVersion() const
+TagLib::ushort S3M::Properties::fileFormatVersion() const
 {
   return d->fileFormatVersion;
 }
 
-uchar S3M::Properties::globalVolume() const
+TagLib::uchar S3M::Properties::globalVolume() const
 {
   return d->globalVolume;
 }
 
-uchar S3M::Properties::masterVolume() const
+TagLib::uchar S3M::Properties::masterVolume() const
 {
   return d->masterVolume;
 }
 
-uchar S3M::Properties::tempo() const
+TagLib::uchar S3M::Properties::tempo() const
 {
   return d->tempo;
 }
 
-uchar S3M::Properties::bpmSpeed() const
+TagLib::uchar S3M::Properties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }
 
-void S3M::Properties::setLengthInPatterns(ushort lengthInPatterns)
+void S3M::Properties::setLengthInPatterns(TagLib::ushort lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }
@@ -158,47 +158,47 @@ void S3M::Properties::setStereo(bool stereo)
   d->stereo = stereo;
 }
 
-void S3M::Properties::setSampleCount(ushort sampleCount)
+void S3M::Properties::setSampleCount(TagLib::ushort sampleCount)
 {
   d->sampleCount = sampleCount;
 }
 
-void S3M::Properties::setPatternCount(ushort patternCount)
+void S3M::Properties::setPatternCount(TagLib::ushort patternCount)
 {
   d->patternCount = patternCount;
 }
 
-void S3M::Properties::setFlags(ushort flags)
+void S3M::Properties::setFlags(TagLib::ushort flags)
 {
   d->flags = flags;
 }
 
-void S3M::Properties::setTrackerVersion(ushort trackerVersion)
+void S3M::Properties::setTrackerVersion(TagLib::ushort trackerVersion)
 {
   d->trackerVersion = trackerVersion;
 }
 
-void S3M::Properties::setFileFormatVersion(ushort fileFormatVersion)
+void S3M::Properties::setFileFormatVersion(TagLib::ushort fileFormatVersion)
 {
   d->fileFormatVersion = fileFormatVersion;
 }
 
-void S3M::Properties::setGlobalVolume(uchar globalVolume)
+void S3M::Properties::setGlobalVolume(TagLib::uchar globalVolume)
 {
   d->globalVolume = globalVolume;
 }
 
-void S3M::Properties::setMasterVolume(uchar masterVolume)
+void S3M::Properties::setMasterVolume(TagLib::uchar masterVolume)
 {
   d->masterVolume = masterVolume;
 }
 
-void S3M::Properties::setTempo(uchar tempo)
+void S3M::Properties::setTempo(TagLib::uchar tempo)
 {
   d->tempo = tempo;
 }
 
-void S3M::Properties::setBpmSpeed(uchar bpmSpeed)
+void S3M::Properties::setBpmSpeed(TagLib::uchar bpmSpeed)
 {
   d->bpmSpeed = bpmSpeed;
 }

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -161,12 +161,12 @@ void TagUnion::setGenre(const String &s)
   setUnion(Genre, s);
 }
 
-void TagUnion::setYear(uint i)
+void TagUnion::setYear(TagLib::uint i)
 {
   setUnion(Year, i);
 }
 
-void TagUnion::setTrack(uint i)
+void TagUnion::setTrack(TagLib::uint i)
 {
   setUnion(Track, i);
 }

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -44,7 +44,7 @@
 namespace TagLib {
   static const char hexTable[17] = "0123456789abcdef";
 
-  static const uint crcTable[256] = {
+  static const TagLib::uint crcTable[256] = {
     0x00000000, 0x04c11db7, 0x09823b6e, 0x0d4326d9, 0x130476dc, 0x17c56b6b,
     0x1a864db2, 0x1e475005, 0x2608edb8, 0x22c9f00f, 0x2f8ad6d6, 0x2b4bcb61,
     0x350c9b64, 0x31cd86d3, 0x3c8ea00a, 0x384fbdbd, 0x4c11db70, 0x48d0c6c7,
@@ -95,7 +95,7 @@ namespace TagLib {
    */
 
   template <class Vector>
-  int vectorFind(const Vector &v, const Vector &pattern, uint offset, int byteAlign)
+  int vectorFind(const Vector &v, const Vector &pattern, TagLib::uint offset, int byteAlign)
   {
     if(pattern.size() > v.size() || offset > v.size() - 1)
       return -1;
@@ -105,22 +105,22 @@ namespace TagLib {
 
     if(pattern.size() == 1) {
       char p = pattern[0];
-      for(uint i = offset; i < v.size(); i++) {
+      for(TagLib::uint i = offset; i < v.size(); i++) {
         if(v[i] == p && (i - offset) % byteAlign == 0)
           return i;
       }
       return -1;
     }
 
-    uchar lastOccurrence[256];
+    TagLib::uchar lastOccurrence[256];
 
-    for(uint i = 0; i < 256; ++i)
-      lastOccurrence[i] = uchar(pattern.size());
+    for(TagLib::uint i = 0; i < 256; ++i)
+      lastOccurrence[i] = TagLib::uchar(pattern.size());
 
-    for(uint i = 0; i < pattern.size() - 1; ++i)
-      lastOccurrence[uchar(pattern[i])] = uchar(pattern.size() - i - 1);
+    for(TagLib::uint i = 0; i < pattern.size() - 1; ++i)
+      lastOccurrence[TagLib::uchar(pattern[i])] = TagLib::uchar(pattern.size() - i - 1);
 
-    for(uint i = pattern.size() - 1 + offset; i < v.size(); i += lastOccurrence[uchar(v.at(i))]) {
+    for(TagLib::uint i = pattern.size() - 1 + offset; i < v.size(); i += lastOccurrence[TagLib::uchar(v.at(i))]) {
       int iBuffer = i;
       int iPattern = pattern.size() - 1;
 
@@ -159,17 +159,17 @@ namespace TagLib {
       return v.at(v.size() - index - 1);
     }
 
-    ByteVectorMirror mid(uint index, uint length = 0xffffffff) const
+    ByteVectorMirror mid(TagLib::uint index, TagLib::uint length = 0xffffffff) const
     {
       return length == 0xffffffff ? v.mid(0, index) : v.mid(index - length, length);
     }
 
-    uint size() const
+    TagLib::uint size() const
     {
       return v.size();
     }
 
-    int find(const ByteVectorMirror &pattern, uint offset = 0, int byteAlign = 1) const
+    int find(const ByteVectorMirror &pattern, TagLib::uint offset = 0, int byteAlign = 1) const
     {
       ByteVectorMirror v(*this);
 
@@ -210,11 +210,11 @@ namespace TagLib {
       return sum;
     }
 
-    uint size = sizeof(T);
-    uint last = data.size() > size ? size - 1 : data.size() - 1;
+    TagLib::uint size = sizeof(T);
+    TagLib::uint last = data.size() > size ? size - 1 : data.size() - 1;
 
-    for(uint i = 0; i <= last; i++)
-      sum |= (T) uchar(data[i]) << ((mostSignificantByteFirst ? last - i : i) * 8);
+    for(TagLib::uint i = 0; i <= last; i++)
+      sum |= (T) TagLib::uchar(data[i]) << ((mostSignificantByteFirst ? last - i : i) * 8);
 
     return sum;
   }
@@ -227,7 +227,7 @@ namespace TagLib {
     ByteVector v(size, 0);
 
     for(int i = 0; i < size; i++)
-      v[i] = uchar(value >> ((mostSignificantByteFirst ? size - 1 - i : i) * 8) & 0xff);
+      v[i] = TagLib::uchar(value >> ((mostSignificantByteFirst ? size - 1 - i : i) * 8) & 0xff);
 
     return v;
   }
@@ -246,7 +246,7 @@ public:
 
   // std::vector<T>::size() is very slow, so we'll cache the value
 
-  uint size;
+  TagLib::uint size;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -255,7 +255,7 @@ public:
 
 ByteVector ByteVector::null;
 
-ByteVector ByteVector::fromCString(const char *s, uint length)
+ByteVector ByteVector::fromCString(const char *s, TagLib::uint length)
 {
   ByteVector v;
 
@@ -267,9 +267,9 @@ ByteVector ByteVector::fromCString(const char *s, uint length)
   return v;
 }
 
-ByteVector ByteVector::fromUInt(uint value, bool mostSignificantByteFirst)
+ByteVector ByteVector::fromUInt(TagLib::uint value, bool mostSignificantByteFirst)
 {
-  return fromNumber<uint>(value, mostSignificantByteFirst);
+  return fromNumber<TagLib::uint>(value, mostSignificantByteFirst);
 }
 
 ByteVector ByteVector::fromShort(short value, bool mostSignificantByteFirst)
@@ -291,7 +291,7 @@ ByteVector::ByteVector()
   d = new ByteVectorPrivate;
 }
 
-ByteVector::ByteVector(uint size, char value)
+ByteVector::ByteVector(TagLib::uint size, char value)
 {
   d = new ByteVectorPrivate(size, value);
 }
@@ -308,7 +308,7 @@ ByteVector::ByteVector(char c)
   d->size = 1;
 }
 
-ByteVector::ByteVector(const char *data, uint length)
+ByteVector::ByteVector(const char *data, TagLib::uint length)
 {
   d = new ByteVectorPrivate;
   setData(data, length);
@@ -326,7 +326,7 @@ ByteVector::~ByteVector()
     delete d;
 }
 
-ByteVector &ByteVector::setData(const char *data, uint length)
+ByteVector &ByteVector::setData(const char *data, TagLib::uint length)
 {
   detach();
 
@@ -354,7 +354,7 @@ const char *ByteVector::data() const
   return size() > 0 ? DATA(d) : 0;
 }
 
-ByteVector ByteVector::mid(uint index, uint length) const
+ByteVector ByteVector::mid(TagLib::uint index, TagLib::uint length) const
 {
   ByteVector v;
 
@@ -374,17 +374,17 @@ ByteVector ByteVector::mid(uint index, uint length) const
   return v;
 }
 
-char ByteVector::at(uint index) const
+char ByteVector::at(TagLib::uint index) const
 {
   return index < size() ? d->data[index] : 0;
 }
 
-int ByteVector::find(const ByteVector &pattern, uint offset, int byteAlign) const
+int ByteVector::find(const ByteVector &pattern, TagLib::uint offset, int byteAlign) const
 {
   return vectorFind<ByteVector>(*this, pattern, offset, byteAlign);
 }
 
-int ByteVector::rfind(const ByteVector &pattern, uint offset, int byteAlign) const
+int ByteVector::rfind(const ByteVector &pattern, TagLib::uint offset, int byteAlign) const
 {
   // Ok, this is a little goofy, but pretty cool after it sinks in.  Instead of
   // reversing the find method's Boyer-Moore search algorithm I created a "mirror"
@@ -396,7 +396,7 @@ int ByteVector::rfind(const ByteVector &pattern, uint offset, int byteAlign) con
   return v.find(p, offset, byteAlign);
 }
 
-bool ByteVector::containsAt(const ByteVector &pattern, uint offset, uint patternOffset, uint patternLength) const
+bool ByteVector::containsAt(const ByteVector &pattern, TagLib::uint offset, TagLib::uint patternOffset, TagLib::uint patternLength) const
 {
   if(pattern.size() < patternLength)
     patternLength = pattern.size();
@@ -408,7 +408,7 @@ bool ByteVector::containsAt(const ByteVector &pattern, uint offset, uint pattern
 
   // loop through looking for a mismatch
 
-  for(uint i = 0; i < patternLength - patternOffset; i++) {
+  for(TagLib::uint i = 0; i < patternLength - patternOffset; i++) {
     if(at(i + offset) != pattern[i + patternOffset])
       return false;
   }
@@ -431,8 +431,8 @@ ByteVector &ByteVector::replace(const ByteVector &pattern, const ByteVector &wit
   if(pattern.size() == 0 || pattern.size() > size())
     return *this;
 
-  const uint withSize = with.size();
-  const uint patternSize = pattern.size();
+  const TagLib::uint withSize = with.size();
+  const TagLib::uint patternSize = pattern.size();
   int offset = 0;
 
   if(withSize == patternSize) {
@@ -447,7 +447,7 @@ ByteVector &ByteVector::replace(const ByteVector &pattern, const ByteVector &wit
   }
 
   // calculate new size:
-  uint newSize = 0;
+  TagLib::uint newSize = 0;
   for(;;) {
     int next = find(pattern, offset);
     if(next < 0) {
@@ -501,7 +501,7 @@ int ByteVector::endsWithPartialMatch(const ByteVector &pattern) const
   // try to match the last n-1 bytes from the vector (where n is the pattern
   // size) -- continue trying to match n-2, n-3...1 bytes
 
-  for(uint i = 1; i < pattern.size(); i++) {
+  for(TagLib::uint i = 1; i < pattern.size(); i++) {
     if(containsAt(pattern, startIndex + i, 0, pattern.size() - i))
       return startIndex + i;
   }
@@ -516,7 +516,7 @@ ByteVector &ByteVector::append(const ByteVector &v)
 
   detach();
 
-  uint originalSize = d->size;
+  TagLib::uint originalSize = d->size;
   resize(d->size + v.d->size);
   ::memcpy(DATA(d) + originalSize, DATA(v.d), v.size());
 
@@ -537,7 +537,7 @@ TagLib::uint ByteVector::size() const
   return d->size;
 }
 
-ByteVector &ByteVector::resize(uint size, char padding)
+ByteVector &ByteVector::resize(TagLib::uint size, char padding)
 {
   if(d->size < size) {
     d->data.reserve(size);
@@ -583,15 +583,15 @@ bool ByteVector::isEmpty() const
 
 TagLib::uint ByteVector::checksum() const
 {
-  uint sum = 0;
+  TagLib::uint sum = 0;
   for(ByteVector::ConstIterator it = begin(); it != end(); ++it)
-    sum = (sum << 8) ^ crcTable[((sum >> 24) & 0xff) ^ uchar(*it)];
+    sum = (sum << 8) ^ crcTable[((sum >> 24) & 0xff) ^ TagLib::uchar(*it)];
   return sum;
 }
 
 TagLib::uint ByteVector::toUInt(bool mostSignificantByteFirst) const
 {
-  return toNumber<uint>(d->data, mostSignificantByteFirst);
+  return toNumber<TagLib::uint>(d->data, mostSignificantByteFirst);
 }
 
 short ByteVector::toShort(bool mostSignificantByteFirst) const
@@ -698,8 +698,8 @@ ByteVector ByteVector::toHex() const
 {
   ByteVector encoded(size() * 2);
 
-  uint j = 0;
-  for(uint i = 0; i < size(); i++) {
+  TagLib::uint j = 0;
+  for(TagLib::uint i = 0; i < size(); i++) {
     unsigned char c = d->data[i];
     encoded[j++] = hexTable[(c >> 4) & 0x0F];
     encoded[j++] = hexTable[(c     ) & 0x0F];

--- a/taglib/toolkit/tbytevectorlist.cpp
+++ b/taglib/toolkit/tbytevectorlist.cpp
@@ -47,7 +47,7 @@ ByteVectorList ByteVectorList::split(const ByteVector &v, const ByteVector &patt
 {
   ByteVectorList l;
 
-  uint previousOffset = 0;
+  TagLib::uint previousOffset = 0;
   for(int offset = v.find(pattern, 0, byteAlign);
       offset != -1 && (max == 0 || max > int(l.size()) + 1);
       offset = v.find(pattern, offset + pattern.size(), byteAlign))

--- a/taglib/toolkit/tbytevectorstream.cpp
+++ b/taglib/toolkit/tbytevectorstream.cpp
@@ -68,7 +68,7 @@ FileName ByteVectorStream::name() const
   return FileName(""); // XXX do we need a name?
 }
 
-ByteVector ByteVectorStream::readBlock(ulong length)
+ByteVector ByteVectorStream::readBlock(TagLib::ulong length)
 {
   if(length == 0)
     return ByteVector::null;
@@ -80,7 +80,7 @@ ByteVector ByteVectorStream::readBlock(ulong length)
 
 void ByteVectorStream::writeBlock(const ByteVector &data)
 {
-  uint size = data.size();
+  TagLib::uint size = data.size();
   if(d->position + size > length()) {
     truncate(d->position + size);
   }
@@ -88,7 +88,7 @@ void ByteVectorStream::writeBlock(const ByteVector &data)
   d->position += size;
 }
 
-void ByteVectorStream::insert(const ByteVector &data, ulong start, ulong replace)
+void ByteVectorStream::insert(const ByteVector &data, TagLib::ulong start, TagLib::ulong replace)
 {
   long sizeDiff = data.size() - replace;
   if(sizeDiff < 0) {
@@ -96,20 +96,20 @@ void ByteVectorStream::insert(const ByteVector &data, ulong start, ulong replace
   }
   else if(sizeDiff > 0) {
     truncate(length() + sizeDiff);
-    ulong readPosition = start + replace;
-    ulong writePosition = start + data.size();
+    TagLib::ulong readPosition = start + replace;
+    TagLib::ulong writePosition = start + data.size();
     memmove(d->data.data() + writePosition, d->data.data() + readPosition, length() - sizeDiff - readPosition);
   }
   seek(start);
   writeBlock(data);
 }
 
-void ByteVectorStream::removeBlock(ulong start, ulong length)
+void ByteVectorStream::removeBlock(TagLib::ulong start, TagLib::ulong length)
 {
-  ulong readPosition = start + length;
-  ulong writePosition = start;
-  if(readPosition < ulong(ByteVectorStream::length())) {
-    ulong bytesToMove = ByteVectorStream::length() - readPosition;
+  TagLib::ulong readPosition = start + length;
+  TagLib::ulong writePosition = start;
+  if(readPosition < TagLib::ulong(ByteVectorStream::length())) {
+    TagLib::ulong bytesToMove = ByteVectorStream::length() - readPosition;
     memmove(d->data.data() + writePosition, d->data.data() + readPosition, bytesToMove);
     writePosition += bytesToMove;
   }

--- a/taglib/toolkit/tdebug.cpp
+++ b/taglib/toolkit/tdebug.cpp
@@ -39,7 +39,7 @@ void TagLib::debug(const String &s)
 
 void TagLib::debugData(const ByteVector &v)
 {
-  for(uint i = 0; i < v.size(); i++) {
+  for(TagLib::uint i = 0; i < v.size(); i++) {
 
     std::cout << "*** [" << i << "] - '" << char(v[i]) << "' - int " << int(v[i])
               << std::endl;

--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -59,7 +59,7 @@ public:
 
   IOStream *stream;
   bool valid;
-  static const uint bufferSize = 1024;
+  static const TagLib::uint bufferSize = 1024;
 };
 
 File::FilePrivate::FilePrivate(IOStream *stream) :
@@ -95,7 +95,7 @@ FileName File::name() const
   return d->stream->name();
 }
 
-ByteVector File::readBlock(ulong length)
+ByteVector File::readBlock(TagLib::ulong length)
 {
   return d->stream->readBlock(length);
 }
@@ -269,12 +269,12 @@ long File::rfind(const ByteVector &pattern, long fromOffset, const ByteVector &b
   return -1;
 }
 
-void File::insert(const ByteVector &data, ulong start, ulong replace)
+void File::insert(const ByteVector &data, TagLib::ulong start, TagLib::ulong replace)
 {
   d->stream->insert(data, start, replace);
 }
 
-void File::removeBlock(ulong start, ulong length)
+void File::removeBlock(TagLib::ulong start, TagLib::ulong length)
 {
   d->stream->removeBlock(start, length);
 }

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -75,8 +75,8 @@ public:
   FileNameHandle name;
 
   bool readOnly;
-  ulong size;
-  static const uint bufferSize = 1024;
+  TagLib::ulong size;
+  static const TagLib::uint bufferSize = 1024;
 };
 
 FileStream::FileStreamPrivate::FileStreamPrivate(FileName fileName, bool openReadOnly) :
@@ -89,7 +89,7 @@ FileStream::FileStreamPrivate::FileStreamPrivate(FileName fileName, bool openRea
 
 #ifdef _WIN32
 
-  if(wcslen((const wchar_t *) fileName) > 0) {
+  if(wcslen((const TagLib::wchar *) fileName) > 0) {
 
     if(openReadOnly)
       file = _wfopen(name, L"rb");
@@ -147,7 +147,7 @@ FileName FileStream::name() const
   return d->name;
 }
 
-ByteVector FileStream::readBlock(ulong length)
+ByteVector FileStream::readBlock(TagLib::ulong length)
 {
   if(!d->file) {
     debug("FileStream::readBlock() -- Invalid File");
@@ -158,12 +158,12 @@ ByteVector FileStream::readBlock(ulong length)
     return ByteVector::null;
 
   if(length > FileStreamPrivate::bufferSize &&
-     length > ulong(FileStream::length()))
+     length > TagLib::ulong(FileStream::length()))
   {
     length = FileStream::length();
   }
 
-  ByteVector v(static_cast<uint>(length));
+  ByteVector v(static_cast<TagLib::uint>(length));
   const int count = fread(v.data(), sizeof(char), length, d->file);
   v.resize(count);
   return v;
@@ -182,7 +182,7 @@ void FileStream::writeBlock(const ByteVector &data)
   fwrite(data.data(), sizeof(char), data.size(), d->file);
 }
 
-void FileStream::insert(const ByteVector &data, ulong start, ulong replace)
+void FileStream::insert(const ByteVector &data, TagLib::ulong start, TagLib::ulong replace)
 {
   if(!d->file)
     return;
@@ -209,7 +209,7 @@ void FileStream::insert(const ByteVector &data, ulong start, ulong replace)
   // the *differnce* in the tag sizes.  We want to avoid overwriting parts
   // that aren't yet in memory, so this is necessary.
 
-  ulong bufferLength = bufferSize();
+  TagLib::ulong bufferLength = bufferSize();
 
   while(data.size() - replace > bufferLength)
     bufferLength += bufferSize();
@@ -220,7 +220,7 @@ void FileStream::insert(const ByteVector &data, ulong start, ulong replace)
   long writePosition = start;
 
   ByteVector buffer;
-  ByteVector aboutToOverwrite(static_cast<uint>(bufferLength));
+  ByteVector aboutToOverwrite(static_cast<TagLib::uint>(bufferLength));
 
   // This is basically a special case of the loop below.  Here we're just
   // doing the same steps as below, but since we aren't using the same buffer
@@ -258,7 +258,7 @@ void FileStream::insert(const ByteVector &data, ulong start, ulong replace)
     // Check to see if we just read the last block.  We need to call clear()
     // if we did so that the last write succeeds.
 
-    if(ulong(bytesRead) < bufferLength)
+    if(TagLib::ulong(bytesRead) < bufferLength)
       clear();
 
     // Seek to the write position and write our buffer.  Increment the
@@ -280,19 +280,19 @@ void FileStream::insert(const ByteVector &data, ulong start, ulong replace)
   }
 }
 
-void FileStream::removeBlock(ulong start, ulong length)
+void FileStream::removeBlock(TagLib::ulong start, TagLib::ulong length)
 {
   if(!d->file)
     return;
 
-  ulong bufferLength = bufferSize();
+  TagLib::ulong bufferLength = bufferSize();
 
   long readPosition = start + length;
   long writePosition = start;
 
-  ByteVector buffer(static_cast<uint>(bufferLength));
+  ByteVector buffer(static_cast<TagLib::uint>(bufferLength));
 
-  ulong bytesRead = 1;
+  TagLib::ulong bytesRead = 1;
 
   while(bytesRead != 0) {
     seek(readPosition);

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -100,7 +100,7 @@ String::String(const std::string &s, Type t)
   wstring::iterator targetIt = d->data.begin();
 
   for(std::string::const_iterator it = s.begin(); it != s.end(); it++) {
-    *targetIt = uchar(*it);
+    *targetIt = TagLib::uchar(*it);
     ++targetIt;
   }
 
@@ -113,7 +113,7 @@ String::String(const wstring &s, Type t)
   prepare(t);
 }
 
-String::String(const wchar_t *s, Type t)
+String::String(const TagLib::wchar *s, Type t)
 {
   d = new StringPrivate(s);
   prepare(t);
@@ -134,14 +134,14 @@ String::String(const char *s, Type t)
   wstring::iterator targetIt = d->data.begin();
 
   for(int i = 0; i < length; i++) {
-    *targetIt = uchar(s[i]);
+    *targetIt = TagLib::uchar(s[i]);
     ++targetIt;
   }
 
   prepare(t);
 }
 
-String::String(wchar_t c, Type t)
+String::String(TagLib::wchar c, Type t)
 {
   d = new StringPrivate;
   d->data += c;
@@ -157,7 +157,7 @@ String::String(char c, Type t)
     return;
   }
 
-  d->data += uchar(c);
+  d->data += TagLib::uchar(c);
   prepare(t);
 }
 
@@ -174,7 +174,7 @@ String::String(const ByteVector &v, Type t)
     d->data.resize(v.size());
     wstring::iterator targetIt = d->data.begin();
     for(ByteVector::ConstIterator it = v.begin(); it != v.end() && (*it); ++it) {
-      *targetIt = uchar(*it);
+      *targetIt = TagLib::uchar(*it);
       ++targetIt;
       ++length;
     }
@@ -333,7 +333,7 @@ bool String::startsWith(const String &s) const
   return substr(0, s.length()) == s;
 }
 
-String String::substr(uint position, uint n) const
+String String::substr(TagLib::uint position, TagLib::uint n) const
 {
   if(n > position + d->data.size())
     n = d->data.size() - position;
@@ -460,10 +460,10 @@ int String::toInt(bool *ok) const
 {
   int value = 0;
 
-  uint size = d->data.size();
+  TagLib::uint size = d->data.size();
   bool negative = size > 0 && d->data[0] == '-';
-  uint start = negative ? 1 : 0;
-  uint i = start;
+  TagLib::uint start = negative ? 1 : 0;
+  TagLib::uint i = start;
 
   for(; i < size && d->data[i] >= '0' && d->data[i] <= '9'; i++)
     value = value * 10 + (d->data[i] - '0');
@@ -575,7 +575,7 @@ String &String::operator+=(const String &s)
   return *this;
 }
 
-String &String::operator+=(const wchar_t *s)
+String &String::operator+=(const TagLib::wchar *s)
 {
   detach();
 
@@ -588,11 +588,11 @@ String &String::operator+=(const char *s)
   detach();
 
   for(int i = 0; s[i] != 0; i++)
-    d->data += uchar(s[i]);
+    d->data += TagLib::uchar(s[i]);
   return *this;
 }
 
-String &String::operator+=(wchar_t c)
+String &String::operator+=(TagLib::wchar c)
 {
   detach();
 
@@ -604,7 +604,7 @@ String &String::operator+=(char c)
 {
   detach();
 
-  d->data += uchar(c);
+  d->data += TagLib::uchar(c);
   return *this;
 }
 
@@ -631,7 +631,7 @@ String &String::operator=(const std::string &s)
 
   wstring::iterator targetIt = d->data.begin();
   for(std::string::const_iterator it = s.begin(); it != s.end(); it++) {
-    *targetIt = uchar(*it);
+    *targetIt = TagLib::uchar(*it);
     ++targetIt;
   }
 
@@ -646,7 +646,7 @@ String &String::operator=(const wstring &s)
   return *this;
 }
 
-String &String::operator=(const wchar_t *s)
+String &String::operator=(const TagLib::wchar *s)
 {
   if(d->deref())
     delete d;
@@ -659,11 +659,11 @@ String &String::operator=(char c)
   if(d->deref())
     delete d;
   d = new StringPrivate;
-  d->data += uchar(c);
+  d->data += TagLib::uchar(c);
   return *this;
 }
 
-String &String::operator=(wchar_t c)
+String &String::operator=(TagLib::wchar c)
 {
   if(d->deref())
     delete d;
@@ -684,7 +684,7 @@ String &String::operator=(const char *s)
 
   wstring::iterator targetIt = d->data.begin();
   for(int i = 0; i < length; i++) {
-    *targetIt = uchar(s[i]);
+    *targetIt = TagLib::uchar(s[i]);
     ++targetIt;
   }
 
@@ -700,10 +700,10 @@ String &String::operator=(const ByteVector &v)
   d->data.resize(v.size());
   wstring::iterator targetIt = d->data.begin();
 
-  uint i = 0;
+  TagLib::uint i = 0;
 
   for(ByteVector::ConstIterator it = v.begin(); it != v.end() && (*it); ++it) {
-    *targetIt = uchar(*it);
+    *targetIt = TagLib::uchar(*it);
     ++targetIt;
     ++i;
   }
@@ -745,7 +745,7 @@ void String::prepare(Type t)
       bool swap = d->data[0] != 0xfeff;
       d->data.erase(d->data.begin(), d->data.begin() + 1);
       if(swap) {
-        for(uint i = 0; i < d->data.size(); i++)
+        for(TagLib::uint i = 0; i < d->data.size(); i++)
           d->data[i] = byteSwap((unsigned short)d->data[i]);
       }
     }
@@ -791,7 +791,7 @@ void String::prepare(Type t)
   }
   case UTF16LE:
   {
-    for(uint i = 0; i < d->data.size(); i++)
+    for(TagLib::uint i = 0; i < d->data.size(); i++)
       d->data[i] = byteSwap((unsigned short)d->data[i]);
     break;
   }

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -63,7 +63,7 @@ public:
 
   const ID3v2::FrameFactory *ID3v2FrameFactory;
   long ID3v2Location;
-  uint ID3v2OriginalSize;
+  TagLib::uint ID3v2OriginalSize;
 
   long ID3v1Location;
 

--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -62,7 +62,7 @@ public:
   }
 
   long APELocation;
-  uint APESize;
+  TagLib::uint APESize;
 
   long ID3v1Location;
 

--- a/taglib/xm/xmfile.cpp
+++ b/taglib/xm/xmfile.cpp
@@ -73,35 +73,35 @@ public:
    * Reads associated values from \a file, but never reads more
    * then \a limit bytes.
    */
-  virtual uint read(TagLib::File &file, uint limit) = 0;
+  virtual TagLib::uint read(TagLib::File &file, TagLib::uint limit) = 0;
 
   /*!
    * Returns the number of bytes this reader would like to read.
    */
-  virtual uint size() const = 0;
+  virtual TagLib::uint size() const = 0;
 };
 
 class SkipReader : public Reader
 {
 public:
-  SkipReader(uint size) : m_size(size)
+  SkipReader(TagLib::uint size) : m_size(size)
   {
   }
 
-  uint read(TagLib::File &file, uint limit)
+  TagLib::uint read(TagLib::File &file, TagLib::uint limit)
   {
-    uint count = std::min(m_size, limit);
+    TagLib::uint count = std::min(m_size, limit);
     file.seek(count, TagLib::File::Current);
     return count;
   }
 
-  uint size() const
+  TagLib::uint size() const
   {
     return m_size;
   }
 
 private:
-  uint m_size;
+  TagLib::uint m_size;
 };
 
 template<typename T>
@@ -119,15 +119,15 @@ protected:
 class StringReader : public ValueReader<String>
 {
 public:
-  StringReader(String &string, uint size) :
+  StringReader(String &string, TagLib::uint size) :
     ValueReader<String>(string), m_size(size)
   {
   }
 
-  uint read(TagLib::File &file, uint limit)
+  TagLib::uint read(TagLib::File &file, TagLib::uint limit)
   {
     ByteVector data = file.readBlock(std::min(m_size, limit));
-    uint count = data.size();
+    TagLib::uint count = data.size();
     int index = data.find((char) 0);
     if(index > -1) {
       data.resize(index);
@@ -137,21 +137,21 @@ public:
     return count;
   }
 
-  uint size() const
+  TagLib::uint size() const
   {
     return m_size;
   }
 
 private:
-  uint m_size;
+  TagLib::uint m_size;
 };
 
-class ByteReader : public ValueReader<uchar>
+class ByteReader : public ValueReader<TagLib::uchar>
 {
 public:
-  ByteReader(uchar &byte) : ValueReader<uchar>(byte) {}
+  ByteReader(TagLib::uchar &byte) : ValueReader<TagLib::uchar>(byte) {}
 
-  uint read(TagLib::File &file, uint limit)
+  TagLib::uint read(TagLib::File &file, TagLib::uint limit)
   {
     ByteVector data = file.readBlock(std::min(1U,limit));
     if(data.size() > 0) {
@@ -160,7 +160,7 @@ public:
     return data.size();
   }
 
-  uint size() const
+  TagLib::uint size() const
   {
     return 1;
   }
@@ -179,41 +179,41 @@ protected:
   bool bigEndian;
 };
 
-class U16Reader : public NumberReader<ushort>
+class U16Reader : public NumberReader<TagLib::ushort>
 {
 public:
-  U16Reader(ushort &value, bool bigEndian)
-  : NumberReader<ushort>(value, bigEndian) {}
+  U16Reader(TagLib::ushort &value, bool bigEndian)
+  : NumberReader<TagLib::ushort>(value, bigEndian) {}
 
-  uint read(TagLib::File &file, uint limit)
+  TagLib::uint read(TagLib::File &file, TagLib::uint limit)
   {
     ByteVector data = file.readBlock(std::min(2U,limit));
     value = data.toUShort(bigEndian);
     return data.size();
   }
 
-  uint size() const
+  TagLib::uint size() const
   {
     return 2;
   }
 };
 
-class U32Reader : public NumberReader<ulong>
+class U32Reader : public NumberReader<TagLib::ulong>
 {
 public:
-  U32Reader(ulong &value, bool bigEndian = true) :
-    NumberReader<ulong>(value, bigEndian)
+  U32Reader(TagLib::ulong &value, bool bigEndian = true) :
+    NumberReader<TagLib::ulong>(value, bigEndian)
   {
   }
 
-  uint read(TagLib::File &file, uint limit)
+  TagLib::uint read(TagLib::File &file, TagLib::uint limit)
   {
     ByteVector data = file.readBlock(std::min(4U,limit));
     value = data.toUInt(bigEndian);
     return data.size();
   }
 
-  uint size() const
+  TagLib::uint size() const
   {
     return 4;
   }
@@ -239,7 +239,7 @@ public:
   /*!
    * Don't read anything but skip \a size bytes.
    */
-  StructReader &skip(uint size)
+  StructReader &skip(TagLib::uint size)
   {
     m_readers.append(new SkipReader(size));
     return *this;
@@ -248,7 +248,7 @@ public:
   /*!
    * Read a string of \a size characters (bytes) into \a string.
    */
-  StructReader &string(String &string, uint size)
+  StructReader &string(String &string, TagLib::uint size)
   {
     m_readers.append(new StringReader(string, size));
     return *this;
@@ -257,7 +257,7 @@ public:
   /*!
    * Read a byte into \a byte.
    */
-  StructReader &byte(uchar &byte)
+  StructReader &byte(TagLib::uchar &byte)
   {
     m_readers.append(new ByteReader(byte));
     return *this;
@@ -267,7 +267,7 @@ public:
    * Read a unsigned 16 Bit integer into \a number. The byte order
    * is controlled by \a bigEndian.
    */
-  StructReader &u16(ushort &number, bool bigEndian)
+  StructReader &u16(TagLib::ushort &number, bool bigEndian)
   {
     m_readers.append(new U16Reader(number, bigEndian));
     return *this;
@@ -276,7 +276,7 @@ public:
   /*!
    * Read a unsigned 16 Bit little endian integer into \a number.
    */
-  StructReader &u16L(ushort &number)
+  StructReader &u16L(TagLib::ushort &number)
   {
     return u16(number, false);
   }
@@ -284,7 +284,7 @@ public:
   /*!
    * Read a unsigned 16 Bit big endian integer into \a number.
    */
-  StructReader &u16B(ushort &number)
+  StructReader &u16B(TagLib::ushort &number)
   {
     return u16(number, true);
   }
@@ -293,7 +293,7 @@ public:
    * Read a unsigned 32 Bit integer into \a number. The byte order
    * is controlled by \a bigEndian.
    */
-  StructReader &u32(ulong &number, bool bigEndian)
+  StructReader &u32(TagLib::ulong &number, bool bigEndian)
   {
     m_readers.append(new U32Reader(number, bigEndian));
     return *this;
@@ -302,7 +302,7 @@ public:
   /*!
    * Read a unsigned 32 Bit little endian integer into \a number.
    */
-  StructReader &u32L(ulong &number)
+  StructReader &u32L(TagLib::ulong &number)
   {
     return u32(number, false);
   }
@@ -310,14 +310,14 @@ public:
   /*!
    * Read a unsigned 32 Bit big endian integer into \a number.
    */
-  StructReader &u32B(ulong &number)
+  StructReader &u32B(TagLib::ulong &number)
   {
     return u32(number, true);
   }
 
-  uint size() const
+  TagLib::uint size() const
   {
-    uint size = 0;
+    TagLib::uint size = 0;
     for(List<Reader*>::ConstIterator i = m_readers.begin();
         i != m_readers.end(); ++ i) {
       size += (*i)->size();
@@ -325,12 +325,12 @@ public:
     return size;
   }
 
-  uint read(TagLib::File &file, uint limit)
+  TagLib::uint read(TagLib::File &file, TagLib::uint limit)
   {
-    uint sumcount = 0;
+    TagLib::uint sumcount = 0;
     for(List<Reader*>::Iterator i = m_readers.begin();
         limit > 0 && i != m_readers.end(); ++ i) {
-      uint count = (*i)->read(file, limit);
+      TagLib::uint count = (*i)->read(file, limit);
       limit    -= count;
       sumcount += count;
     }
@@ -395,43 +395,43 @@ bool XM::File::save()
   seek(1, Current);
   writeString(d->tag.trackerName(), 20);
   seek(2, Current);
-  ulong headerSize = 0;
+  TagLib::ulong headerSize = 0;
   if(!readU32L(headerSize))
     return false;
   seek(2+2+2, Current);
 
-  ushort patternCount = 0;
-  ushort instrumentCount = 0;
+  TagLib::ushort patternCount = 0;
+  TagLib::ushort instrumentCount = 0;
   if(!readU16L(patternCount) || !readU16L(instrumentCount))
     return false;
 
   seek(60 + headerSize);
 
   // need to read patterns again in order to seek to the instruments:
-  for(ushort i = 0; i < patternCount; ++ i) {
-    ulong patternHeaderLength = 0;
+  for(TagLib::ushort i = 0; i < patternCount; ++ i) {
+    TagLib::ulong patternHeaderLength = 0;
     if(!readU32L(patternHeaderLength) || patternHeaderLength < 4)
       return false;
 
-    ushort dataSize = 0;
+    TagLib::ushort dataSize = 0;
     StructReader pattern;
     pattern.skip(3).u16L(dataSize);
 
-    uint count = pattern.read(*this, patternHeaderLength - 4U);
-    if(count != std::min(patternHeaderLength - 4U, (ulong)pattern.size()))
+    TagLib::uint count = pattern.read(*this, patternHeaderLength - 4U);
+    if(count != std::min(patternHeaderLength - 4U, (TagLib::ulong)pattern.size()))
       return false;
 
     seek(patternHeaderLength - (4 + count) + dataSize, Current);
   }
 
   StringList lines = d->tag.comment().split("\n");
-  uint sampleNameIndex = instrumentCount;
-  for(ushort i = 0; i < instrumentCount; ++ i) {
-    ulong instrumentHeaderSize = 0;
+  TagLib::uint sampleNameIndex = instrumentCount;
+  for(TagLib::ushort i = 0; i < instrumentCount; ++ i) {
+    TagLib::ulong instrumentHeaderSize = 0;
     if(!readU32L(instrumentHeaderSize) || instrumentHeaderSize < 4)
       return false;
 
-    uint len = std::min(22UL, instrumentHeaderSize - 4U);
+    TagLib::uint len = std::min(22UL, instrumentHeaderSize - 4U);
     if(i > lines.size())
       writeString(String::null, len);
     else
@@ -439,28 +439,28 @@ bool XM::File::save()
 
     long offset = 0;
     if(instrumentHeaderSize >= 29U) {
-      ushort sampleCount = 0;
+      TagLib::ushort sampleCount = 0;
       seek(1, Current);
       if(!readU16L(sampleCount))
         return false;
 
       if(sampleCount > 0) {
-        ulong sampleHeaderSize = 0;
+        TagLib::ulong sampleHeaderSize = 0;
         if(instrumentHeaderSize < 33U || !readU32L(sampleHeaderSize))
           return false;
         // skip unhandeled header proportion:
         seek(instrumentHeaderSize - 33, Current);
 
-        for(ushort j = 0; j < sampleCount; ++ j) {
+        for(TagLib::ushort j = 0; j < sampleCount; ++ j) {
           if(sampleHeaderSize > 4U) {
-            ulong sampleLength = 0;
+            TagLib::ulong sampleLength = 0;
             if(!readU32L(sampleLength))
               return false;
             offset += sampleLength;
 
             seek(std::min(sampleHeaderSize, 14UL), Current);
             if(sampleHeaderSize > 18U) {
-              uint len = std::min(sampleHeaderSize - 18U, 22UL);
+              TagLib::uint len = std::min(sampleHeaderSize - 18U, 22UL);
               if(sampleNameIndex >= lines.size())
                 writeString(String::null, len);
               else
@@ -507,14 +507,14 @@ void XM::File::read(bool)
   READ_U32L_AS(headerSize);
   READ_ASSERT(headerSize >= 4);
 
-  ushort length          = 0;
-  ushort restartPosition = 0;
-  ushort channels        = 0;
-  ushort patternCount    = 0;
-  ushort instrumentCount = 0;
-  ushort flags    = 0;
-  ushort tempo    = 0;
-  ushort bpmSpeed = 0;
+  TagLib::ushort length          = 0;
+  TagLib::ushort restartPosition = 0;
+  TagLib::ushort channels        = 0;
+  TagLib::ushort patternCount    = 0;
+  TagLib::ushort instrumentCount = 0;
+  TagLib::ushort flags    = 0;
+  TagLib::ushort tempo    = 0;
+  TagLib::ushort bpmSpeed = 0;
 
   StructReader header;
   header.u16L(length)
@@ -526,8 +526,8 @@ void XM::File::read(bool)
         .u16L(tempo)
         .u16L(bpmSpeed);
 
-  uint count = header.read(*this, headerSize - 4U);
-  uint size = std::min(headerSize - 4U, (ulong)header.size());
+  TagLib::uint count = header.read(*this, headerSize - 4U);
+  TagLib::uint size = std::min(headerSize - 4U, (TagLib::ulong)header.size());
 
   READ_ASSERT(count == size);
 
@@ -543,43 +543,43 @@ void XM::File::read(bool)
   seek(60 + headerSize);
 
   // read patterns:
-  for(ushort i = 0; i < patternCount; ++ i) {
+  for(TagLib::ushort i = 0; i < patternCount; ++ i) {
     READ_U32L_AS(patternHeaderLength);
     READ_ASSERT(patternHeaderLength >= 4);
 
-    uchar  packingType = 0;
-    ushort rowCount = 0;
-    ushort dataSize = 0;
+    TagLib::uchar  packingType = 0;
+    TagLib::ushort rowCount = 0;
+    TagLib::ushort dataSize = 0;
     StructReader pattern;
     pattern.byte(packingType).u16L(rowCount).u16L(dataSize);
 
-    uint count = pattern.read(*this, patternHeaderLength - 4U);
-    READ_ASSERT(count == std::min(patternHeaderLength - 4U, (ulong)pattern.size()));
+    TagLib::uint count = pattern.read(*this, patternHeaderLength - 4U);
+    READ_ASSERT(count == std::min(patternHeaderLength - 4U, (TagLib::ulong)pattern.size()));
 
     seek(patternHeaderLength - (4 + count) + dataSize, Current);
   }
 
   StringList intrumentNames;
   StringList sampleNames;
-  uint sumSampleCount = 0;
+  TagLib::uint sumSampleCount = 0;
 
   // read instruments:
-  for(ushort i = 0; i < instrumentCount; ++ i) {
+  for(TagLib::ushort i = 0; i < instrumentCount; ++ i) {
     READ_U32L_AS(instrumentHeaderSize);
     READ_ASSERT(instrumentHeaderSize >= 4);
 
     String instrumentName;
-    uchar  instrumentType = 0;
-    ushort sampleCount = 0;
+    TagLib::uchar  instrumentType = 0;
+    TagLib::ushort sampleCount = 0;
 
     StructReader instrument;
     instrument.string(instrumentName, 22).byte(instrumentType).u16L(sampleCount);
 
     // 4 for instrumentHeaderSize
-    uint count = 4 + instrument.read(*this, instrumentHeaderSize - 4U);
-    READ_ASSERT(count == std::min(instrumentHeaderSize, (ulong)instrument.size() + 4));
+    TagLib::uint count = 4 + instrument.read(*this, instrumentHeaderSize - 4U);
+    READ_ASSERT(count == std::min(instrumentHeaderSize, (TagLib::ulong)instrument.size() + 4));
 
-    ulong sampleHeaderSize = 0;
+    TagLib::ulong sampleHeaderSize = 0;
     long offset = 0;
     if(sampleCount > 0) {
       sumSampleCount += sampleCount;
@@ -588,16 +588,16 @@ void XM::File::read(bool)
       // skip unhandeled header proportion:
       seek(instrumentHeaderSize - count - 4, Current);
 
-      for(ushort j = 0; j < sampleCount; ++ j) {
-        ulong sampleLength = 0;
-        ulong loopStart    = 0;
-        ulong loopLength   = 0;
-        uchar volume       = 0;
-        uchar finetune     = 0;
-        uchar sampleType   = 0;
-        uchar panning      = 0;
-        uchar noteNumber   = 0;
-        uchar compression  = 0;
+      for(TagLib::ushort j = 0; j < sampleCount; ++ j) {
+        TagLib::ulong sampleLength = 0;
+        TagLib::ulong loopStart    = 0;
+        TagLib::ulong loopLength   = 0;
+        TagLib::uchar volume       = 0;
+        TagLib::uchar finetune     = 0;
+        TagLib::uchar sampleType   = 0;
+        TagLib::uchar panning      = 0;
+        TagLib::uchar noteNumber   = 0;
+        TagLib::uchar compression  = 0;
         String sampleName;
         StructReader sample;
         sample.u32L(sampleLength)
@@ -611,8 +611,8 @@ void XM::File::read(bool)
               .byte(compression)
               .string(sampleName, 22);
 
-        uint count = sample.read(*this, sampleHeaderSize);
-        READ_ASSERT(count == std::min(sampleHeaderSize, (ulong)sample.size()));
+        TagLib::uint count = sample.read(*this, sampleHeaderSize);
+        READ_ASSERT(count == std::min(sampleHeaderSize, (TagLib::ulong)sample.size()));
         // skip unhandeled header proportion:
         seek(sampleHeaderSize - count, Current);
 

--- a/taglib/xm/xmproperties.cpp
+++ b/taglib/xm/xmproperties.cpp
@@ -41,16 +41,16 @@ public:
   {
   }
   
-  ushort lengthInPatterns;
+  TagLib::ushort lengthInPatterns;
   int    channels;
-  ushort version;
-  ushort restartPosition;
-  ushort patternCount;
-  ushort instrumentCount;
-  uint   sampleCount;
-  ushort flags;
-  ushort tempo;
-  ushort bpmSpeed;
+  TagLib::ushort version;
+  TagLib::ushort restartPosition;
+  TagLib::ushort patternCount;
+  TagLib::ushort instrumentCount;
+  TagLib::uint   sampleCount;
+  TagLib::ushort flags;
+  TagLib::ushort tempo;
+  TagLib::ushort bpmSpeed;
 };
 
 XM::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
@@ -84,52 +84,52 @@ int XM::Properties::channels() const
   return d->channels;
 }
 
-ushort XM::Properties::lengthInPatterns() const
+TagLib::ushort XM::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
 
-ushort XM::Properties::version() const
+TagLib::ushort XM::Properties::version() const
 {
   return d->version;
 }
 
-ushort XM::Properties::restartPosition() const
+TagLib::ushort XM::Properties::restartPosition() const
 {
   return d->restartPosition;
 }
 
-ushort XM::Properties::patternCount() const
+TagLib::ushort XM::Properties::patternCount() const
 {
   return d->patternCount;
 }
 
-ushort XM::Properties::instrumentCount() const
+TagLib::ushort XM::Properties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-uint XM::Properties::sampleCount() const
+TagLib::uint XM::Properties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-ushort XM::Properties::flags() const
+TagLib::ushort XM::Properties::flags() const
 {
   return d->flags;
 }
 
-ushort XM::Properties::tempo() const
+TagLib::ushort XM::Properties::tempo() const
 {
   return d->tempo;
 }
 
-ushort XM::Properties::bpmSpeed() const
+TagLib::ushort XM::Properties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }
 
-void XM::Properties::setLengthInPatterns(ushort lengthInPatterns)
+void XM::Properties::setLengthInPatterns(TagLib::ushort lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }
@@ -139,42 +139,42 @@ void XM::Properties::setChannels(int channels)
   d->channels = channels;
 }
 
-void XM::Properties::setVersion(ushort version)
+void XM::Properties::setVersion(TagLib::ushort version)
 {
   d->version = version;
 }
 
-void XM::Properties::setRestartPosition(ushort restartPosition)
+void XM::Properties::setRestartPosition(TagLib::ushort restartPosition)
 {
   d->restartPosition = restartPosition;
 }
 
-void XM::Properties::setPatternCount(ushort patternCount)
+void XM::Properties::setPatternCount(TagLib::ushort patternCount)
 {
   d->patternCount = patternCount;
 }
 
-void XM::Properties::setInstrumentCount(ushort instrumentCount)
+void XM::Properties::setInstrumentCount(TagLib::ushort instrumentCount)
 {
   d->instrumentCount = instrumentCount;
 }
 
-void XM::Properties::setSampleCount(uint sampleCount)
+void XM::Properties::setSampleCount(TagLib::uint sampleCount)
 {
   d->sampleCount = sampleCount;
 }
 
-void XM::Properties::setFlags(ushort flags)
+void XM::Properties::setFlags(TagLib::ushort flags)
 {
   d->flags = flags;
 }
 
-void XM::Properties::setTempo(ushort tempo)
+void XM::Properties::setTempo(TagLib::ushort tempo)
 {
   d->tempo = tempo;
 }
 
-void XM::Properties::setBpmSpeed(ushort bpmSpeed)
+void XM::Properties::setBpmSpeed(TagLib::ushort bpmSpeed)
 {
   d->bpmSpeed = bpmSpeed;
 }

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -296,7 +296,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("ident"), f.identification());
     CPPUNIT_ASSERT_EQUAL(15.0f / 512.0f,
                          f.volumeAdjustment(ID3v2::RelativeVolumeFrame::FrontRight));
-    CPPUNIT_ASSERT_EQUAL((uchar)8,
+    CPPUNIT_ASSERT_EQUAL((TagLib::uchar)8,
                          f.peakVolume(ID3v2::RelativeVolumeFrame::FrontRight).bitsRepresentingPeak);
     CPPUNIT_ASSERT_EQUAL(ByteVector("\x45"),
                          f.peakVolume(ID3v2::RelativeVolumeFrame::FrontRight).peakVolume);

--- a/tests/test_mod.cpp
+++ b/tests/test_mod.cpp
@@ -93,7 +93,7 @@ private:
     CPPUNIT_ASSERT_EQUAL(0, p->sampleRate());
     CPPUNIT_ASSERT_EQUAL(8, p->channels());
     CPPUNIT_ASSERT_EQUAL(31U, p->instrumentCount());
-    CPPUNIT_ASSERT_EQUAL((uchar)1, p->lengthInPatterns());
+    CPPUNIT_ASSERT_EQUAL((TagLib::uchar)1, p->lengthInPatterns());
     CPPUNIT_ASSERT_EQUAL(title, t->title());
     CPPUNIT_ASSERT_EQUAL(String::null, t->artist());
     CPPUNIT_ASSERT_EQUAL(String::null, t->album());


### PR DESCRIPTION
...t confliction with typedefs from system header.

I thought about using cmake to check type definitions,
but in this way taglib's user would have to have the same check in their projects,
so I think it's better not to leave anything out of the header file.
