### PR TITLE
Add support for files with .aac extension

### DIFF
--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -171,6 +171,7 @@ StringList FileRef::defaultFileExtensions()
   l.append("s3m");
   l.append("it");
   l.append("xm");
+  l.append("aac");
 
   return l;
 }
@@ -276,6 +277,14 @@ File *FileRef::create(FileName fileName, bool readAudioProperties,
       return new IT::File(fileName, readAudioProperties, audioPropertiesStyle);
     if(ext == "XM")
       return new XM::File(fileName, readAudioProperties, audioPropertiesStyle);
+    if(ext == "AAC") {
+      // AAC files might represent both MP4 or MPEG data, so we try both
+      File *file = new MP4::File(fileName, readAudioProperties, audioPropertiesStyle);
+      if (file->isValid())
+        return file;
+      delete file;
+      return new MPEG::File(fileName, readAudioProperties, audioPropertiesStyle);
+    }
   }
 
   return 0;


### PR DESCRIPTION
I raised this issue some time ago on your old bug tracker (https://bugs.kde.org/show_bug.cgi?id=298198) and finally take some time to try to fix it myself.

More details are available in the original bug but, to summarize:
- support for file with .aac extension by adding a special check, like for .oga, as .aac files might corresponds to MP4 or MPEG (http://en.wikipedia.org/wiki/Advanced_Audio_Coding#Container_formats).
