### PR TITLE
Replace RefCounter with a smart pointer

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -51,6 +51,7 @@ set(tag_HDRS
   toolkit/tmap.tcc
   toolkit/tpropertymap.h
   toolkit/tbyteswap.h
+  toolkit/trefcountptr.h
   mpeg/mpegfile.h
   mpeg/mpegproperties.h
   mpeg/mpegheader.h
@@ -309,6 +310,10 @@ add_library(tag ${tag_LIB_SRCS} ${tag_HDRS})
 
 if(ZLIB_FOUND)
 	target_link_libraries(tag ${ZLIB_LIBRARIES})
+endif()
+
+if(WIN32 AND NOT TAGLIB_STATIC)
+	target_link_libraries(tag shlwapi.lib)
 endif()
 
 set_target_properties(tag PROPERTIES

--- a/taglib/asf/asfattribute.cpp
+++ b/taglib/asf/asfattribute.cpp
@@ -34,7 +34,7 @@
 
 using namespace TagLib;
 
-class ASF::Attribute::AttributePrivate : public RefCounter
+class ASF::Attribute::AttributePrivate
 {
 public:
   AttributePrivate()
@@ -60,77 +60,71 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 ASF::Attribute::Attribute()
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = UnicodeType;
 }
 
 ASF::Attribute::Attribute(const ASF::Attribute &other)
   : d(other.d)
 {
-  d->ref();
 }
 
 ASF::Attribute &ASF::Attribute::operator=(const ASF::Attribute &other)
 {
-  if(d->deref())
-    delete d;
   d = other.d;
-  d->ref();
   return *this;
 }
 
 ASF::Attribute::~Attribute()
 {
-  if(d->deref())
-    delete d;
 }
 
 ASF::Attribute::Attribute(const String &value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = UnicodeType;
   d->stringValue = value;
 }
 
 ASF::Attribute::Attribute(const ByteVector &value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = BytesType;
   d->byteVectorValue = value;
 }
 
 ASF::Attribute::Attribute(const ASF::Picture &value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = BytesType;
   d->pictureValue = value;
 }
 
 ASF::Attribute::Attribute(unsigned int value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = DWordType;
   d->intValue = value;
 }
 
 ASF::Attribute::Attribute(unsigned long long value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = QWordType;
   d->longLongValue = value;
 }
 
 ASF::Attribute::Attribute(unsigned short value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = WordType;
   d->shortValue = value;
 }
 
 ASF::Attribute::Attribute(bool value)
+  : d(new AttributePrivate())
 {
-  d = new AttributePrivate;
   d->type = BoolType;
   d->boolValue = value;
 }

--- a/taglib/asf/asfattribute.h
+++ b/taglib/asf/asfattribute.h
@@ -194,7 +194,7 @@ namespace TagLib
       ByteVector render(const String &name, int kind = 0) const;
 
       class AttributePrivate;
-      AttributePrivate *d;
+      RefCountPtr<AttributePrivate> d;
     };
   }
 

--- a/taglib/asf/asfpicture.cpp
+++ b/taglib/asf/asfpicture.cpp
@@ -35,7 +35,7 @@
 
 using namespace TagLib;
 
