### PR TITLE
Parameter to disable duplication between ID3v1 and ID3v2 tags, #115.

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -187,6 +187,11 @@ bool MPEG::File::save(int tags, bool stripOthers)
 
 bool MPEG::File::save(int tags, bool stripOthers, int id3v2Version)
 {
+  return save(tags, stripOthers, id3v2Version, true);
+}
+
+bool MPEG::File::save(int tags, bool stripOthers, int id3v2Version, bool duplicateTags)
+{
   if(tags == NoTags && stripOthers)
     return strip(AllTags);
 
@@ -203,14 +208,19 @@ bool MPEG::File::save(int tags, bool stripOthers, int id3v2Version)
     return false;
   }
 
-  // Create the tags if we've been asked to.  Copy the values from the tag that
-  // does exist into the new tag, except if the existing tag is to be stripped.
+  // Create the tags if we've been asked to.
 
-  if((tags & ID3v2) && ID3v1Tag() && !(stripOthers && !(tags & ID3v1)))
-    Tag::duplicate(ID3v1Tag(), ID3v2Tag(true), false);
+  if (duplicateTags) {
 
-  if((tags & ID3v1) && d->tag[ID3v2Index] && !(stripOthers && !(tags & ID3v2)))
-    Tag::duplicate(ID3v2Tag(), ID3v1Tag(true), false);
+    // Copy the values from the tag that does exist into the new tag,
+    // except if the existing tag is to be stripped.
+
+    if((tags & ID3v2) && ID3v1Tag() && !(stripOthers && !(tags & ID3v1)))
+      Tag::duplicate(ID3v1Tag(), ID3v2Tag(true), false);
+
+    if((tags & ID3v1) && d->tag[ID3v2Index] && !(stripOthers && !(tags & ID3v2)))
+      Tag::duplicate(ID3v2Tag(), ID3v1Tag(true), false);
+  }
 
   bool success = true;
 

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -214,6 +214,24 @@ namespace TagLib {
       bool save(int tags, bool stripOthers, int id3v2Version);
 
       /*!
+       * Save the file.  This will attempt to save all of the tag types that are
+       * specified by OR-ing together TagTypes values.  The save() method above
+       * uses AllTags.  This returns true if saving was successful.
+       *
+       * If \a stripOthers is true this strips all tags not included in the mask,
+       * but does not modify them in memory, so later calls to save() which make
+       * use of these tags will remain valid.  This also strips empty tags.
+       *
+       * The \a id3v2Version parameter specifies the version of the saved
+       * ID3v2 tag. It can be either 4 or 3.
+       *
+       * If \a duplicateTags is true and at least one tag -- ID3v1 or ID3v2 --
+       * exists this will duplicate its content into the other tag.
+       */
+      // BIC: combine with the above method
+      bool save(int tags, bool stripOthers, int id3v2Version, bool duplicateTags);
+
+      /*!
        * Returns a pointer to the ID3v2 tag of the file.
        *
        * A tag will always be returned, regardless of whether there is a


### PR DESCRIPTION
New optional parameter for MPEG::File::save() to disable duplication between ID3v1 and ID3v2 tags.
