### PR TITLE
A small fix, and some additional iTunes hacks (v2.2 frames in v2.3 tag)

### DIFF
--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -107,6 +107,17 @@ Frame *FrameFactory::createFrame(const ByteVector &origData, Header *tagHeader) 
     return 0;
   }
 
+#ifndef NO_ITUNES_HACKS
+  if(version == 3 && frameID.size() == 4 && frameID[3] == '\0') {
+    // iTunes v2.3 tags store v2.2 frames - convert now
+    frameID = frameID.mid(0, 3);
+    header->setFrameID(frameID);
+    header->setVersion(2);
+    updateFrame(header);
+    header->setVersion(3);
+  }
+#endif
+
   for(ByteVector::ConstIterator it = frameID.begin(); it != frameID.end(); it++) {
     if( (*it < 'A' || *it > 'Z') && (*it < '0' || *it > '9') ) {
       delete header;


### PR DESCRIPTION
Old versions of iTunes (v8.x.y.z) wrote ID3v2.3 tags using ID3v2.2 frames.  i.e. you'd see a TYE tag for year rather than TYER.

Easily detectable as the 4th char in the field id is 0.  To fix it, we downgrade the version, run it through updateFrame() and then bump the version.  An alternate here perhaps would be to implement a new updateFrame() that takes a version number in rather than use the version from the header (and have the existing virtual function call that).

In addition, there was a minor bugfix, in that the check for the frameID length was incorrect, due to !a == b typically not returning the same as the wanted a != b.

I can supply a sample track should you want it for tests etc.
