### PR TITLE
Add a required target_link_libraries in Win32

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -311,6 +311,10 @@ if(ZLIB_FOUND)
 	target_link_libraries(tag ${ZLIB_LIBRARIES})
 endif()
 
+if(WIN32 AND NOT TAGLIB_STATIC)
+	target_link_libraries(tag shlwapi.lib)
+endif()
+
 set_target_properties(tag PROPERTIES
   VERSION ${TAGLIB_SOVERSION_MAJOR}.${TAGLIB_SOVERSION_MINOR}.${TAGLIB_SOVERSION_PATCH}
   SOVERSION ${TAGLIB_SOVERSION_MAJOR}


### PR DESCRIPTION
Add a link for Windows API lib `shlwapi.lib` required in fileref.cpp.
