### PR TITLE
Don't duplicate from ID3v1 to ID3v2 when saving only ID3v2

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -207,12 +207,12 @@ bool MPEG::File::save(int tags, bool stripOthers, int id3v2Version)
   }
 
   // Create the tags if we've been asked to.  Copy the values from the tag that
-  // does exist into the new tag.
+  // does exist into the new tag, except if the existing tag is to be stripped.
 
-  if((tags & ID3v2) && ID3v1Tag())
+  if((tags & ID3v2) && ID3v1Tag() && !(stripOthers && !(tags & ID3v1)))
     Tag::duplicate(ID3v1Tag(), ID3v2Tag(true), false);
 
-  if((tags & ID3v1) && d->tag[ID3v2Index])
+  if((tags & ID3v1) && d->tag[ID3v2Index] && !(stripOthers && !(tags & ID3v2)))
     Tag::duplicate(ID3v2Tag(), ID3v1Tag(true), false);
 
   bool success = true;


### PR DESCRIPTION
When saving only v2 with stripOthers (which means stripping v1), the
data from v1 would still be duplicated to v2. Likewise for the other way
around.

This is not the expected outcome when e.g. a frame was removed in v2,
because it would be added again on save from the v1 data. The test shows
that.

This changes save to only duplicate the data when the other tag type
will not be stripped.
