### PR TITLE
Remove 'using namespace std' in tmap.h

### DIFF
--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -27,7 +27,6 @@
 #define TAGLIB_MAP_H
 
 #include <map>
-using namespace std;
 
 #include "taglib.h"
 


### PR DESCRIPTION
This is a textbook example of why using-directives should be applied sparingly or avoided entirely; TagLib declares a typedef for TagLib::wstring in taglib.h for GCC < 3. tmap.h has a "using namespace std" directive, which lifts everything in std into the global scope, causing an ambiguous symbol when wstring is used in tstring.cpp.
