### PR TITLE
Detect C++11 features automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,6 @@ else()
 endif()
 OPTION(ENABLE_STATIC_RUNTIME "Visual Studio, link with runtime statically"  OFF)
 
-option(ENABLE_CXX11 "Enable C++11 features" OFF)
-if(ENABLE_CXX11)
-  add_definitions(-DTAGLIB_USE_CXX11)
-endif()
-
 option(VISIBILITY_HIDDEN "Build with -fvisibility=hidden"  OFF)
 if(VISIBILITY_HIDDEN)
   add_definitions (-fvisibility=hidden)

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -9,15 +9,57 @@ include(CheckCXXSourceCompiles)
 # check for libz using the cmake supplied FindZLIB.cmake
 find_package(ZLIB)
 if(ZLIB_FOUND)
-	set(HAVE_ZLIB 1)
+    set(HAVE_ZLIB 1)
 else()
-	set(HAVE_ZLIB 0)
+    set(HAVE_ZLIB 0)
 endif()
+
+# Determine whether or not your compiler supports move semantics.
+check_cxx_source_compiles("
+    #ifdef __clang__
+    # pragma clang diagnostic error \"-Wc++11-extensions\" 
+    #endif
+    #include <utility>
+    int func(int &&x) { return x - 1; }
+    int main() { return func(std::move(1)); }
+" SUPPORT_MOVE_SEMANTICS)
+
+# Determine whether or not your compiler supports template alias.
+check_cxx_source_compiles("
+    #ifdef __clang__
+    # pragma clang diagnostic error \"-Wc++11-extensions\" 
+    #endif
+    #include <vector>
+    template <typename T> using myVector = std::vector<T>;
+    int main() { return 0; }
+" SUPPORT_TEMPLATE_ALIAS)
+
+# Determine where shared_ptr<T> is defined regardless of C++11 support.
+check_cxx_source_compiles("
+    #include <memory>
+    int main() { std::tr1::shared_ptr<int> x; return 0; }
+" HAVE_STD_SHARED_PTR)
+
+check_cxx_source_compiles("
+    #include <tr1/memory>
+    int main() { std::tr1::shared_ptr<int> x; return 0; }
+" HAVE_TR1_SHARED_PTR)
+
+check_cxx_source_compiles("
+    #include <boost/shared_ptr.hpp>
+    int main() { boost::shared_ptr<int> x; return 0; }
+" HAVE_BOOST_SHARED_PTR)
+
+# Determine whether your compiler supports codecvt header.
+check_cxx_source_compiles("
+  #include <codecvt>
+  int main() { std::codecvt_utf8_utf16<wchar_t> x; return 0; }
+" HAVE_CODECVT)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 find_package(CppUnit)
 if(NOT CppUnit_FOUND AND BUILD_TESTS)
-	message(STATUS "CppUnit not found, disabling tests.")
-	set(BUILD_TESTS OFF)
+    message(STATUS "CppUnit not found, disabling tests.")
+    set(BUILD_TESTS OFF)
 endif()
 

--- a/config-taglib.h.cmake
+++ b/config-taglib.h.cmake
@@ -3,6 +3,20 @@
 /* Define if you have libz */
 #cmakedefine   HAVE_ZLIB 1
 
+/* Defined if your compiler supports the move semantics */
+#cmakedefine   SUPPORT_MOVE_SEMANTICS 1
+
+/* Defined if your compiler supports the template alias */
+#cmakedefine   SUPPORT_TEMPLATE_ALIAS 1
+
+/* Defined if your compiler supports shared_ptr */
+#cmakedefine   HAVE_STD_SHARED_PTR 1
+#cmakedefine   HAVE_TR1_SHARED_PTR 1
+#cmakedefine   HAVE_BOOST_SHARED_PTR 1
+
+/* Defined if your compiler has <codecvt> header */
+#cmakedefine   HAVE_CODECVT 1
+
 #cmakedefine   NO_ITUNES_HACKS 1
 #cmakedefine   WITH_ASF 1
 #cmakedefine   WITH_MP4 1

--- a/taglib/asf/asfattribute.cpp
+++ b/taglib/asf/asfattribute.cpp
@@ -129,7 +129,7 @@ ASF::Attribute &ASF::Attribute::operator=(const ASF::Attribute &other)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ASF::Attribute &ASF::Attribute::operator=(ASF::Attribute &&other)
 {

--- a/taglib/asf/asfattribute.h
+++ b/taglib/asf/asfattribute.h
@@ -115,12 +115,12 @@ namespace TagLib
        */
       ASF::Attribute &operator=(const Attribute &other);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
       /*!
        * Moves the contents of \a other into this item.
        *
-       * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+       * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
        */
       ASF::Attribute &operator=(Attribute &&other);
 

--- a/taglib/asf/asfpicture.cpp
+++ b/taglib/asf/asfpicture.cpp
@@ -60,7 +60,7 @@ ASF::Picture::Picture(const Picture& other)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ASF::Picture::Picture(Picture &&other)
   : d(std::move(other.d))
@@ -131,7 +131,7 @@ ASF::Picture& ASF::Picture::operator=(const ASF::Picture& other)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ASF::Picture& ASF::Picture::operator=(ASF::Picture &&other)
 {

--- a/taglib/asf/asfpicture.h
+++ b/taglib/asf/asfpicture.h
@@ -107,12 +107,12 @@ namespace TagLib
        */
       Picture(const Picture& other);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
       /*!
        * Constructs an picture equivalent to \a other.
        *
-       * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+       * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
        */
       Picture(Picture &&other);
 
@@ -128,12 +128,12 @@ namespace TagLib
        */
       Picture& operator=(const Picture& other);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
       /*!
        * Moves the contents of \a other into this picture.
        *
-       * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+       * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
       */
       Picture& operator=(Picture &&other);
 

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -98,7 +98,7 @@ FileRef::FileRef(const FileRef &ref)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 FileRef::FileRef(FileRef &&ref) 
   : d(std::move(ref.d))
@@ -195,7 +195,7 @@ FileRef &FileRef::operator=(const FileRef &ref)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 FileRef &FileRef::operator=(FileRef &&ref)
 {

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -139,12 +139,12 @@ namespace TagLib {
      */
     FileRef(const FileRef &ref);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Move \a ref into the FileRef.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     FileRef(FileRef &&ref);
 
@@ -238,12 +238,12 @@ namespace TagLib {
      */
     FileRef &operator=(const FileRef &ref);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a ref into this FileRef.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     FileRef &operator=(FileRef &&ref);
 

--- a/taglib/mp4/mp4coverart.cpp
+++ b/taglib/mp4/mp4coverart.cpp
@@ -60,7 +60,7 @@ MP4::CoverArt &
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 MP4::CoverArt &
   MP4::CoverArt::operator=(CoverArt &&item)

--- a/taglib/mp4/mp4coverart.h
+++ b/taglib/mp4/mp4coverart.h
@@ -54,7 +54,7 @@ namespace TagLib {
 
       CoverArt(const CoverArt &item);
       CoverArt &operator=(const CoverArt &item);
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
       CoverArt &operator=(CoverArt &&item);
 #endif
 

--- a/taglib/mp4/mp4item.cpp
+++ b/taglib/mp4/mp4item.cpp
@@ -72,7 +72,7 @@ MP4::Item::Item(const Item &item)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 MP4::Item::Item(Item &&item) 
   : d(std::move(item.d))
@@ -88,7 +88,7 @@ MP4::Item &
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 MP4::Item &
   MP4::Item::operator=(Item &&item)

--- a/taglib/mp4/mp4item.h
+++ b/taglib/mp4/mp4item.h
@@ -56,12 +56,12 @@ namespace TagLib {
 
       Item();
       Item(const Item &item);
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
       Item(Item &&item);
 #endif
 
       Item &operator=(const Item &item);
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
       Item &operator=(Item &&item);
 #endif
       ~Item();

--- a/taglib/mpeg/mpegheader.cpp
+++ b/taglib/mpeg/mpegheader.cpp
@@ -78,7 +78,7 @@ MPEG::Header::Header(const Header &h)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 MPEG::Header::Header(Header &&h) 
   : d(std::move(h.d))
@@ -157,7 +157,7 @@ MPEG::Header &MPEG::Header::operator=(const Header &h)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 MPEG::Header &MPEG::Header::operator=(Header &&h)
 {

--- a/taglib/mpeg/mpegheader.h
+++ b/taglib/mpeg/mpegheader.h
@@ -57,12 +57,12 @@ namespace TagLib {
        */
       Header(const Header &h);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
       /*!
        * Moves \a h into this Header.
        *
-       * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+       * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
       */
       Header(Header &&h);
 
@@ -166,12 +166,12 @@ namespace TagLib {
        */
       Header &operator=(const Header &h);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
       /*!
        * Moves \a h into this Header.
        *
-       * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+       * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
        */
       Header &operator=(Header &&h);
 

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -380,7 +380,7 @@ ByteVector::ByteVector(const ByteVector &v, size_t offset, size_t length)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ByteVector::ByteVector(ByteVector &&v) 
   : d(std::move(v.d))
@@ -762,7 +762,7 @@ ByteVector &ByteVector::operator=(const ByteVector &v)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ByteVector &ByteVector::operator=(ByteVector &&v)
 {

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -68,12 +68,12 @@ namespace TagLib {
      */
     ByteVector(const ByteVector &v);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Constructs a byte vector equivalent to \a v.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     ByteVector(ByteVector &&v);
 
@@ -429,12 +429,12 @@ namespace TagLib {
      */
     ByteVector &operator=(const ByteVector &v);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a v into this ByteVector.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     ByteVector &operator=(ByteVector &&v);
 

--- a/taglib/toolkit/tbytevectorlist.cpp
+++ b/taglib/toolkit/tbytevectorlist.cpp
@@ -73,7 +73,7 @@ ByteVectorList::ByteVectorList(const ByteVectorList &l) : List<ByteVector>(l)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ByteVectorList::ByteVectorList(ByteVectorList &&l) : List<ByteVector>(l)
 {
@@ -87,7 +87,7 @@ ByteVectorList &ByteVectorList::operator=(const ByteVectorList &l)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 ByteVectorList &ByteVectorList::operator=(ByteVectorList &&l)
 {

--- a/taglib/toolkit/tbytevectorlist.h
+++ b/taglib/toolkit/tbytevectorlist.h
@@ -54,12 +54,12 @@ namespace TagLib {
      */
     ByteVectorList(const ByteVectorList &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a l into this ByteVectorList.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     ByteVectorList(ByteVectorList &&l);
 
@@ -72,12 +72,12 @@ namespace TagLib {
      */
     ByteVectorList &operator=(const ByteVectorList &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a l into this ByteVectorList.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     ByteVectorList &operator=(ByteVectorList &&l);
 

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -70,12 +70,12 @@ namespace TagLib {
      */
     List(const List<T> &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a l into this List.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     List(List<T> &&l);
 
@@ -135,13 +135,13 @@ namespace TagLib {
      */
     List<T> &append(const List<T> &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Appends \a item to the end of the list and returns a reference to the
      * list.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     List<T> &append(T &&item);
 
@@ -149,7 +149,7 @@ namespace TagLib {
      * Appends all of the values in \a l to the end of the list and returns a
      * reference to the list.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     List<T> &append(List<T> &&l);
 
@@ -167,13 +167,13 @@ namespace TagLib {
      */
     List<T> &prepend(const List<T> &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Prepends \a item to the beginning list and returns a reference to the
      * list.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     List<T> &prepend(T &&item);
 
@@ -181,7 +181,7 @@ namespace TagLib {
      * Prepends all of the items in \a l to the beginning list and returns a
      * reference to the list.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     List<T> &prepend(List<T> &&l);
 
@@ -272,12 +272,12 @@ namespace TagLib {
      */
     List<T> &operator=(const List<T> &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a l into this List.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     List<T> &operator=(List<T> &&l);
 

--- a/taglib/toolkit/tlist.tcc
+++ b/taglib/toolkit/tlist.tcc
@@ -54,7 +54,7 @@ public:
   ListPrivate() : ListPrivateBase() {}
   ListPrivate(const std::list<TP> &l) : ListPrivateBase(), list(l) {}
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
   ListPrivate(std::list<TP> &&l) : ListPrivateBase(), list(l) {}
 
@@ -76,7 +76,7 @@ public:
   ListPrivate() : ListPrivateBase() {}
   ListPrivate(const std::list<TP *> &l) : ListPrivateBase(), list(l) {}
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
   ListPrivate(std::list<TP *> &&l) : ListPrivateBase(), list(l) {}
 
@@ -120,7 +120,7 @@ List<T>::List(const List<T> &l)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class T>
 List<T>::List(List<T> &&l) 
@@ -197,7 +197,7 @@ List<T> &List<T>::append(const List<T> &l)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class T>
 List<T> &List<T>::append(T &&item)
@@ -236,7 +236,7 @@ List<T> &List<T>::prepend(const List<T> &l)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class T>
 List<T> &List<T>::prepend(T &&item)
@@ -364,7 +364,7 @@ List<T> &List<T>::operator=(const List<T> &l)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class T>
 List<T> &List<T>::operator=(List<T> &&l)

--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -73,12 +73,12 @@ namespace TagLib {
      */
     Map(const Map<Key, T> &m);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a m into this Map.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     Map(Map<Key, T> &&m);
 
@@ -119,13 +119,13 @@ namespace TagLib {
      */
     Map<Key, T> &insert(const Key &key, const T &value);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Inserts \a value under \a key in the map.  If a value for \a key already
      * exists it will be overwritten.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     Map<Key, T> &insert(const Key &key, T &&value);
 
@@ -197,12 +197,12 @@ namespace TagLib {
      */
     Map<Key, T> &operator=(const Map<Key, T> &m);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a m into this Map.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     Map<Key, T> &operator=(Map<Key, T> &&m);
 

--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -40,7 +40,7 @@ public:
 
   MapPrivate(const std::map<class KeyP, class TP> &m) : RefCounter(), map(m) {}
 
-# ifdef TAGLIB_USE_CXX11
+# ifdef SUPPORT_MOVE_SEMANTICS
 
   MapPrivate(std::map<class KeyP, class TP> &&m) : RefCounter(), map(m) {}
 
@@ -56,7 +56,7 @@ public:
 
   MapPrivate(const std::map<KeyP, TP>& m) : map(m) {}
 
-# ifdef TAGLIB_USE_CXX11
+# ifdef SUPPORT_MOVE_SEMANTICS
 
   MapPrivate(std::map<KeyP, TP> &&m) : map(m) {}
 
@@ -83,7 +83,7 @@ Map<Key, T>::Map(const Map<Key, T> &m)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class Key, class T>
 TagLib::Map<Key, T>::Map(Map<Key, T> &&m)
@@ -132,7 +132,7 @@ Map<Key, T> &Map<Key, T>::insert(const Key &key, const T &value)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class Key, class T>
 Map<Key, T> &Map<Key, T>::insert(const Key &key, T &&value)
@@ -221,7 +221,7 @@ Map<Key, T> &Map<Key, T>::operator=(const Map<Key, T> &m)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 template <class Key, class T>
 Map<Key, T> &Map<Key, T>::operator=(Map<Key, T> &&m)

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -24,7 +24,10 @@
  ***************************************************************************/
 
 // This class assumes that std::basic_string<T> has a contiguous and null-terminated buffer.
-// 
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
 
 #include "tstring.h"
 #include "tdebug.h"
@@ -33,15 +36,11 @@
 
 #include <string.h>
 
-// Determine if the compiler supports codecvt.
-
-#if (defined(_MSC_VER) && _MSC_VER >= 1600)
-# define TAGLIB_USE_CODECVT
-#endif
-
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 # include <codecvt>
-  typedef std::codecvt_utf8_utf16<wchar_t> utf8_utf16_t;
+  namespace {
+    typedef std::codecvt_utf8_utf16<wchar_t> utf8_utf16_t;
+  }
 #else
 # include "unicode.h"
 #endif
@@ -68,7 +67,7 @@ public:
   {
   }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
   StringPrivate(wstring &&s) 
     : data(s) 
@@ -105,7 +104,7 @@ String::String(const String &s)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 String::String(String &&s) 
   : d(std::move(s.d))
@@ -216,7 +215,7 @@ std::string String::to8Bit(bool unicode) const
   else {
     s.resize(d->data.size() * 4 + 1);
 
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 
     std::mbstate_t st = 0;
     const wchar_t *source;
@@ -387,7 +386,7 @@ ByteVector String::data(Type t) const
   {
     ByteVector v(size() * 4 + 1, 0);
 
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 
     std::mbstate_t st = 0;
     const wchar_t *source;
@@ -648,7 +647,7 @@ String &String::operator=(const String &s)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 String &String::operator=(String &&s)
 {
@@ -672,7 +671,7 @@ String &String::operator=(const wstring &s)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 String &String::operator=(wstring &&s)
 {
@@ -758,7 +757,7 @@ void String::copyFromUTF8(const char *s, size_t length)
 {
   d->data.resize(length);
 
-#ifdef TAGLIB_USE_CODECVT
+#ifdef HAVE_CODECVT
 
   std::mbstate_t st = 0;
   const char *source;

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -119,12 +119,12 @@ namespace TagLib {
      */
     String(const String &s);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Constructs a String equivalent to \a s.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     String(String &&s);
 
@@ -403,12 +403,12 @@ namespace TagLib {
      */
     String &operator=(const String &s);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a s into this String.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     String &operator=(String &&s);
 
@@ -424,12 +424,12 @@ namespace TagLib {
      */
     String &operator=(const wstring &s);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a s into this String.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     String &operator=(wstring &&s);
 

--- a/taglib/toolkit/tstringlist.cpp
+++ b/taglib/toolkit/tstringlist.cpp
@@ -61,7 +61,7 @@ StringList::StringList(const StringList &l) : List<String>(l)
 {
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 StringList::StringList(StringList &&l) : List<String>(l)
 {
@@ -111,7 +111,7 @@ StringList &StringList::append(const StringList &l)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 StringList &StringList::append(String &&s)
 {
@@ -133,7 +133,7 @@ StringList &StringList::operator=(const StringList &l)
   return *this;
 }
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
 StringList &StringList::operator=(StringList &&l)
 {

--- a/taglib/toolkit/tstringlist.h
+++ b/taglib/toolkit/tstringlist.h
@@ -58,12 +58,12 @@ namespace TagLib {
      */
     StringList(const StringList &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Constructs a StringList equivalent to \a l.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     StringList(StringList &&l);
 
@@ -99,13 +99,13 @@ namespace TagLib {
      */
     StringList &append(const StringList &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Appends \a s to the end of the list and returns a reference to the
      * list.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     StringList &append(String &&s);
 
@@ -113,7 +113,7 @@ namespace TagLib {
      * Appends all of the values in \a l to the end of the list and returns a
      * reference to the list.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     StringList &append(StringList &&l);
 
@@ -126,12 +126,12 @@ namespace TagLib {
      */
     StringList &operator=(const StringList &l);
 
-#ifdef TAGLIB_USE_CXX11
+#ifdef SUPPORT_MOVE_SEMANTICS
 
     /*!
      * Moves \a l into this StringList.
      *
-     * \note Not available unless TAGLIB_USE_CXX11 macro is defined.
+     * \note Not available unless SUPPORT_MOVE_SEMANTICS macro is defined.
      */
     StringList &operator=(StringList &&l);
 


### PR DESCRIPTION
Changed to automatically detect C++11 features and use `shared_ptr<T>` rather than the self-implemented smart pointer if possible.
Removed the `ENABLE_CXX11` switch because it is no longer useful.

This patch will cause the ABI incosistency between compilers (and also their verisons or options).
However, in my opinion, it is natural that objects produced by different compilers are not binary-compatible.   
