### PR TITLE
Corrupted FLAC files scan can result in heavy CPU consumption: fix

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -70,7 +70,8 @@ public:
 
   ~FilePrivate()
   {
-    for(uint i = 0; i < blocks.size(); i++) {
+    uint size = blocks.size();
+    for(uint i = 0; i < size; i++) {
       delete blocks[i];
     }
     delete properties;


### PR DESCRIPTION
As suggested on https://bugs.kde.org/show_bug.cgi?id=304015 by Tim De Baets, here is a pull request which fix the problem reported.
More information is available in the bug report.
