### PR TITLE
Bug fix in String::substr()

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -345,9 +345,6 @@ bool String::startsWith(const String &s) const
 
 String String::substr(uint position, uint n) const
 {
-  if(n > position + d->data.size())
-    n = d->data.size() - position;
-
   String s;
   s.d->data = d->data.substr(position, n);
   return s;


### PR DESCRIPTION
Removed the check for overrunning in `String::substr()`.
The conditional expression is wrong and the check itself is unnecessary.

But it's a quite trivial bug. Probably, it won't have effect even if you leave it.
