### PR TITLE
Fix reading read-only files in Win32

### DIFF
--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -84,7 +84,7 @@ namespace {
 
   // For non-Windows 
 
-  const FILE *InvalidFile = 0;
+  FILE *const InvalidFile = 0;
 
   struct FileNameHandle : public std::string
   {


### PR DESCRIPTION
Fixed the wrong handling of read-only files in Win32.
The bug is pointed out by Ulrich Decker in the mailing list.
