### PR TITLE
Disambiguate several uint and ushort references

### DIFF
--- a/taglib/it/itproperties.cpp
+++ b/taglib/it/itproperties.cpp
@@ -94,7 +94,7 @@ int IT::Properties::channels() const
   return d->channels;
 }
 
-ushort IT::Properties::lengthInPatterns() const
+TagLib::ushort IT::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
@@ -104,37 +104,37 @@ bool IT::Properties::stereo() const
   return d->flags & Stereo;
 }
 
-ushort IT::Properties::instrumentCount() const
+TagLib::ushort IT::Properties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-ushort IT::Properties::sampleCount() const
+TagLib::ushort IT::Properties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-ushort IT::Properties::patternCount() const
+TagLib::ushort IT::Properties::patternCount() const
 {
   return d->patternCount;
 }
 
-ushort IT::Properties::version() const
+TagLib::ushort IT::Properties::version() const
 {
   return d->version;
 }
 
-ushort IT::Properties::compatibleVersion() const
+TagLib::ushort IT::Properties::compatibleVersion() const
 {
   return d->compatibleVersion;
 }
 
-ushort IT::Properties::flags() const
+TagLib::ushort IT::Properties::flags() const
 {
   return d->flags;
 }
 
-ushort IT::Properties::special() const
+TagLib::ushort IT::Properties::special() const
 {
   return d->special;
 }

--- a/taglib/mod/modproperties.cpp
+++ b/taglib/mod/modproperties.cpp
@@ -70,7 +70,7 @@ int Mod::Properties::channels() const
   return d->channels;
 }
 
-uint Mod::Properties::instrumentCount() const
+TagLib::uint Mod::Properties::instrumentCount() const
 {
   return d->instrumentCount;
 }

--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -139,7 +139,7 @@ int RIFF::AIFF::Properties::sampleWidth() const
   return d->sampleWidth;
 }
 
-uint RIFF::AIFF::Properties::sampleFrames() const
+TagLib::uint RIFF::AIFF::Properties::sampleFrames() const
 {
   return d->sampleFrames;
 }

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -104,7 +104,7 @@ int RIFF::WAV::Properties::sampleWidth() const
   return d->sampleWidth;
 }
 
-uint RIFF::WAV::Properties::sampleFrames() const
+TagLib::uint RIFF::WAV::Properties::sampleFrames() const
 {
   return d->sampleFrames;
 }

--- a/taglib/s3m/s3mproperties.cpp
+++ b/taglib/s3m/s3mproperties.cpp
@@ -88,7 +88,7 @@ int S3M::Properties::channels() const
   return d->channels;
 }
 
-ushort S3M::Properties::lengthInPatterns() const
+TagLib::ushort S3M::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
@@ -98,27 +98,27 @@ bool S3M::Properties::stereo() const
   return d->stereo;
 }
 
-ushort S3M::Properties::sampleCount() const
+TagLib::ushort S3M::Properties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-ushort S3M::Properties::patternCount() const
+TagLib::ushort S3M::Properties::patternCount() const
 {
   return d->patternCount;
 }
 
-ushort S3M::Properties::flags() const
+TagLib::ushort S3M::Properties::flags() const
 {
   return d->flags;
 }
 
-ushort S3M::Properties::trackerVersion() const
+TagLib::ushort S3M::Properties::trackerVersion() const
 {
   return d->trackerVersion;
 }
 
-ushort S3M::Properties::fileFormatVersion() const
+TagLib::ushort S3M::Properties::fileFormatVersion() const
 {
   return d->fileFormatVersion;
 }

--- a/taglib/trueaudio/trueaudioproperties.cpp
+++ b/taglib/trueaudio/trueaudioproperties.cpp
@@ -103,7 +103,7 @@ int TrueAudio::Properties::channels() const
   return d->channels;
 }
 
-uint TrueAudio::Properties::sampleFrames() const
+TagLib::uint TrueAudio::Properties::sampleFrames() const
 {
   return d->sampleFrames;
 }

--- a/taglib/wavpack/wavpackproperties.cpp
+++ b/taglib/wavpack/wavpackproperties.cpp
@@ -117,7 +117,7 @@ int WavPack::Properties::bitsPerSample() const
   return d->bitsPerSample;
 }
 
-uint WavPack::Properties::sampleFrames() const
+TagLib::uint WavPack::Properties::sampleFrames() const
 {
   return d->sampleFrames;
 }

--- a/taglib/xm/xmproperties.cpp
+++ b/taglib/xm/xmproperties.cpp
@@ -84,47 +84,47 @@ int XM::Properties::channels() const
   return d->channels;
 }
 
-ushort XM::Properties::lengthInPatterns() const
+TagLib::ushort XM::Properties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
 
-ushort XM::Properties::version() const
+TagLib::ushort XM::Properties::version() const
 {
   return d->version;
 }
 
-ushort XM::Properties::restartPosition() const
+TagLib::ushort XM::Properties::restartPosition() const
 {
   return d->restartPosition;
 }
 
-ushort XM::Properties::patternCount() const
+TagLib::ushort XM::Properties::patternCount() const
 {
   return d->patternCount;
 }
 
-ushort XM::Properties::instrumentCount() const
+TagLib::ushort XM::Properties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-uint XM::Properties::sampleCount() const
+TagLib::uint XM::Properties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-ushort XM::Properties::flags() const
+TagLib::ushort XM::Properties::flags() const
 {
   return d->flags;
 }
 
-ushort XM::Properties::tempo() const
+TagLib::ushort XM::Properties::tempo() const
 {
   return d->tempo;
 }
 
-ushort XM::Properties::bpmSpeed() const
+TagLib::ushort XM::Properties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }


### PR DESCRIPTION
Taglib fails to compile with complaints that references to uint and ushort are ambiguous.  E.g.:

```
[ 60%] Building CXX object taglib/CMakeFiles/tag.dir/wavpack/wavpackfile.cpp.o                           
[ 61%] Building CXX object taglib/CMakeFiles/tag.dir/wavpack/wavpackproperties.cpp.o                     
/usr/ports/audio/taglib/work/taglib-1.8beta/taglib/wavpack/wavpackproperties.cpp:120: error: reference to 'uint' is ambiguous
/usr/include/sys/types.h:56: error: candidates are: typedef unsigned int uint
/usr/ports/audio/taglib/work/taglib-1.8beta/taglib/toolkit/taglib.h:81: error:                 typedef unsigned int TagLib::uint
/usr/ports/audio/taglib/work/taglib-1.8beta/taglib/wavpack/wavpackproperties.cpp:120: error: reference to 'uint' is ambiguous
/usr/include/sys/types.h:56: error: candidates are: typedef unsigned int uint
/usr/ports/audio/taglib/work/taglib-1.8beta/taglib/toolkit/taglib.h:81: error:                 typedef unsigned int TagLib::uint
/usr/ports/audio/taglib/work/taglib-1.8beta/taglib/wavpack/wavpackproperties.cpp:120: error: 'uint' does not name a type
*** Error code 1
```
