### PR TITLE
Restore ABI changed in pull request #60

### DIFF
--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -158,6 +158,11 @@ void RIFF::File::setChunkData(uint i, const ByteVector &data)
     d->chunks[i].offset = d->chunks[i-1].offset + 8 + d->chunks[i-1].size + d->chunks[i-1].padding;
 }
 
+void RIFF::File::setChunkData(const ByteVector &name, const ByteVector &data)
+{
+  setChunkData(name, data, false);
+}
+
 void RIFF::File::setChunkData(const ByteVector &name, const ByteVector &data, bool alwaysCreate)
 {
   if(d->chunks.size() == 0) {

--- a/taglib/riff/rifffile.h
+++ b/taglib/riff/rifffile.h
@@ -107,12 +107,22 @@ namespace TagLib {
        * given name already exists it will be overwritten, otherwise it will be
        * created after the existing chunks.
        *
+       * \warning This will update the file immediately.
+       */
+      void setChunkData(const ByteVector &name, const ByteVector &data);
+
+      /*!
+       * Sets the data for the chunk \a name to \a data.  If a chunk with the
+       * given name already exists it will be overwritten, otherwise it will be
+       * created after the existing chunks.
+       *
        * \note If \a alwaysCreate is true, a new chunk is created regardless of 
-       * existence of chunk \a name. It should be used for only "LIST" chunks. 
+       * whether or not the chunk \a name exists. It should only be used for 
+       * "LIST" chunks. 
        *
        * \warning This will update the file immediately.
        */
-      void setChunkData(const ByteVector &name, const ByteVector &data, bool alwaysCreate = false);
+      void setChunkData(const ByteVector &name, const ByteVector &data, bool alwaysCreate);
 
       /*!
        * Removes the specified chunk.


### PR DESCRIPTION
Recreated an overload of the function `RIFF::File::setChunkData()` removed by mistake.
