### PR TITLE
Stop loading a FLAC file if it has too many metadata blocks.

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -413,8 +413,17 @@ void FLAC::File::scan()
   d->blocks.append(new UnknownMetadataBlock(blockType, d->streamInfoData));
   nextBlockOffset += length + 4;
 
+  int blockCount = 0;
+
   // Search through the remaining metadata
   while(!isLastBlock) {
+
+    if (++blockCount > 1024) {
+      debug("FLAC::File::scan() -- FLAC stream has more than 1024 metadata "
+            "blocks, probably corrupt.");
+      setValid(false);
+      return;
+    }
 
     header = readBlock(4);
     blockType = header[0] & 0x7f;


### PR DESCRIPTION
A file containing all \0 bytes is a valid stream of empty STREAMINFO
METADATA_BLOCKs.  FLAC::File::scan reads all these into memory, if the file
is large Taglib may consume all the memory on the machine.

This patch adds a safety that stops reading after 1024 blocks.  (1024 should
be enough for anyone).

For a (large) example file that triggers the problem, see:
https://docs.google.com/file/d/0Byds9jlkR0IxQnpYUUxTZnVtQU0/edit
Uploaded by this user:
http://code.google.com/p/clementine-player/issues/detail?id=3500