### PR TITLE
Use more platform-independent byteswap functions.

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -21,3 +21,22 @@ if(NOT CppUnit_FOUND AND BUILD_TESTS)
 	set(BUILD_TESTS OFF)
 endif()
 
+# Check where to find the byteorder-related functions (htobe32 etc).
+check_cxx_source_compiles("
+    #include <endian.h>
+    int main() {
+        htobe64(0);
+    }
+" BYTEORDER_IN_ENDIAN_H)
+check_cxx_source_compiles("
+    #include <sys/endian.h>
+    int main() {
+        htobe64(0);
+    }
+" BYTEORDER_IN_SYS_ENDIAN_H)
+check_cxx_source_compiles("
+    #include <sys/types.h>
+    int main() {
+        htobe64(0);
+    }
+" BYTEORDER_IN_SYS_TYPES_H)

--- a/config-taglib.h.cmake
+++ b/config-taglib.h.cmake
@@ -7,5 +7,9 @@
 #cmakedefine   WITH_ASF 1
 #cmakedefine   WITH_MP4 1
 
+#cmakedefine   BYTEORDER_IN_ENDIAN_H 1
+#cmakedefine   BYTEORDER_IN_SYS_ENDIAN_H 1
+#cmakedefine   BYTEORDER_IN_SYS_TYPES_H 1
+
 #cmakedefine TESTS_DIR "@TESTS_DIR@"
 


### PR DESCRIPTION
The code introduced in a4e68a0 is not very cross-platform, and makes the 
faulty assumption that byteswap.h is a GCC header, while it is actually a 
glibc one. The immediate result is that the code did not compile on other 
systems which used GCC anymore (BSDs and probably OS X/Windows too).

Fix this by doing this more portably:
- Instead of only implementing the byteSwap() functions for a few
  selected little-endian systems, resort to always calling the
  htobe{16,32,64} family of functions, which, although not part of POSIX,
  are present on pretty much every system and just evaluate to null macros
  on big-endian systems.
- Windows is the exception, as usual. For now, we just assume Windows is
  always running on little-endian systems and we can thus just call its
  _byteswap_{ushort,ulong,uint64} functions. This would not be possible on
  other systems because we may end up erroneously swapping the bytes on
  big-endian systems.
