### PR TITLE
Fixed an error thrown by Xcode Static Analyzer

### DIFF
--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -365,7 +365,7 @@ void ID3v2::Tag::removeUnsupportedProperties(const StringList &properties)
       if(it->size() <= 5)
         continue; // invalid specification
       String description = it->substr(5);
-      Frame *frame;
+      Frame *frame = NULL;
       if(id == "TXXX")
         frame = UserTextIdentificationFrame::find(this, description);
       else if(id == "WXXX")


### PR DESCRIPTION
Fixed error "Branch condition evaluates to a garbage value" (from Xcode 4.3.3 Static Analyzer, mpeg/id3v2/id3v2tag.cpp:377)

This error occurs when the frame variable is left uninitialized because its id doesn't match any of the ids in the if and else-id cases. Initializing it on declaration fixes this issue.
