### PR TITLE
Add ByteVector::toUInt24() function

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -399,7 +399,7 @@ void FLAC::File::scan()
 
   char blockType = header[0] & 0x7f;
   bool isLastBlock = (header[0] & 0x80) != 0;
-  uint length = header.toUInt(1U, 3U);
+  uint length = header.toUInt24(1U);
 
   // First block should be the stream_info metadata
 
@@ -419,7 +419,7 @@ void FLAC::File::scan()
     header = readBlock(4);
     blockType = header[0] & 0x7f;
     isLastBlock = (header[0] & 0x80) != 0;
-    length = header.toUInt(1U, 3U);
+    length = header.toUInt24(1U);
 
     ByteVector data = readBlock(length);
     if(data.size() != length || length == 0) {

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -575,7 +575,7 @@ MP4::Tag::updateOffsets(long delta, long offset)
       }
       d->file->seek(atom->offset + 9);
       ByteVector data = d->file->readBlock(atom->length - 9);
-      const unsigned int flags = data.toUInt(0, 3, true);
+      const unsigned int flags = data.toUInt24(0U);
       if(flags & 1) {
         long long o = data.toLongLong(7U);
         if(o > offset) {

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -642,7 +642,7 @@ void Frame::Header::setData(const ByteVector &data, uint version)
       return;
     }
 
-    d->frameSize = data.toUInt(3, 3, true);
+    d->frameSize = data.toUInt24(3U);
 
     break;
   }

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -241,7 +241,7 @@ void Ogg::FLAC::File::scan()
 
   char blockType = header[0] & 0x7f;
   bool lastBlock = (header[0] & 0x80) != 0;
-  uint length = header.toUInt(1, 3, true);
+  uint length = header.toUInt24(1U);
   overhead += length;
 
   // Sanity: First block should be the stream_info metadata
@@ -264,7 +264,7 @@ void Ogg::FLAC::File::scan()
     header = metadataHeader.mid(0, 4);
     blockType = header[0] & 0x7f;
     lastBlock = (header[0] & 0x80) != 0;
-    length = header.toUInt(1, 3, true);
+    length = header.toUInt24(1U);
     overhead += length;
 
     if(blockType == 1) {

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -201,6 +201,8 @@ ulonglong byteSwap<ulonglong>(ulonglong x)
   return byteSwap64(x);
 }
 
+// This overload of toNumber() should be called when the required data size == sizeof(T).
+
 template <class T>
 T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
 {
@@ -215,6 +217,8 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
     return *reinterpret_cast<const T*>(v.data() + offset);
 }
 
+// This overload of toNumber() should be called when the required data size < sizeof(T).
+
 template <class T>
 T toNumber(const ByteVector &v, size_t offset, size_t length, bool mostSignificantByteFirst)
 {
@@ -223,18 +227,13 @@ T toNumber(const ByteVector &v, size_t offset, size_t length, bool mostSignifica
     return 0;
   }
 
-  if(length >= sizeof(T)) {
-    return toNumber<T>(v, offset, mostSignificantByteFirst);
+  T sum = 0;
+  for(size_t i = 0; i < length; i++) {
+    const size_t shift = (mostSignificantByteFirst ? length - 1 - i : i) * 8;
+    sum |= static_cast<T>(static_cast<uchar>(v[offset + i]) << shift);
   }
-  else {
-    T sum = 0;
-    for(size_t i = 0; i < length; i++) {
-      const size_t shift = (mostSignificantByteFirst ? length - 1 - i : i) * 8;
-      sum |= static_cast<T>(static_cast<uchar>(v[offset + i]) << shift);
-    }
 
-    return sum;
-  }
+  return sum;
 }
 
 template <class T>
@@ -704,39 +703,44 @@ TagLib::uint ByteVector::toUInt(uint offset, bool mostSignificantByteFirst) cons
   return toNumber<uint>(*this, offset, mostSignificantByteFirst);
 }
 
