### PR TITLE
Fixed memory leak

### DIFF
--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -190,7 +190,7 @@ void ID3v1::Tag::setTrack(uint i)
 
 void ID3v1::Tag::setStringHandler(const StringHandler *handler)
 {
-  if (TagPrivate::stringHandler != &defaultStringHandler)
+  if(TagPrivate::stringHandler != &defaultStringHandler)
     delete TagPrivate::stringHandler;
 
   TagPrivate::stringHandler = handler;


### PR DESCRIPTION
The default StringHandler object is never freed. This isn't an issue in most cases, but is problematic when TagLib is compiled into a dynamically loaded library, which is loaded and unloaded during the course of the main application's lifetime (a leak occurs each time the library is loaded).
