### PR TITLE
Virtual PropertyMap, read PropertyMap from TagUnion

### DIFF
--- a/taglib/ape/apetag.h
+++ b/taglib/ape/apetag.h
@@ -117,7 +117,7 @@ namespace TagLib {
        * TRACK to TRACKNUMBER, YEAR to DATE, and ALBUM ARTIST to ALBUMARTIST, respectively,
        * in order to be compliant with the names used in other formats.
        */
-      PropertyMap properties() const;
+      virtual PropertyMap properties() const;
 
       void removeUnsupportedProperties(const StringList &properties);
 
@@ -127,7 +127,7 @@ namespace TagLib {
        * specification requires keys to have between 2 and 16 printable ASCII characters
        * with the exception of the fixed strings "ID3", "TAG", "OGGS", and "MP+".
        */
-      PropertyMap setProperties(const PropertyMap &);
+      virtual PropertyMap setProperties(const PropertyMap &);
 
       /*!
        * Check if the given String is a valid APE tag key.

--- a/taglib/mod/modtag.h
+++ b/taglib/mod/modtag.h
@@ -163,7 +163,7 @@ namespace TagLib {
        * Implements the unified property interface -- export function.
        * Since the module tag is very limited, the exported map is as well.
        */
-      PropertyMap properties() const;
+      virtual PropertyMap properties() const;
 
       /*!
        * Implements the unified property interface -- import function.
@@ -173,7 +173,7 @@ namespace TagLib {
        * all but the first will be contained in the returned map of unsupported
        * properties.
        */
-      PropertyMap setProperties(const PropertyMap &);
+      virtual PropertyMap setProperties(const PropertyMap &);
 
     private:
       Tag(const Tag &);

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -319,7 +319,7 @@ namespace TagLib {
        *  once, the description, separated by a "/".
        *
        */
-      PropertyMap properties() const;
+      virtual PropertyMap properties() const;
 
       /*!
        * Removes unsupported frames given by \a properties. The elements of
@@ -338,7 +338,7 @@ namespace TagLib {
        * Implements the unified property interface -- import function.
        * See the comments in properties().
        */
-      PropertyMap setProperties(const PropertyMap &);
+      virtual PropertyMap setProperties(const PropertyMap &);
 
       /*!
        * Render the tag back to binary data, suitable to be written to disk.

--- a/taglib/ogg/xiphcomment.h
+++ b/taglib/ogg/xiphcomment.h
@@ -147,7 +147,7 @@ namespace TagLib {
        * comment is nothing more than a map from tag names to list of values,
        * as is the dict interface).
        */
-      PropertyMap properties() const;
+      virtual PropertyMap properties() const;
 
       /*!
        * Implements the unified property interface -- import function.
@@ -156,7 +156,7 @@ namespace TagLib {
        * containing '=' or '~') in which case the according values will
        * be contained in the returned PropertyMap.
        */
-      PropertyMap setProperties(const PropertyMap&);
+      virtual PropertyMap setProperties(const PropertyMap&);
 
       /*!
        * Check if the given String is a valid Xiph comment key.

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -58,7 +58,7 @@ namespace TagLib {
      * The default implementation in this class considers only the usual built-in
      * tags (artist, album, ...) and only one value per key.
      */
-    PropertyMap properties() const;
+    virtual PropertyMap properties() const;
 
     /*!
      * Removes unsupported properties, or a subset of them, from the tag.
@@ -76,7 +76,7 @@ namespace TagLib {
      * (artist, album, ...), and only one value per key; the rest will be contained
      * in the returned PropertyMap.
      */
-    PropertyMap setProperties(const PropertyMap &properties);
+    virtual PropertyMap setProperties(const PropertyMap &properties);
 
     /*!
      * Returns the track name; if no track name is present in the tag

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -25,6 +25,7 @@
 
 #include "tagunion.h"
 #include "tstringlist.h"
+#include "tpropertymap.h"
 
 using namespace TagLib;
 
@@ -100,6 +101,21 @@ void TagUnion::set(int index, Tag *tag)
 {
   delete d->tags[index];
   d->tags[index] = tag;
+}
+
+PropertyMap TagUnion::properties() const
+{
+  PropertyMap map;
+  // inverse order due to merge preferring the second map, e.g. 1 has highest
+  // priority.
+  if (tag(2))
+    map.merge(tag(2)->properties());
+  if (tag(1))
+    map.merge(tag(1)->properties());
+  if (tag(0))
+    map.merge(tag(0)->properties());
+  
+  return map;
 }
 
 String TagUnion::title() const
@@ -183,4 +199,3 @@ bool TagUnion::isEmpty() const
 
   return true;
 }
-

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -56,6 +56,8 @@ namespace TagLib {
 
     void set(int index, Tag *tag);
 
+    virtual PropertyMap properties() const;
+
     virtual String title() const;
     virtual String artist() const;
     virtual String album() const;


### PR DESCRIPTION
First of all thanks for merging the last pull request.

When accessing a TagUnion currently there is no way to use other properties than the default ones. Also the PropertyMap methods are not virtual, so individual casting would be required to access additional tag fields (that are not accessible directly via the Tag class).

The attatched commit fixes both issues for me. I also marked the setProperties methods as virtual for constancy, even though for my specific project (Nightingale, fork of Songbird) they are not required, as the writing is tag-specific there.

I personally think having a unified, simple tag reading is a good thing, however I could understand if you want to force developers to not access the PropertyMap without knowing what tag types are available (-> what keys are to be used with that specific tag). I'm open for discussion, also if you have another idea how to solve this issue.
