### PR TITLE
Make textual lyric frames use UTF8

### DIFF
--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -129,7 +129,7 @@ Frame *Frame::createTextualFrame(const String &key, const StringList &values) //
   // now we check if it's one of the "special" cases:
   // -LYRICS: depending on the number of values, use USLT or TXXX (with description=LYRICS)
   if((key == "LYRICS" || key.startsWith(lyricsPrefix)) && values.size() == 1){
-    UnsynchronizedLyricsFrame *frame = new UnsynchronizedLyricsFrame();
+    UnsynchronizedLyricsFrame *frame = new UnsynchronizedLyricsFrame(String::UTF8);
     frame->setDescription(key == "LYRICS" ? key : key.substr(lyricsPrefix.size()));
     frame->setText(values.front());
     return frame;


### PR DESCRIPTION
We at Nightingale run into strange issues with UTF8-only characters. When using an UTF8-String on a standard lyric frame, the written tag is wrong (when using characters not representable within latin1).

A solution (which at least solves our lyric tag issues) would be creating UTF8 lyric frames when using the propertymap interface.
