### PR TITLE
ID3v2 PropertyMap: Comment issues

### DIFF
--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -119,7 +119,7 @@ Frame *Frame::createTextualFrame(const String &key, const StringList &values) //
       TextIdentificationFrame *frame = new TextIdentificationFrame(frameID, String::UTF8);
       frame->setText(values);
       return frame;
-    } else if(values.size() == 1){  // URL frame (not WXXX); support only one value
+    } else if((frameID[0] == 'W') && (values.size() == 1)){  // URL frame (not WXXX); support only one value
         UrlLinkFrame* frame = new UrlLinkFrame(frameID);
         frame->setUrl(values.front());
         return frame;
@@ -143,7 +143,9 @@ Frame *Frame::createTextualFrame(const String &key, const StringList &values) //
   // -COMMENT: depending on the number of values, use COMM or TXXX (with description=COMMENT)
   if((key == "COMMENT" || key.startsWith(commentPrefix)) && values.size() == 1){
     CommentsFrame *frame = new CommentsFrame(String::UTF8);
-    frame->setDescription(key == "COMMENT" ? key : key.substr(commentPrefix.size()));
+    if (key != "COMMENT"){
+      frame->setDescription(key.substr(commentPrefix.size()));
+    }
     frame->setText(values.front());
     return frame;
   }


### PR DESCRIPTION
With the current version, a new comment tag is saved as URL, as it is not a T??? frame, and contains only one String in the StringList.

Also, currently comments get always saved with a description - which is only suitable for non-standard comments, as many tag reading implementations expect a descriptionless comment (e.g. in mp3tag I was able to see the "COMMENT COMMENT" only in advanced window, without the second change in this commit. With this commit applied, it displays as Comment in the regular UI).

The attatched commit fixes both comment tag issues for me.
