### PR TITLE
Fix docs of MPEG::File::ID3v(1|2)Tag for inexistent tag

### DIFF
--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -210,9 +210,9 @@ namespace TagLib {
       /*!
        * Returns a pointer to the ID3v2 tag of the file.
        *
-       * If \a create is false (the default) this will return a null pointer
-       * if there is no valid ID3v2 tag.  If \a create is true it will create
-       * an ID3v2 tag if one does not exist.
+       * A tag will always be returned, regardless of whether there is a
+       * tag in the file or not. Use ID3v2::Tag::isEmpty() to check if
+       * the tag contains no data.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
        * deleted by the user.  It will be deleted when the file (object) is
@@ -223,9 +223,9 @@ namespace TagLib {
       /*!
        * Returns a pointer to the ID3v1 tag of the file.
        *
-       * If \a create is false (the default) this will return a null pointer
-       * if there is no valid ID3v1 tag.  If \a create is true it will create
-       * an ID3v1 tag if one does not exist.
+       * A tag will always be returned, regardless of whether there is a
+       * tag in the file or not. Use Tag::isEmpty() to check if
+       * the tag contains no data.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
        * deleted by the user.  It will be deleted when the file (object) is


### PR DESCRIPTION
Since 37e2d629, the ID3v1 and ID3v2 tags are always created at the end
of MPEG::File::read. So contrary to what the documentation said, a null
pointer is never returned.

To check if a tag contains data, refer to isEmpty() in the
documentation.
## 

I was confused by this while working with TagLib and apparently others too:

http://stackoverflow.com/questions/4404705/unexpected-non-null-return
