### PR TITLE
c: Add support for TAGLIB_STATIC to the C bindings

### DIFF
--- a/bindings/c/tag_c.h
+++ b/bindings/c/tag_c.h
@@ -29,7 +29,9 @@
 extern "C" {
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(TAGLIB_STATIC)
+#define TAGLIB_C_EXPORT
+#elif defined(_WIN32) || defined(_WIN64)
 #ifdef MAKE_TAGLIB_C_LIB
 #define TAGLIB_C_EXPORT __declspec(dllexport)
 #else


### PR DESCRIPTION
Otherwise, we'll fail with dllimport/dllexport linking errors on
Windows.
