### PR TITLE
Add MPEG::FILE::Has*Tag functions

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -437,6 +437,21 @@ long MPEG::File::lastFrameOffset()
   return previousFrameOffset(ID3v1Tag() ? d->ID3v1Location - 1 : length());
 }
 
+bool MPEG::File::hasID3v1Tag() const
+{
+  return d->hasID3v1;
+}
+
+bool MPEG::File::hasID3v2Tag() const
+{
+  return d->hasID3v2;
+}
+
+bool MPEG::File::hasAPETag() const
+{
+  return d->hasAPE;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // private members
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -301,6 +301,21 @@ namespace TagLib {
        */
       long lastFrameOffset();
 
+      /*!
+       * Returns whether or not the file on disk contains ID3v1 tag.
+       */
+      bool hasID3v1Tag() const;
+
+      /*!
+       * Returns whether or not the file on disk contains ID3v2 tag.
+       */
+      bool hasID3v2Tag() const;
+
+      /*!
+       * Returns whether or not the file on disk contains APE tag.
+       */
+      bool hasAPETag() const;
+
     private:
       File(const File &);
       File &operator=(const File &);

--- a/tests/test_mpeg.cpp
+++ b/tests/test_mpeg.cpp
@@ -32,9 +32,12 @@ public:
 
     String xxx = ByteVector(254, 'X');
     MPEG::File f(newname.c_str());
+    CPPUNIT_ASSERT_EQUAL(false, f.hasID3v2Tag());
+
     f.tag()->setTitle(xxx);
     f.tag()->setArtist("Artist A");
     f.save(MPEG::File::AllTags, true, 4);
+    CPPUNIT_ASSERT_EQUAL(true, f.hasID3v2Tag());
 
     MPEG::File f2(newname.c_str());
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(4), f2.ID3v2Tag()->header()->majorVersion());
@@ -66,9 +69,12 @@ public:
 
     String xxx = ByteVector(254, 'X');
     MPEG::File f(newname.c_str());
+    CPPUNIT_ASSERT_EQUAL(false, f.hasID3v2Tag());
+
     f.tag()->setTitle(xxx);
     f.tag()->setArtist("Artist A");
     f.save(MPEG::File::AllTags, true, 3);
+    CPPUNIT_ASSERT_EQUAL(true, f.hasID3v2Tag());
 
     MPEG::File f2(newname.c_str());
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(3), f2.ID3v2Tag()->header()->majorVersion());


### PR DESCRIPTION
Added funtions `MPEG::File::hasID3v1Tag()`, `MPEG::File::hasID3v2Tag()` and `MPEG::File::hasAPETag()`.
They return whether the actual file on disk contains the specified tags.
