### PR TITLE
Use shared_ptr if possible regardless of C++11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ else()
 endif()
 OPTION(ENABLE_STATIC_RUNTIME "Visual Studio, link with runtime statically"  OFF)
 
-option(ENABLE_CXX11 "Enable C++11 features" OFF)
-if(ENABLE_CXX11)
-  add_definitions(-DTAGLIB_USE_CXX11)
-endif()
-
 option(VISIBILITY_HIDDEN "Build with -fvisibility=hidden"  OFF)
 if(VISIBILITY_HIDDEN)
   add_definitions (-fvisibility=hidden)

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -9,15 +9,32 @@ include(CheckCXXSourceCompiles)
 # check for libz using the cmake supplied FindZLIB.cmake
 find_package(ZLIB)
 if(ZLIB_FOUND)
-	set(HAVE_ZLIB 1)
+    set(HAVE_ZLIB 1)
 else()
-	set(HAVE_ZLIB 0)
+    set(HAVE_ZLIB 0)
 endif()
+
+# Determine where shared_ptr<T> is defined regardless of C++11 support.
+
+check_cxx_source_compiles("
+    #include <memory>
+    int main() { std::tr1::shared_ptr<int> x; return 0; }
+" HAVE_STD_SHARED_PTR)
+
+check_cxx_source_compiles("
+    #include <tr1/memory>
+    int main() { std::tr1::shared_ptr<int> x; return 0; }
+" HAVE_TR1_SHARED_PTR)
+
+check_cxx_source_compiles("
+    #include <boost/shared_ptr.hpp>
+    int main() { boost::shared_ptr<int> x; return 0; }
+" HAVE_BOOST_SHARED_PTR)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 find_package(CppUnit)
 if(NOT CppUnit_FOUND AND BUILD_TESTS)
-	message(STATUS "CppUnit not found, disabling tests.")
-	set(BUILD_TESTS OFF)
+    message(STATUS "CppUnit not found, disabling tests.")
+    set(BUILD_TESTS OFF)
 endif()
 

--- a/config-taglib.h.cmake
+++ b/config-taglib.h.cmake
@@ -3,6 +3,10 @@
 /* Define if you have libz */
 #cmakedefine   HAVE_ZLIB 1
 
+#cmakedefine   HAVE_STD_SHARED_PTR 1
+#cmakedefine   HAVE_TR1_SHARED_PTR 1
+#cmakedefine   HAVE_BOOST_SHARED_PTR 1
+
 #cmakedefine   NO_ITUNES_HACKS 1
 #cmakedefine   WITH_ASF 1
 #cmakedefine   WITH_MP4 1

--- a/taglib/toolkit/trefcountptr.h
+++ b/taglib/toolkit/trefcountptr.h
@@ -26,10 +26,31 @@
 #ifndef TAGLIB_REFCOUNTPTR_H
 #define TAGLIB_REFCOUNTPTR_H
 
-// TAGLIB_USE_CXX11 determines whether or not to enable C++11 features.
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
 
-#ifdef TAGLIB_USE_CXX11
+#ifndef DO_NOT_DOCUMENT // Tell Doxygen to skip this class.
+/*!
+ * \internal
+ * This is just used as a smart pointer for shared classes in TagLib.
+ *
+ * \warning This <b>is not</b> part of the TagLib public API!
+ */
+
+// RefCountPtr<T> is just an alias of shared_ptr<T> if it is available.
+
+#if defined(HAVE_STD_SHARED_PTR)
 # include <memory>
+# define RefCountPtr std::tr1::shared_ptr
+
+#elif defined(HAVE_TR1_SHARED_PTR) 
+# include <tr1/memory>
+# define RefCountPtr std::tr1::shared_ptr
+
+#elif defined(HAVE_BOOST_SHARED_PTR) 
+# include <boost/shared_ptr.hpp>
+# define RefCountPtr boost::shared_ptr
 
 #else
 # ifdef __APPLE__
@@ -46,29 +67,10 @@
 #   include <ia64intrin.h>
 #   define TAGLIB_ATOMIC_GCC
 # endif
-#endif
-
-#ifndef DO_NOT_DOCUMENT // Tell Doxygen to skip this class.
-
-/*!
- * \internal
- * This is just used as a smart pointer for shared classes in TagLib.
- *
- * \warning This <b>is not</b> part of the TagLib public API!
- */
-
-#ifdef TAGLIB_USE_CXX11
-
-  // RefCountPtr<T> is just an alias of std::shared_ptr<T> if C++11 is available.
-# define RefCountPtr std::shared_ptr
-
-  // Workaround for the fact that some compilers don't support the template aliases.
-
-#else
 
 namespace TagLib {
 
-  // RefCountPtr<T> mimics std::shared_ptr<T> if C++11 is not available.
+  // RefCountPtr<T> mimics std::shared_ptr<T> if it is not available.
 
   template<typename T>
   class RefCountPtr


### PR DESCRIPTION
Changed to use `shared_ptr<T>` rather than the self-implemented smart pointer if possible regardless of the C++11 support.
Though `shared_ptr<T>` is a part of C++11 standard, some major compilers provide it prior to the C++11 support. 
`ENABLE_CXX11` switch is removed because it is no longer used.
