### PR TITLE
Fix compilation errors with Visual Studio 2010

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -260,7 +260,7 @@ PropertyMap APE::Tag::setProperties(const PropertyMap &origProps)
 
 bool APE::Tag::checkKey(const String &key)
 {
-  if(key.size() < 2 or key.size() > 16)
+  if(key.size() < 2 || key.size() > 16)
       return false;
     for(String::ConstIterator it = key.begin(); it != key.end(); it++)
         // only allow printable ASCII including space (32..127)

--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -279,10 +279,10 @@ void MPC::Properties::readSV7(const ByteVector &data)
     }
 
     if (d->trackPeak != 0)
-      d->trackPeak = (int)(log10(d->trackPeak) * 20 * 256 + .5);
+      d->trackPeak = (int)(log10((double)d->trackPeak) * 20 * 256 + .5);
 
     if (d->albumPeak != 0)
-      d->albumPeak = (int)(log10(d->albumPeak) * 20 * 256 + .5);
+      d->albumPeak = (int)(log10((double)d->albumPeak) * 20 * 256 + .5);
 
     bool trueGapless = (gapless >> 31) & 0x0001;
     if(trueGapless) {


### PR DESCRIPTION
Fixed some compilation errors with Visual Studio 2010. 
1 syntax error and 2 ambiguous function calls.