-class ASF::Picture::PicturePrivate : public RefCounter
+class ASF::Picture::PicturePrivate
 {
 public:
   bool valid;
@@ -50,21 +50,18 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 ASF::Picture::Picture()
+  : d(new PicturePrivate())
 {
-  d = new PicturePrivate();
   d->valid = true;
 }
 
 ASF::Picture::Picture(const Picture& other)
   : d(other.d)
 {
-  d->ref();
 }
 
 ASF::Picture::~Picture()
 {
-  if(d->deref())
-    delete d;
 }
 
 bool ASF::Picture::isValid() const
@@ -121,12 +118,7 @@ int ASF::Picture::dataSize() const
 
 ASF::Picture& ASF::Picture::operator=(const ASF::Picture& other)
 {
-  if(other.d != d) {
-    if(d->deref())
-      delete d;
-    d = other.d;
-    d->ref();
-  }
+  d = other.d;
   return *this;
 }
 

--- a/taglib/asf/asfpicture.h
+++ b/taglib/asf/asfpicture.h
@@ -207,10 +207,10 @@ namespace TagLib
       static Picture fromInvalid();
       friend class Attribute;
 #endif
-      private:
-        class PicturePrivate;
-        PicturePrivate *d;
-      };
+    private:
+      class PicturePrivate;
+      RefCountPtr<PicturePrivate> d;
+    };
   }
 }
 

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -91,7 +91,6 @@ namespace TagLib {
 
     class TAGLIB_EXPORT FileTypeResolver
     {
-      TAGLIB_IGNORE_MISSING_DESTRUCTOR
     public:
       /*!
        * This method must be overridden to provide an additional file type
@@ -106,6 +105,8 @@ namespace TagLib {
                                bool readAudioProperties = true,
                                AudioProperties::ReadStyle
                                audioPropertiesStyle = AudioProperties::Average) const = 0;
+
+      virtual ~FileTypeResolver();
     };
 
     /*!
@@ -255,7 +256,7 @@ namespace TagLib {
 
   private:
     class FileRefPrivate;
-    FileRefPrivate *d;
+    RefCountPtr<FileRefPrivate> d;
   };
 
 } // namespace TagLib

--- a/taglib/mp4/mp4coverart.cpp
+++ b/taglib/mp4/mp4coverart.cpp
@@ -33,43 +33,35 @@
 
 using namespace TagLib;
 
-class MP4::CoverArt::CoverArtPrivate : public RefCounter
+class MP4::CoverArt::CoverArtPrivate
 {
 public:
-  CoverArtPrivate() : RefCounter(), format(MP4::CoverArt::JPEG) {}
+  CoverArtPrivate() : format(MP4::CoverArt::JPEG) {}
 
   Format format;
   ByteVector data;
 };
 
 MP4::CoverArt::CoverArt(Format format, const ByteVector &data)
+  : d(new CoverArtPrivate())
 {
-  d = new CoverArtPrivate;
   d->format = format;
   d->data = data;
 }
 
 MP4::CoverArt::CoverArt(const CoverArt &item) : d(item.d)
 {
-  d->ref();
 }
 
 MP4::CoverArt &
 MP4::CoverArt::operator=(const CoverArt &item)
 {
-  if(d->deref()) {
-    delete d;
-  }
   d = item.d;
-  d->ref();
   return *this;
 }
 
 MP4::CoverArt::~CoverArt()
 {
-  if(d->deref()) {
-    delete d;
-  }
 }
 
 MP4::CoverArt::Format

--- a/taglib/mp4/mp4coverart.h
+++ b/taglib/mp4/mp4coverart.h
@@ -63,7 +63,7 @@ namespace TagLib {
 
     private:
       class CoverArtPrivate;
-      CoverArtPrivate *d;
+      RefCountPtr<CoverArtPrivate> d;
     };
 
     typedef List<CoverArt> CoverArtList;

--- a/taglib/mp4/mp4item.cpp
+++ b/taglib/mp4/mp4item.cpp
@@ -33,10 +33,10 @@
 
 using namespace TagLib;
 
-class MP4::Item::ItemPrivate : public RefCounter
+class MP4::Item::ItemPrivate 
 {
 public:
-  ItemPrivate() : RefCounter(), valid(true), atomDataType(TypeUndefined) {}
+  ItemPrivate() : valid(true), atomDataType(TypeUndefined) {}
 
   bool valid;
   AtomDataType atomDataType;
@@ -54,86 +54,78 @@ public:
 };
 
 MP4::Item::Item()
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->valid = false;
 }
 
 MP4::Item::Item(const Item &item) : d(item.d)
 {
-  d->ref();
 }
 
 MP4::Item &
 MP4::Item::operator=(const Item &item)
 {
-  if(d->deref()) {
-    delete d;
-  }
   d = item.d;
-  d->ref();
   return *this;
 }
 
 MP4::Item::~Item()
 {
-  if(d->deref()) {
-    delete d;
-  }
 }
 
 MP4::Item::Item(bool value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_bool = value;
 }
 
 MP4::Item::Item(int value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_int = value;
 }
 
 MP4::Item::Item(uchar value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_byte = value;
 }
 
 MP4::Item::Item(uint value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_uint = value;
 }
 
 MP4::Item::Item(long long value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_longlong = value;
 }
 
 MP4::Item::Item(int value1, int value2)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_intPair.first = value1;
   d->m_intPair.second = value2;
 }
 
 MP4::Item::Item(const ByteVectorList &value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_byteVectorList = value;
 }
 
 MP4::Item::Item(const StringList &value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_stringList = value;
 }
 
 MP4::Item::Item(const MP4::CoverArtList &value)
+  : d(new ItemPrivate())
 {
-  d = new ItemPrivate;
   d->m_coverArtList = value;
 }
 

--- a/taglib/mp4/mp4item.h
+++ b/taglib/mp4/mp4item.h
@@ -73,7 +73,7 @@ namespace TagLib {
 
     private:
       class ItemPrivate;
-      ItemPrivate *d;
+      RefCountPtr<ItemPrivate> d;
     };
 
   }

--- a/taglib/mpeg/mpegheader.cpp
+++ b/taglib/mpeg/mpegheader.cpp
@@ -33,7 +33,7 @@
 
 using namespace TagLib;
 
-class MPEG::Header::HeaderPrivate : public RefCounter
+class MPEG::Header::HeaderPrivate
 {
 public:
   HeaderPrivate() :
@@ -68,20 +68,18 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 MPEG::Header::Header(const ByteVector &data)
+  : d(new HeaderPrivate())
 {
-  d = new HeaderPrivate;
   parse(data);
 }
 
-MPEG::Header::Header(const Header &h) : d(h.d)
+MPEG::Header::Header(const Header &h) 
+  : d(h.d)
 {
-  d->ref();
 }
 
 MPEG::Header::~Header()
 {
-  if (d->deref())
-    delete d;
 }
 
 bool MPEG::Header::isValid() const
@@ -146,14 +144,7 @@ int MPEG::Header::samplesPerFrame() const
 
 MPEG::Header &MPEG::Header::operator=(const Header &h)
 {
-  if(&h == this)
-    return *this;
-
-  if(d->deref())
-    delete d;
-
   d = h.d;
-  d->ref();
   return *this;
 }
 

--- a/taglib/mpeg/mpegheader.h
+++ b/taglib/mpeg/mpegheader.h
@@ -27,6 +27,7 @@
 #define TAGLIB_MPEGHEADER_H
 
 #include "taglib_export.h"
+#include "trefcountptr.h"
 
 namespace TagLib {
 
@@ -158,7 +159,7 @@ namespace TagLib {
       void parse(const ByteVector &data);
 
       class HeaderPrivate;
-      HeaderPrivate *d;
+      RefCountPtr<HeaderPrivate> d;
     };
   }
 }

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -26,9 +26,9 @@
 #ifndef TAGLIB_BYTEVECTOR_H
 #define TAGLIB_BYTEVECTOR_H
 
-#include "taglib.h"
 #include "taglib_export.h"
-
+#include "taglib.h"
+#include "trefcountptr.h"
 #include <vector>
 #include <iostream>
 
@@ -446,7 +446,7 @@ namespace TagLib {
 
   private:
     class ByteVectorPrivate;
-    ByteVectorPrivate *d;
+    RefCountPtr<ByteVectorPrivate> d;
   };
 }
 

--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -38,8 +38,13 @@ namespace TagLib {
   public:
     FileName(const wchar_t *name) : m_wname(name) {}
     FileName(const char *name) : m_name(name) {}
+    
     operator const wchar_t *() const { return m_wname.c_str(); }
     operator const char *() const { return m_name.c_str(); }
+  
+    const std::wstring &wstr() const { return m_wname; }
+    const std::string  &str()  const { return m_name; }  
+  
   private:
     std::string m_name;
     std::wstring m_wname;

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -27,7 +27,7 @@
 #define TAGLIB_LIST_H
 
 #include "taglib.h"
-
+#include "trefcountptr.h"
 #include <list>
 
 namespace TagLib {
@@ -243,7 +243,7 @@ namespace TagLib {
   private:
 #ifndef DO_NOT_DOCUMENT
     template <class TP> class ListPrivate;
-    ListPrivate<T> *d;
+    RefCountPtr<ListPrivate<T> > d;
 #endif
   };
 

--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -26,9 +26,10 @@
 #ifndef TAGLIB_MAP_H
 #define TAGLIB_MAP_H
 
+#include "taglib.h"
+#include "trefcountptr.h"
 #include <map>
 
-#include "taglib.h"
 
 namespace TagLib {
 
@@ -185,7 +186,7 @@ namespace TagLib {
   private:
 #ifndef DO_NOT_DOCUMENT
     template <class KeyP, class TP> class MapPrivate;
-    MapPrivate<Key, T> *d;
+    RefCountPtr<MapPrivate<Key, T> > d;
 #endif
   };
 

--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -31,36 +31,49 @@ namespace TagLib {
 
 template <class Key, class T>
 template <class KeyP, class TP>
-class Map<Key, T>::MapPrivate : public RefCounter
+class Map<Key, T>::MapPrivate
 {
 public:
-  MapPrivate() : RefCounter() {}
+  MapPrivate() {}
+
 #ifdef WANT_CLASS_INSTANTIATION_OF_MAP
-  MapPrivate(const std::map<class KeyP, class TP>& m) : RefCounter(), map(m) {}
+
+  MapPrivate(const std::map<class KeyP, class TP> &m) : RefCounter(), map(m) {}
+
+  void clear() {
+    std::map<class KeyP, class TP>().swap(map);
+  }
+
   std::map<class KeyP, class TP> map;
+
 #else
-  MapPrivate(const std::map<KeyP, TP>& m) : RefCounter(), map(m) {}
+
+  MapPrivate(const std::map<KeyP, TP>& m) : map(m) {}
+
+  void clear() {
+    std::map<KeyP, TP>().swap(map);
+  }
+
   std::map<KeyP, TP> map;
+
 #endif
 };
 
 template <class Key, class T>
 Map<Key, T>::Map()
+  : d(new MapPrivate<Key, T>())
 {
-  d = new MapPrivate<Key, T>;
 }
 
 template <class Key, class T>
-Map<Key, T>::Map(const Map<Key, T> &m) : d(m.d)
+Map<Key, T>::Map(const Map<Key, T> &m) 
+  : d(m.d)
 {
-  d->ref();
 }
 
 template <class Key, class T>
 Map<Key, T>::~Map()
 {
-  if(d->deref())
-    delete(d);
 }
 
 template <class Key, class T>
@@ -149,7 +162,7 @@ Map<Key, T> &Map<Key,T>::erase(const Key &key)
 }
 
 template <class Key, class T>
-TagLib::uint Map<Key, T>::size() const
+uint Map<Key, T>::size() const
 {
   return d->map.size();
 }
@@ -170,13 +183,7 @@ T &Map<Key, T>::operator[](const Key &key)
 template <class Key, class T>
 Map<Key, T> &Map<Key, T>::operator=(const Map<Key, T> &m)
 {
-  if(&m == this)
-    return *this;
-
-  if(d->deref())
-    delete(d);
   d = m.d;
-  d->ref();
   return *this;
 }
 
@@ -187,10 +194,8 @@ Map<Key, T> &Map<Key, T>::operator=(const Map<Key, T> &m)
 template <class Key, class T>
 void Map<Key, T>::detach()
 {
-  if(d->count() > 1) {
-    d->deref();
-    d = new MapPrivate<Key, T>(d->map);
-  }
+  if(!d.unique())
+    d.reset(new MapPrivate<Key, T>(d->map));
 }
 
 } // namespace TagLib

--- a/taglib/toolkit/trefcountptr.h
+++ b/taglib/toolkit/trefcountptr.h
@@ -1,0 +1,240 @@
+/***************************************************************************
+    copyright            : (C) 2013 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_REFCOUNTPTR_H
+#define TAGLIB_REFCOUNTPTR_H
+
+#include "tdebug.h"
+
+#ifdef __APPLE__
+#  include <libkern/OSAtomic.h>
+#  define TAGLIB_ATOMIC_MAC
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#  define TAGLIB_ATOMIC_WIN
+#elif defined (__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 401)    \
+  && (defined(__i386__) || defined(__i486__) || defined(__i586__) || \
+  defined(__i686__) || defined(__x86_64) || defined(__ia64)) \
+  && !defined(__INTEL_COMPILER)
+#  define TAGLIB_ATOMIC_GCC
+#elif defined(__ia64) && defined(__INTEL_COMPILER)
+#  include <ia64intrin.h>
+#  define TAGLIB_ATOMIC_GCC
+#endif
+
+#ifndef DO_NOT_DOCUMENT // Tell Doxygen to skip this class.
+
+/*!
+ * \internal
+ * This is just used as a smart pointer for shared classes in TagLib.
+ *
+ * \warning This <b>is not</b> part of the TagLib public API!
+ */
+
+namespace TagLib {
+
+  // RefCountPtr<T> mimics std::shared_ptr<T>.
+
+  template<typename T>
+  class RefCountPtr
+  {
+  private:
+
+    // Counter base class. Provides a reference counter.
+
+    class counter_base
+    {
+    public:
+      counter_base() 
+        : count(1) 
+      {
+      }
+
+      virtual ~counter_base()
+      {
+      }
+
+      void addref() 
+      { 
+        increment(&count); 
+      }
+
+      void release()
+      {
+        if(decrement(&count) == 0) {
+          dispose();
+          delete this;
+        }
+      }
+
+      long use_count() const
+      {
+        return static_cast<long>(count);
+      }
+
+      virtual void dispose() = 0;
+
+    private:
+# if defined(TAGLIB_ATOMIC_MAC)
+      typedef volatile int32_t counter_t;
+
+      inline static void increment(counter_t *c) { OSAtomicIncrement32Barrier(c); }
+      inline static counter_t decrement(counter_t *c) { return OSAtomicDecrement32Barrier(c); }
+
+# elif defined(TAGLIB_ATOMIC_WIN)
+      typedef volatile long counter_t;
+
+      inline static void increment(counter_t *c) { InterlockedIncrement(c); }
+      inline static counter_t decrement(counter_t *c) { return InterlockedDecrement(c); }
+
+# elif defined(TAGLIB_ATOMIC_GCC)
+      typedef volatile int counter_t;
+
+      inline static void increment(counter_t *c) { __sync_add_and_fetch(c, 1); }
+      inline static counter_t decrement(counter_t *c) { return __sync_sub_and_fetch(c, 1); }
+
+# else
+      typedef uint counter_t;
+
+      inline static void increment(counter_t *c) { ++(*c) }
+      inline static counter_t decrement(counter_t *c) { return --(*c); }
+
+# endif
+
+      counter_t count;
+    };
+
+    // Counter impl class. Provides a dynamic deleter.
+
+    template <typename U>
+    class counter_impl : public counter_base
+    {
+    public:
+      counter_impl(U *p)
+        : p(p)
+      {
+      }
+
+      virtual void dispose() 
+      { 
+        delete p; 
+      }
+
+      U *get() const
+      {
+        return p;
+      }
+
+    private:
+      U *p;
+    };
+
+  public:
+    template <typename U>
+    explicit RefCountPtr(U *p)
+      : counter(new counter_impl<U>(p))
+    {
+    }
+
+    RefCountPtr(const RefCountPtr &x)
+    {
+      counter = x.counter;
+      counter->addref();
+    }
+
+    ~RefCountPtr()
+    {
+      counter->release();
+    }
+
+    T *get() const
+    {
+      return static_cast<counter_impl<T>*>(counter)->get();
+    }
+
+    long use_count() const
+    {
+      return counter->use_count();
+    }
+
+    bool unique() const 
+    { 
+      return (use_count() == 1);
+    }
+
+    template <typename U>
+    void reset(U *p)
+    {
+      if(get() != p)
+      {
+        counter->release();
+        counter = new counter_impl<U>(p);
+      }
+    }
+
+    RefCountPtr<T> &operator=(const RefCountPtr<T> &x)
+    {
+      if(get() != x.get())
+      {
+        counter->release();
+
+        counter = x.counter;
+        counter->addref();
+      }
+      return *this;
+    }
+
+    T& operator*() const
+    {
+      return *get();
+    }
+
+    T* operator->() const
+    {
+      return get();
+    }
+
+    bool operator==(const RefCountPtr<T> &x) const 
+    {
+      return (get() == x.get());
+    }
+
+    bool operator!=(const RefCountPtr<T> &x) const
+    {
+      return !operator==(x);
+    }
+
+    operator bool() const
+    {
+      return (get() != 0);
+    }
+
+  private:
+    counter_base *counter;
+  };
+}
+
+#endif // DO_NOT_DOCUMENT
+
+#endif

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -26,12 +26,8 @@
 #ifndef TAGLIB_STRING_H
 #define TAGLIB_STRING_H
 
-#include "taglib_export.h"
-#include "taglib.h"
 #include "tbytevector.h"
-
 #include <string>
-#include <iostream>
 
 /*!
  * \relates TagLib::String
@@ -485,7 +481,7 @@ namespace TagLib {
     static const Type WCharByteOrder;
 
     class StringPrivate;
-    StringPrivate *d;
+    RefCountPtr<StringPrivate> d;
   };
 }
 


### PR DESCRIPTION
Replaced `RefCounter` class with a smart pointer like `std::shared_ptr` to get rid of  complicated ref/deref operations.
This patch is almost equivalent to #140 for taglib2 branch.
