### PR TITLE
Fix improper string handling

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -311,6 +311,10 @@ if(ZLIB_FOUND)
 	target_link_libraries(tag ${ZLIB_LIBRARIES})
 endif()
 
+if(WIN32 AND NOT TAGLIB_STATIC)
+	target_link_libraries(tag shlwapi.lib)
+endif()
+
 set_target_properties(tag PROPERTIES
   VERSION ${TAGLIB_SOVERSION_MAJOR}.${TAGLIB_SOVERSION_MINOR}.${TAGLIB_SOVERSION_PATCH}
   SOVERSION ${TAGLIB_SOVERSION_MAJOR}

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -28,8 +28,13 @@
  ***************************************************************************/
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+# include <config.h>
 #endif
+
+#ifdef _WIN32
+# include <Shlwapi.h>
+#endif 
+
 
 #include <tfile.h>
 #include <tstring.h>
@@ -218,21 +223,36 @@ File *FileRef::create(FileName fileName, bool readAudioProperties,
 
   // Ok, this is really dumb for now, but it works for testing.
 
-  String s;
+  String ext;
 
 #ifdef _WIN32
-  s = (wcslen((const wchar_t *) fileName) > 0) ? String((const wchar_t *) fileName) : String((const char *) fileName);
+  // Avoids direct conversion from FileName to String
+  // because String can't decode strings in local encodings properly.
+
+  if(!fileName.wstr().empty()) {
+    const wchar_t *pext = PathFindExtensionW(fileName.wstr().c_str());
+    if(*pext == L'.')
+      ext = String(pext + 1).upper();
+  }
+  else {
+    const char *pext = PathFindExtensionA(fileName.str().c_str());
+    if(*pext == '.')
+      ext = String(pext + 1).upper();
+  }
 #else
-  s = fileName;
+  {
+    String s = fileName;
+    const int pos = s.rfind(".");
+    if(pos != -1)
+      ext = s.substr(pos + 1).upper();
+  }
 #endif
 
   // If this list is updated, the method defaultFileExtensions() should also be
   // updated.  However at some point that list should be created at the same time
   // that a default file type resolver is created.
 
-  int pos = s.rfind(".");
-  if(pos != -1) {
-    String ext = s.substr(pos + 1).upper();
+  if(!ext.isEmpty()) {
     if(ext == "MP3")
       return new MPEG::File(fileName, readAudioProperties, audioPropertiesStyle);
     if(ext == "OGG")

--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -38,8 +38,13 @@ namespace TagLib {
   public:
     FileName(const wchar_t *name) : m_wname(name) {}
     FileName(const char *name) : m_name(name) {}
+
     operator const wchar_t *() const { return m_wname.c_str(); }
     operator const char *() const { return m_name.c_str(); }
+
+    const std::wstring &wstr() const { return m_wname; }
+    const std::string  &str()  const { return m_name; }  
+
   private:
     std::string m_name;
     std::wstring m_wname;


### PR DESCRIPTION
Fixed an improper handling of non-unicode strings in `FileRef` in Win32.
