### PR TITLE
Detect UTF-16 byte order at compile time

### DIFF
--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -76,6 +76,18 @@
 # endif
 #endif
 
+// Detect CPU endian at compile time rather than run time if possible.
+// This is a poor list. Hope someone enrich it.
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) \
+     || (defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))) \
+     || (defined(__clang__) && (defined(__i386__) || defined(__x86_64__)))
+# define TAGLIB_LITTLE_ENDIAN
+/*
+#elif ....
+# define TAGLIB_BIG_ENDIAN
+*/
+#endif
+
 //! A namespace for all TagLib related classes and functions
 
 /*!

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -512,9 +512,9 @@ namespace TagLib {
     /*!
      * Indicates which byte order of UTF-16 is used to store strings internally. 
      *
-     * \note Set to \e UTF16BE or \e UTF16LE at run time.
+     * \note \e String::UTF16BE or \e String::UTF16LE
      */
-    static Type WCharByteOrder;
+    static const Type WCharByteOrder;
 
     class StringPrivate;
 


### PR DESCRIPTION
Detect UTF-16 byte order at compile time rather than run time if possible.
