### PR TITLE
Add a common base class for string handlers (revised)

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -40,6 +40,7 @@ set(tag_HDRS
   toolkit/tlist.h
   toolkit/tlist.tcc
   toolkit/tstringlist.h
+  toolkit/tstringhandler.h
   toolkit/tbytevector.h
   toolkit/tbytevectorlist.h
   toolkit/tbytevectorstream.h
@@ -273,6 +274,7 @@ set(xm_SRCS
 set(toolkit_SRCS
   toolkit/tstring.cpp
   toolkit/tstringlist.cpp
+  toolkit/tstringhandler.cpp
   toolkit/tbytevector.cpp
   toolkit/tbytevectorlist.cpp
   toolkit/tbytevectorstream.cpp

--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -48,19 +48,15 @@ public:
   uchar track;
   uchar genre;
 
-  static const StringHandler *stringHandler;
+  static const TagLib::StringHandler *stringHandler;
 };
 
-static const StringHandler defaultStringHandler;
-const ID3v1::StringHandler *ID3v1::Tag::TagPrivate::stringHandler = &defaultStringHandler;
+static const ID3v1::StringHandler defaultStringHandler;
+const TagLib::StringHandler *ID3v1::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 ////////////////////////////////////////////////////////////////////////////////
 // StringHandler implementation
 ////////////////////////////////////////////////////////////////////////////////
-
-StringHandler::StringHandler()
-{
-}
 
 String ID3v1::StringHandler::parse(const ByteVector &data) const
 {
@@ -69,12 +65,10 @@ String ID3v1::StringHandler::parse(const ByteVector &data) const
 
 ByteVector ID3v1::StringHandler::render(const String &s) const
 {
-  if(!s.isLatin1())
-  {
+  if(s.isLatin1())
+    return s.data(String::Latin1);
+  else
     return ByteVector();
-  }
-
-  return s.data(String::Latin1);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -192,9 +186,9 @@ void ID3v1::Tag::setTrack(uint i)
   d->track = i < 256 ? i : 0;
 }
 
-void ID3v1::Tag::setStringHandler(const StringHandler *handler)
+void ID3v1::Tag::setStringHandler(const TagLib::StringHandler *handler)
 {
-  if (handler)
+  if(handler)
     TagPrivate::stringHandler = handler;
   else
     TagPrivate::stringHandler = &defaultStringHandler;

--- a/taglib/mpeg/id3v1/id3v1tag.h
+++ b/taglib/mpeg/id3v1/id3v1tag.h
@@ -28,6 +28,7 @@
 
 #include "tag.h"
 #include "tbytevector.h"
+#include "tstringhandler.h"
 #include "taglib_export.h"
 
 namespace TagLib {
@@ -45,10 +46,10 @@ namespace TagLib {
      * practice it does not.  TagLib by default only supports ISO-8859-1 data
      * in ID3v1 tags.
      *
-     * However by subclassing this class and reimplementing parse() and render()
-     * and setting your reimplementation as the default with
-     * ID3v1::Tag::setStringHandler() you can define how you would like these
-     * transformations to be done.
+     * However by subclassing TagLib::StringHandler class and reimplementing 
+     * parse() and render() and setting your reimplementation as the default 
+     * with ID3v1::Tag::setStringHandler() you can define how you would like 
+     * these transformations to be done.
      *
      * \warning It is advisable <b>not</b> to write non-ISO-8859-1 data to ID3v1
      * tags.  Please consider disabling the writing of ID3v1 tags in the case
@@ -57,13 +58,9 @@ namespace TagLib {
      * \see ID3v1::Tag::setStringHandler()
      */
 
-    class TAGLIB_EXPORT StringHandler
+    class TAGLIB_EXPORT StringHandler : public TagLib::StringHandler
     {
-      TAGLIB_IGNORE_MISSING_DESTRUCTOR
     public:
-      // BIC: Add virtual destructor.
-      StringHandler();
-
       /*!
        * Decode a string from \a data.  The default implementation assumes that
        * \a data is an ISO-8859-1 (Latin1) character array.
@@ -162,7 +159,7 @@ namespace TagLib {
        *
        * \see StringHandler
        */
-      static void setStringHandler(const StringHandler *handler);
+      static void setStringHandler(const TagLib::StringHandler *handler);
 
     protected:
       /*!

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -71,27 +71,24 @@ public:
   FrameListMap frameListMap;
   FrameList frameList;
 
-  static const Latin1StringHandler *stringHandler;
+  static const TagLib::StringHandler *stringHandler;
 };
 
-static const Latin1StringHandler defaultStringHandler;
-const ID3v2::Latin1StringHandler *ID3v2::Tag::TagPrivate::stringHandler = &defaultStringHandler;
+static const ID3v2::Latin1StringHandler defaultStringHandler;
+const TagLib::StringHandler *ID3v2::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 ////////////////////////////////////////////////////////////////////////////////
-// StringHandler implementation
+// Latin1StringHandler implementation
 ////////////////////////////////////////////////////////////////////////////////
 
-Latin1StringHandler::Latin1StringHandler()
-{
-}
-
-Latin1StringHandler::~Latin1StringHandler()
-{
-}
-
-String Latin1StringHandler::parse(const ByteVector &data) const
+String ID3v2::Latin1StringHandler::parse(const ByteVector &data) const
 {
   return String(data, String::Latin1);
+}
+
+ByteVector ID3v2::Latin1StringHandler::render(const String &s) const
+{
+  return ByteVector();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -606,12 +603,12 @@ ByteVector ID3v2::Tag::render(int version) const
   return d->header.render() + tagData;
 }
 
-Latin1StringHandler const *ID3v2::Tag::latin1StringHandler()
+TagLib::StringHandler const *ID3v2::Tag::latin1StringHandler()
 {
   return TagPrivate::stringHandler;
 }
 
-void ID3v2::Tag::setLatin1StringHandler(const Latin1StringHandler *handler)
+void ID3v2::Tag::setLatin1StringHandler(const TagLib::StringHandler *handler)
 {
   if(handler)
     TagPrivate::stringHandler = handler;

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -29,6 +29,7 @@
 #include "tag.h"
 #include "tbytevector.h"
 #include "tstring.h"
+#include "tstringhandler.h"
 #include "tlist.h"
 #include "tmap.h"
 #include "taglib_export.h"
@@ -74,17 +75,21 @@ namespace TagLib {
      *
      * \see ID3v2::Tag::setStringHandler()
      */
-    class TAGLIB_EXPORT Latin1StringHandler
+    class TAGLIB_EXPORT Latin1StringHandler : public TagLib::StringHandler
     {
     public:
-      Latin1StringHandler();
-      virtual ~Latin1StringHandler();
-
       /*!
        * Decode a string from \a data.  The default implementation assumes that
        * \a data is an ISO-8859-1 (Latin1) character array.
        */
       virtual String parse(const ByteVector &data) const;
+
+      /*!
+       * Encode a ByteVector with the data from \a s.
+       *
+       * /note Not implemented intentionally.  Always returns empty \s ByteVector.
+       */
+      virtual ByteVector render(const String &s) const;
     };
 
     //! The main class in the ID3v2 implementation
@@ -360,7 +365,7 @@ namespace TagLib {
        *
        * \see Latin1StringHandler
        */
-      static Latin1StringHandler const *latin1StringHandler();
+      static TagLib::StringHandler const *latin1StringHandler();
 
       /*!
        * Sets the string handler that decides how the "Latin-1" data will be
@@ -373,7 +378,7 @@ namespace TagLib {
        *
        * \see Latin1StringHandler
        */
-      static void setLatin1StringHandler(const Latin1StringHandler *handler);
+      static void setLatin1StringHandler(const TagLib::StringHandler *handler);
 
     protected:
       /*!

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -54,20 +54,15 @@ public:
 
   FieldListMap fieldListMap;
 
-  static const StringHandler *stringHandler;
+  static const TagLib::StringHandler *stringHandler;
 };
+
+static const RIFF::Info::StringHandler defaultStringHandler;
+const TagLib::StringHandler *RIFF::Info::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 ////////////////////////////////////////////////////////////////////////////////
 // StringHandler implementation
 ////////////////////////////////////////////////////////////////////////////////
-
-StringHandler::StringHandler()
-{
-}
-
-StringHandler::~StringHandler()
-{
-}
 
 String RIFF::Info::StringHandler::parse(const ByteVector &data) const
 {
@@ -82,9 +77,6 @@ ByteVector RIFF::Info::StringHandler::render(const String &s) const
 ////////////////////////////////////////////////////////////////////////////////
 // public members
 ////////////////////////////////////////////////////////////////////////////////
-
-static const StringHandler defaultStringHandler;
-const RIFF::Info::StringHandler *RIFF::Info::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 RIFF::Info::Tag::Tag(const ByteVector &data) : TagLib::Tag()
 {
@@ -233,7 +225,7 @@ ByteVector RIFF::Info::Tag::render() const
     return data;
 }
 
-void RIFF::Info::Tag::setStringHandler(const StringHandler *handler)
+void RIFF::Info::Tag::setStringHandler(const TagLib::StringHandler *handler)
 {
   if(handler)
     TagPrivate::stringHandler = handler;

--- a/taglib/riff/wav/infotag.h
+++ b/taglib/riff/wav/infotag.h
@@ -30,6 +30,7 @@
 #include "tmap.h"
 #include "tstring.h"
 #include "tstringlist.h"
+#include "tstringhandler.h"
 #include "tbytevector.h"
 #include "taglib_export.h"
 
@@ -57,12 +58,9 @@ namespace TagLib {
      * \see ID3v1::Tag::setStringHandler()
      */
 
-    class TAGLIB_EXPORT StringHandler
+    class TAGLIB_EXPORT StringHandler : public TagLib::StringHandler
     {
     public:
-      StringHandler();
-      ~StringHandler();
-
       /*!
        * Decode a string from \a data.  The default implementation assumes that
        * \a data is an UTF-8 character array.
@@ -157,7 +155,7 @@ namespace TagLib {
        *
        * \see StringHandler
        */
-      static void setStringHandler(const StringHandler *handler);
+      static void setStringHandler(const TagLib::StringHandler *handler);
     
     protected:
       /*!

--- a/taglib/toolkit/tstringhandler.cpp
+++ b/taglib/toolkit/tstringhandler.cpp
@@ -1,0 +1,30 @@
+/***************************************************************************
+    copyright            : (C) 2012 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "tstringhandler.h"
+
+TagLib::StringHandler::~StringHandler()
+{
+}

--- a/taglib/toolkit/tstringhandler.h
+++ b/taglib/toolkit/tstringhandler.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+    copyright            : (C) 2012 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_STRINGHANDLER_H
+#define TAGLIB_STRINGHANDLER_H
+
+#include "tstring.h"
+#include "tbytevector.h"
+#include "taglib_export.h"
+
+namespace TagLib 
+{
+  //! A abstraction for the string to data encoding.
+
+  /*!
+   * ID3v1, ID3v2 and RIFF Info tag sometimes store strings in local encodings
+   * encodings instead of ISO-8859-1 (Latin1), such as Windows-1252 for western 
+   * languages, Shift_JIS for Japanese and so on. However, TagLib only supports 
+   * genuine ISO-8859-1 by default.
+   *
+   * Here is an option to read and write tags in your preferrd encoding 
+   * by subclassing this class, reimplementing parse() and render() and setting 
+   * your reimplementation as the default with ID3v1::Tag::setStringHandler(),
+   * ID3v2::Tag::setStringHandler() or Info::Tag::setStringHandler().
+   *
+   * \see ID3v1::Tag::setStringHandler()
+   * \see ID3v2::Tag::setStringHandler()
+   * \see Info::Tag::setStringHandler()
+   */
+
+  class TAGLIB_EXPORT StringHandler
+  {
+  public:
+    ~StringHandler();
+
+    /*!
+     * Decode a string from \a data.
+     */
+    virtual String parse(const ByteVector &data) const = 0;
+
+    /*!
+     * Encode a ByteVector with the data from \a s.
+     */
+    virtual ByteVector render(const String &s) const = 0;
+  };
+}
+
+#endif


### PR DESCRIPTION
Added an abstract class `TagLib::StringHandler` as the common base class of `TagLib::ID3v1::StringHandler`,  `TagLib::ID3v2::Latin1StringHandler` and `TagLib::RIFF::Info::StringHandler`.
This patch aims to allow users not to implement duplicate string handlers.