-TagLib::uint ByteVector::toUInt(uint offset, uint length, bool mostSignificantByteFirst) const
+TagLib::uint ByteVector::toUInt24(bool mostSignificantByteFirst) const
 {
-  return toNumber<uint>(*this, offset, length, mostSignificantByteFirst);
+  return toNumber<uint>(*this, 0, 3, mostSignificantByteFirst);
+}
+
+TagLib::uint ByteVector::toUInt24(uint offset, bool mostSignificantByteFirst) const
+{
+  return toNumber<uint>(*this, offset, 3, mostSignificantByteFirst);
 }
 
 short ByteVector::toShort(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, 0, mostSignificantByteFirst);
+  return toNumber<ushort>(*this, 0, mostSignificantByteFirst);
 }
 
 short ByteVector::toShort(uint offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, offset, mostSignificantByteFirst);
+  return toNumber<ushort>(*this, offset, mostSignificantByteFirst);
 }
 
 unsigned short ByteVector::toUShort(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, 0, mostSignificantByteFirst);
+  return toNumber<ushort>(*this, 0, mostSignificantByteFirst);
 }
 
 unsigned short ByteVector::toUShort(uint offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, offset, mostSignificantByteFirst);
+  return toNumber<ushort>(*this, offset, mostSignificantByteFirst);
 }
 
 long long ByteVector::toLongLong(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned long long>(*this, 0, mostSignificantByteFirst);
+  return toNumber<ulonglong>(*this, 0, mostSignificantByteFirst);
 }
 
 long long ByteVector::toLongLong(uint offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned long long>(*this, offset, mostSignificantByteFirst);
+  return toNumber<ulonglong>(*this, offset, mostSignificantByteFirst);
 }
 
 const char &ByteVector::operator[](int index) const

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -303,17 +303,28 @@ namespace TagLib {
     uint toUInt(uint offset, bool mostSignificantByteFirst = true) const;
 
     /*!
-     * Converts the \a length bytes at \a offset of the vector to an unsigned 
-     * integer. If \a length is larger than 4, the excess is ignored. 
+     * Converts the first 3 bytes of the vector to an unsigned integer.
      *
      * If \a mostSignificantByteFirst is true this will operate left to right
      * evaluating the integer.  For example if \a mostSignificantByteFirst is
-     * true then $00 $00 $00 $01 == 0x00000001 == 1, if false, $01 00 00 00 ==
-     * 0x01000000 == 1.
+     * true then $00 $00 $01 == 0x00000001 == 1, if false, $01 00 00 ==
+     * 0x010000 == 1.
      *
      * \see fromUInt()
      */
-    uint toUInt(uint offset, uint length, bool mostSignificantByteFirst = true) const;
+    uint toUInt24(bool mostSignificantByteFirst = true) const;
+
+    /*!
+     * Converts the 3 bytes at \a offset of the vector to an unsigned integer. 
+     *
+     * If \a mostSignificantByteFirst is true this will operate left to right
+     * evaluating the integer.  For example if \a mostSignificantByteFirst is
+     * true then $00 $00 $01 == 0x000001 == 1, if false, $01 00 00 ==
+     * 0x010000 == 1.
+     *
+     * \see fromUInt()
+     */
+    uint toUInt24(uint offset, bool mostSignificantByteFirst = true) const;
 
     /*!
      * Converts the first 2 bytes of the vector to a (signed) short.


### PR DESCRIPTION
This issue intends to hear some second opinion.

I made the patch #154 to get rid of small-sized `ByteVector::mid()` opeartions. I believe that the patch itself is useful, but somehow rough. 
In the patch, `ByteVector::toUInt()` has an overload takes `length` specifies the data length that will be converted. It sounds meaningless, but I made it because some formats require to handle 24-bit integers. 
However, I now think that it is more straightforward to remove the overload and create special overloads for 24-bit integers like this patch.

I think that it is the clearest:
`ByteVector` has `toUInt16(), 24, 32, 64` and `toInt16()` functions and each one of them have only overload like `toUInt32(size_t offset, bool ostSignificantByteFirst)`. It breaks ABI, so it should be done taglib2 branch.

It is a option to revert the patch to avoid interfering with the work on the version﻿ 1.9.
Which way is better?
