### PR TITLE
Fix warnings with VS2010

### DIFF
--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -348,7 +348,7 @@ void ASF::File::HeaderExtensionObject::parse(ASF::File *file, uint /*size*/)
     else {
       obj = new UnknownObject(guid);
     }
-    obj->parse(file, size);
+    obj->parse(file, (unsigned int)size);
     objects.append(obj);
     dataPos += size;
   }
@@ -535,7 +535,7 @@ bool ASF::File::save()
     data.append(d->objects[i]->render(this));
   }
   data = headerGuid + ByteVector::fromLongLong(data.size() + 30, false) + ByteVector::fromUInt(d->objects.size(), false) + ByteVector("\x01\x02", 2) + data;
-  insert(data, 0, d->size);
+  insert(data, 0, (TagLib::ulong)d->size);
 
   return true;
 }

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -243,7 +243,7 @@ bool FLAC::File::save()
   }
   ByteVector padding = ByteVector::fromUInt(paddingLength);
   padding.resize(paddingLength + 4);
-  padding[0] = FLAC::MetadataBlock::Padding | LastBlockFlag;
+  padding[0] = (char)(FLAC::MetadataBlock::Padding | LastBlockFlag);
   data.append(padding);
 
   // Write the data to the file

--- a/taglib/it/itfile.cpp
+++ b/taglib/it/itfile.cpp
@@ -128,7 +128,7 @@ bool IT::File::save()
 
     seek(sampleOffset + 20);
 
-    if((i + instrumentCount) < lines.size())
+    if((TagLib::uint)(i + instrumentCount) < lines.size())
       writeString(lines[i + instrumentCount], 25);
     else
       writeString(String::null, 25);

--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -214,7 +214,7 @@ void MPC::Properties::readSV8(File *file)
       d->channels = flags[7] * 8 + flags[6] * 4 + flags[5] * 2 + flags[4] + 1;
 
       if((d->sampleFrames - begSilence) != 0)
-        d->bitrate = d->streamLength * 8.0 * d->sampleRate / (d->sampleFrames - begSilence);
+        d->bitrate = (int)(d->streamLength * 8.0 * d->sampleRate / (d->sampleFrames - begSilence));
       d->bitrate = d->bitrate / 1000;
 
       d->length = (d->sampleFrames - begSilence) / d->sampleRate;

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -676,8 +676,9 @@ void ID3v2::Tag::parse(const ByteVector &origData)
     // portion of the frame data.
 
     if(data.at(frameDataPosition) == 0) {
-      if(d->header.footerPresent())
+      if(d->header.footerPresent()) {
         debug("Padding *and* a footer found.  This is not allowed by the spec.");
+      }
 
       d->paddingSize = frameDataLength - frameDataPosition;
       return;

--- a/taglib/mpeg/mpegproperties.cpp
+++ b/taglib/mpeg/mpegproperties.cpp
@@ -221,7 +221,7 @@ void MPEG::Properties::read()
       double length = timePerFrame * d->xingHeader->totalFrames();
 
       d->length = int(length);
-      d->bitrate = d->length > 0 ? d->xingHeader->totalSize() * 8 / length / 1000 : 0;
+      d->bitrate = d->length > 0 ? (int)(d->xingHeader->totalSize() * 8 / length / 1000) : 0;
   }
   else {
     // Since there was no valid Xing header found, we hope that we're in a constant

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -263,9 +263,9 @@ void Ogg::FLAC::File::scan()
       d->hasXiphComment = true;
       d->commentPacket = ipacket;
     }
-    else if(blockType > 5)
+    else if(blockType > 5) {
       debug("Ogg::FLAC::File::scan() -- Unknown metadata block");
-
+    }
   }
 
   // End of metadata, now comes the datastream

--- a/taglib/ogg/vorbis/vorbisproperties.cpp
+++ b/taglib/ogg/vorbis/vorbisproperties.cpp
@@ -173,7 +173,7 @@ void Vorbis::Properties::read()
     long long end = last->absoluteGranularPosition();
 
     if(start >= 0 && end >= 0 && d->sampleRate > 0)
-      d->length = (end - start) / (long long) d->sampleRate;
+      d->length = (int)((end - start) / (long long) d->sampleRate);
     else
       debug("Vorbis::Properties::read() -- Either the PCM values for the start or "
             "end of this file was incorrect or the sample rate is zero.");

--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -154,7 +154,7 @@ void RIFF::AIFF::Properties::read(const ByteVector &data)
   d->sampleFrames   = data.mid(2, 4).toUInt();
   d->sampleWidth    = data.mid(6, 2).toShort();
   double sampleRate = ConvertFromIeeeExtended(reinterpret_cast<unsigned char *>(data.mid(8, 10).data()));
-  d->sampleRate     = sampleRate;
-  d->bitrate        = (sampleRate * d->sampleWidth * d->channels) / 1000.0;
+  d->sampleRate     = (int)sampleRate;
+  d->bitrate        = (int)((sampleRate * d->sampleWidth * d->channels) / 1000.0);
   d->length         = d->sampleRate > 0 ? d->sampleFrames / d->sampleRate : 0;
 }

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -233,8 +233,9 @@ std::string String::to8Bit(bool unicode) const
                                 &target, targetBuffer + outputBufferSize,
                                 Unicode::lenientConversion);
 
-  if(result != Unicode::conversionOK)
+  if(result != Unicode::conversionOK) {
     debug("String::to8Bit() - Unicode conversion error.");
+  }
 
   int newSize = target - targetBuffer;
   s.resize(newSize);
@@ -779,9 +780,9 @@ void String::prepare(Type t)
                                   &target, targetBuffer + bufferSize,
                                   Unicode::lenientConversion);
 
-    if(result != Unicode::conversionOK)
+    if(result != Unicode::conversionOK) {
       debug("String::prepare() - Unicode conversion error.");
-
+    }
 
     int newSize = target != targetBuffer ? target - targetBuffer - 1 : 0;
     d->data.resize(newSize);

--- a/taglib/toolkit/unicode.cpp
+++ b/taglib/toolkit/unicode.cpp
@@ -155,7 +155,7 @@ ConversionResult ConvertUTF16toUTF8 (
 			case 4:	*--target = (ch | byteMark) & byteMask; ch >>= 6;
 			case 3:	*--target = (ch | byteMark) & byteMask; ch >>= 6;
 			case 2:	*--target = (ch | byteMark) & byteMask; ch >>= 6;
-			case 1:	*--target =  ch | firstByteMark[bytesToWrite];
+			case 1:	*--target = (UTF8)(ch | firstByteMark[bytesToWrite]);
 		}
 		target += bytesToWrite;
 	}
@@ -253,7 +253,7 @@ ConversionResult ConvertUTF8toUTF16 (
 				result = sourceIllegal;
 				break;
 			} else {
-			    *target++ = ch;	/* normal case */
+			    *target++ = (UTF16)ch;	/* normal case */
 			}
 		} else if (ch > UNI_MAX_UTF16) {
 			if (flags == strictConversion) {
@@ -270,7 +270,7 @@ ConversionResult ConvertUTF8toUTF16 (
 				result = targetExhausted; break;
 			}
 			ch -= halfBase;
-			*target++ = (ch >> halfShift) + UNI_SUR_HIGH_START;
+			*target++ = (UTF16)((ch >> halfShift) + UNI_SUR_HIGH_START);
 			*target++ = (ch & halfMask) + UNI_SUR_LOW_START;
 		}
 	}


### PR DESCRIPTION
Fixed warnings about numeric casts and empty controlled statements with VS2010.
