### PR TITLE
Detect <codecvt> header automatically

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -14,6 +14,13 @@ else()
 	set(HAVE_ZLIB 0)
 endif()
 
+# Determine whether your compiler supports codecvt header.
+
+check_cxx_source_compiles("
+	#include <codecvt>
+	int main() { std::codecvt_utf8_utf16<wchar_t> x; return 0; }
+" HAVE_CODECVT)
+
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 find_package(CppUnit)
 if(NOT CppUnit_FOUND AND BUILD_TESTS)

--- a/config-taglib.h.cmake
+++ b/config-taglib.h.cmake
@@ -3,6 +3,9 @@
 /* Define if you have libz */
 #cmakedefine   HAVE_ZLIB 1
 
+/* Defined if your compiler has <codecvt> header */
+#cmakedefine   HAVE_CODECVT 1
+
 #cmakedefine   NO_ITUNES_HACKS 1
 #cmakedefine   WITH_ASF 1
 #cmakedefine   WITH_MP4 1

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -25,6 +25,10 @@
 
 // This class assumes that std::basic_string<T> has a contiguous and null-terminated buffer.
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #include "tstring.h"
 #include "tdebug.h"
 #include "tstringlist.h"
@@ -33,15 +37,11 @@
 #include <iostream>
 #include <string.h>
 
-// Determine if the compiler supports codecvt.
-
-#if (defined(_MSC_VER) && _MSC_VER >= 1600)
-# define TAGLIB_USE_CODECVT
-#endif
-
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 # include <codecvt>
-typedef std::codecvt_utf8_utf16<wchar_t> utf8_utf16_t;
+namespace {
+  typedef std::codecvt_utf8_utf16<wchar_t> utf8_utf16_t;
+}
 #else
 # include "unicode.h"
 #endif
@@ -202,7 +202,7 @@ std::string String::to8Bit(bool unicode) const
   else {
     s.resize(d->data.size() * 4 + 1);
 
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 
     std::mbstate_t st = 0;
     const wchar_t *source;
@@ -371,7 +371,7 @@ ByteVector String::data(Type t) const
     {
       ByteVector v(size() * 4 + 1, 0);
 
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 
       std::mbstate_t st = 0;
       const wchar_t *source;
@@ -730,7 +730,7 @@ void String::copyFromUTF8(const char *s, size_t length)
 {
   d->data.resize(length);
 
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 
   std::mbstate_t st = 0;
   const char *source;


### PR DESCRIPTION
Automatically detects whether or not <codecvt> header is provided.
