### PR TITLE
Comment update for ID3v2::Tag::setLatin1StringHandler()

### DIFF
--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -364,10 +364,12 @@ namespace TagLib {
       /*!
        * Sets the string handler that decides how the "Latin-1" data will be
        * converted to and from binary data.
+       * If the parameter \a handler is null, the previous handler is
+       * released and default ISO-8859-1 handler is restored.
        *
-       * If the parameter \a handler is null, default ISO-8859-1 handler
-       * is restored.
-       * 
+       * \note The caller is responsible for deleting the previous handler
+       * as needed after it is released. 
+       *
        * \see Latin1StringHandler
        */
       static void setLatin1StringHandler(const Latin1StringHandler *handler);


### PR DESCRIPTION
Comment update for ID3v2::Tag::setLatin1StringHandler() same as ID3v1::Tag::setStringHandler().
