### PR TITLE
Fix VC++ specific warnings

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -895,8 +895,8 @@ PropertyMap MP4::Tag::setProperties(const PropertyMap &props)
         d->items[name] = MP4::Item(value);
       }
       else if(it->first == "COMPILATION") {
-        bool value = it->second.front().toInt();
-        d->items[name] = MP4::Item(value > 0);
+        bool value = (it->second.front().toInt() != 0);
+        d->items[name] = MP4::Item(value);
       }
       else {
         d->items[name] = it->second;


### PR DESCRIPTION
Fixed some VC++ specific warnings in `mp4tag.cpp`.
