### PR TITLE
Fix -Wcast-align violation

### DIFF
--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -39,7 +39,7 @@
 
 #define UnsignedToFloat(u) (((double)((long)(u - 2147483647L - 1))) + 2147483648.0)
 
-static double ConvertFromIeeeExtended(unsigned char *bytes)
+static double ConvertFromIeeeExtended(const TagLib::uchar *bytes)
 {
   double f;
   int expon;
@@ -153,7 +153,7 @@ void RIFF::AIFF::Properties::read(const ByteVector &data)
   d->channels       = data.toShort(0U);
   d->sampleFrames   = data.toUInt(2U);
   d->sampleWidth    = data.toShort(6U);
-  double sampleRate = ConvertFromIeeeExtended(reinterpret_cast<unsigned char *>(data.mid(8, 10).data()));
+  double sampleRate = ConvertFromIeeeExtended(reinterpret_cast<const uchar *>(data.data() + 8));
   d->sampleRate     = (int)sampleRate;
   d->bitrate        = (int)((sampleRate * d->sampleWidth * d->channels) / 1000.0);
   d->length         = d->sampleRate > 0 ? d->sampleFrames / d->sampleRate : 0;

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -209,10 +209,14 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
     return 0;
   }
 
+  // Uses memcpy instead of reinterpret_cast to avoid an alignment exception.
+  T tmp;
+  ::memcpy(&tmp, v.data() + offset, sizeof(T));
+
   if(isLittleEndianSystem == mostSignificantByteFirst)
-    return byteSwap<T>(*reinterpret_cast<const T*>(v.data() + offset));
+    return byteSwap<T>(tmp);
   else
-    return *reinterpret_cast<const T*>(v.data() + offset);
+    return tmp;
 }
 
 template <class T>

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -474,7 +474,6 @@ namespace TagLib {
      */
     void copyFromUTF16(const char *s, size_t length, Type t);
     
-    template <size_t sizeOfWcharT>
     void internalCopyFromUTF16(const char *s, size_t length, Type t);
 
     /*!


### PR DESCRIPTION
Oops! I have totally forgotten to take the alignment-strict processors into account.

Removed some type conversions that cause `-Wcast-align` violations.
Those casts can cause CPU exceptions on the alignment-strict CPUs like ARM, MIPS and so forth.
