### PR TITLE
Added sampleFrames() to FLAC::Properties

### DIFF
--- a/taglib/flac/flacproperties.cpp
+++ b/taglib/flac/flacproperties.cpp
@@ -42,7 +42,8 @@ public:
     bitrate(0),
     sampleRate(0),
     sampleWidth(0),
-    channels(0) {}
+    channels(0),
+    sampleFrames(0) {}
 
   ByteVector data;
   long streamLength;
@@ -52,6 +53,7 @@ public:
   int sampleRate;
   int sampleWidth;
   int channels;
+  unsigned long long sampleFrames;
   ByteVector signature;
 };
 
@@ -101,6 +103,11 @@ int FLAC::Properties::channels() const
   return d->channels;
 }
 
+unsigned long long FLAC::Properties::sampleFrames() const
+{
+  return d->sampleFrames;
+}
+
 ByteVector FLAC::Properties::signature() const
 {
   return d->signature;
@@ -132,6 +139,8 @@ void FLAC::Properties::read()
   pos += 3;
 
   uint flags = d->data.mid(pos, 4).toUInt(true);
+  pos += 4;
+
   d->sampleRate = flags >> 12;
   d->channels = ((flags >> 9) & 7) + 1;
   d->sampleWidth = ((flags >> 4) & 31) + 1;
@@ -139,12 +148,14 @@ void FLAC::Properties::read()
   // The last 4 bits are the most significant 4 bits for the 36 bit
   // stream length in samples. (Audio files measured in days)
 
-  uint highLength =d->sampleRate > 0 ? (((flags & 0xf) << 28) / d->sampleRate) << 4 : 0;
+  unsigned long long hi = flags & 0xf;
+  unsigned long long lo = d->data.mid(pos, 4).toUInt(true);
   pos += 4;
 
-  d->length = d->sampleRate > 0 ?
-      (d->data.mid(pos, 4).toUInt(true)) / d->sampleRate + highLength : 0;
-  pos += 4;
+  d->sampleFrames = (hi << 32) | lo;
+
+  if(d->sampleRate > 0)
+    d->length = int(d->sampleFrames / d->sampleRate);
 
   // Uncompressed bitrate:
 

--- a/taglib/flac/flacproperties.h
+++ b/taglib/flac/flacproperties.h
@@ -78,6 +78,11 @@ namespace TagLib {
       int sampleWidth() const;
 
       /*!
+       * Return the number of sample frames
+       */
+      unsigned long long sampleFrames() const;
+
+      /*!
        * Returns the MD5 signature of the uncompressed audio stream as read
        * from the stream info header header.
        */


### PR DESCRIPTION
I added a method to `FLAC::Properties` to retrieve the total number of samples in the audio file.

I made the property an `unsigned long long` to match what the reference libFLAC stores in its `FLAC__StreamMetadata_StreamInfo` struct, but the actual number can be no larger than 36 bits, so a `long long` would work as well.
