### PR TITLE
Refector ByteVector

### DIFF
--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -147,6 +147,14 @@ namespace TagLib {
     int find(const ByteVector &pattern, uint offset = 0, int byteAlign = 1) const;
 
     /*!
+     * Searches the char for \a c starting at \a offset and returns
+     * the offset.  Returns -1 if the pattern was not found.  If \a byteAlign is
+     * specified the pattern will only be matched if it starts on a byte divisible
+     * by \a byteAlign (starting from \a offset).
+     */
+    int find(char c, uint offset = 0, int byteAlign = 1) const;
+
+    /*!
      * Searches the ByteVector for \a pattern starting from either the end of the
      * vector or \a offset and returns the offset.  Returns -1 if the pattern was
      * not found.  If \a byteAlign is specified the pattern will only be matched


### PR DESCRIPTION
Added an overload of `find()` which takes a char.
Reorganized complicated `find()` and `rfind()`.
Use x86/x64 BSWAP instruction if possible.
