### PR TITLE
Fix an error message in Win32

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -311,10 +311,6 @@ if(ZLIB_FOUND)
 	target_link_libraries(tag ${ZLIB_LIBRARIES})
 endif()
 
-if(WIN32 AND NOT TAGLIB_STATIC)
-	target_link_libraries(tag shlwapi.lib)
-endif()
-
 set_target_properties(tag PROPERTIES
   VERSION ${TAGLIB_SOVERSION_MAJOR}.${TAGLIB_SOVERSION_MINOR}.${TAGLIB_SOVERSION_PATCH}
   SOVERSION ${TAGLIB_SOVERSION_MAJOR}

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -35,7 +35,6 @@
 # include <Shlwapi.h>
 #endif 
 
-
 #include <tfile.h>
 #include <tstring.h>
 #include <tdebug.h>

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -32,6 +32,10 @@
 #include "taglib_export.h"
 #include "audioproperties.h"
 
+#if _WIN32
+# pragma comment(lib, "shlwapi.lib")
+#endif
+
 namespace TagLib {
 
   class Tag;

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -82,6 +82,36 @@ namespace {
       return 0;
   }
 
+# if _DEBUG
+
+  // Convert a string in a local encoding into a UTF-16 string.
+
+  // This function should only be used to generate an error message.
+  // In actual use, file names in local encodings are passed to CreateFileA()
+  // without any conversions.
+
+  String fileNameToString(const FileName &name)
+  {
+    if(!name.wstr().empty()) {
+      return String(name.wstr());
+    } 
+    else if(!name.str().empty()) {
+      const int len = MultiByteToWideChar(CP_ACP, 0, name.str().c_str(), -1, NULL, 0);
+      if(len == 0)
+        return String::null;
+
+      wstring wstr(len, L'\0');
+      MultiByteToWideChar(CP_ACP, 0, name.str().c_str(), -1, &wstr[0], len);
+
+      return String(wstr);
+    }
+    else {
+      return String::null;
+    }
+  }
+
+# endif
+
 #else
 
   // For non-Windows 
@@ -144,12 +174,7 @@ FileStream::FileStreamPrivate::FileStreamPrivate(const FileName &fileName, bool 
   {
 # ifdef _WIN32
 
-    if(!name.wstr().empty()) {
-      debug("Could not open file " + String(name.wstr()));
-    }
-    else {
-      debug("Could not open file " + String(name.str()));
-    }
+    debug("Could not open file " + fileNameToString(name));
 
 # else
 


### PR DESCRIPTION
Changed to show file names in local encodings correctly when unable to open in Win32.
