### PR TITLE
WAVE properties reader crashes with bit depths < 8

### DIFF
--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -125,5 +125,5 @@ void RIFF::WAV::Properties::read(const ByteVector &data)
 
   d->length = byteRate > 0 ? d->streamLength / byteRate : 0;
   if(d->channels > 0 && d->sampleWidth > 0)
-    d->sampleFrames = d->streamLength / (d->channels * (d->sampleWidth / 8));
+    d->sampleFrames = d->streamLength / (d->channels * ((d->sampleWidth + 7) / 8));
 }


### PR DESCRIPTION
If the bit depth read from a WAVE file is less than 8, the calculation for sampleFrames will crash.  Additionally, the calculation was off for non-integral bit depths.  This commit fixes those issues.
