### PR TITLE
Small change to encourage inlining

### DIFF
--- a/taglib/toolkit/tbyteswap.cpp
+++ b/taglib/toolkit/tbyteswap.cpp
@@ -23,54 +23,11 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#include "taglib.h"
 #include "tbyteswap.h"
 
-// Determines if compiler intrinsic functions are available.
+// Detects CPU byte order at runtime if unable at compile time.
 
-// MSVC: Intrinsic _byteswap_* functions.
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-# include <stdlib.h>
-# define TAGLIB_BYTESWAP_MSC
-
-// GCC 4.8 or above: __builtin_bswap16(), 32 and 64.
-#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
-# define TAGLIB_BYTESWAP_GCC 2
-
-// GCC 4.3 or above: __builtin_bswap16 is missing.
-#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
-# define TAGLIB_BYTESWAP_GCC 1
-
-#endif
-
-// Determines if platform or library specific functions are available.
-
-#if defined(__APPLE__)
-#   include <libkern/OSByteOrder.h>
-#   define TAGLIB_BYTESWAP_MAC
-
-#elif defined(__OpenBSD__)
-#   include <sys/endian.h>
-#   define TAGLIB_BYTESWAP_OPENBSD
-
-#elif defined(__GLIBC__)
-#   include <byteswap.h>
-#   define TAGLIB_BYTESWAP_GLIBC
-
-#endif
-
-// Determines CPU byte order at compile time rather than run time if possible.
-
-#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) \
-  || (defined(__GNUC__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) \
-  || (defined(__clang__) && defined(__LITTLE_ENDIAN__))
-# define TAGLIB_LITTLE_ENDIAN
-
-#elif (defined(__GNUC__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) \
-  || (defined(__clang__) && defined(__BIG_ENDIAN__))
-# define TAGLIB_BIG_ENDIAN
-
-#else
+#ifndef TAGLIB_IS_LITTLE_ENDIAN
 
 namespace {
   bool isLittleEndian()
@@ -84,110 +41,9 @@ namespace {
 
 namespace TagLib 
 {
-  ushort byteSwap16(ushort x)
-  {
-#if defined(TAGLIB_BYTESWAP_MSC)
+#if defined(TAGLIB_IS_LITTLE_ENDIAN)
 
-    return _byteswap_ushort(x);
-
-#elif defined(TAGLIB_BYTESWAP_GCC) && TAGLIB_BYTESWAP_GCC == 2
-
-    return __builtin_bswap16(x);
-
-#elif defined(TAGLIB_BYTESWAP_MAC)
-
-    return OSSwapInt16(x);
-
-#elif defined(TAGLIB_BYTESWAP_OPENBSD)
-
-    return swap16(x);
-
-#elif defined(TAGLIB_BYTESWAP_GLIBC)
-
-    return __bswap_16(x);
-
-#else
-
-    return ((x >> 8) & 0xff) | ((x & 0xff) << 8);
-
-#endif
-  }
-
-  uint byteSwap32(uint x)
-  {
-#if defined(TAGLIB_BYTESWAP_MSC)
-
-    return _byteswap_ulong(x);
-
-#elif defined(TAGLIB_BYTESWAP_GCC) 
-
-    return __builtin_bswap32(x);
-
-#elif defined(TAGLIB_BYTESWAP_MAC)
-
-    return OSSwapInt32(x);
-
-#elif defined(TAGLIB_BYTESWAP_OPENBSD)
-
-    return swap32(x);
-
-#elif defined(TAGLIB_BYTESWAP_GLIBC)
-
-    return __bswap_32(x);
-
-#else
-
-    return ((x & 0xff000000) >> 24) 
-      | ((x & 0x00ff0000) >>  8)
-      | ((x & 0x0000ff00) <<  8) 
-      | ((x & 0x000000ff) << 24);
-
-#endif
-  }
-
-  ulonglong byteSwap64(ulonglong x)
-  {
-#if defined(TAGLIB_BYTESWAP_MSC)
-
-    return _byteswap_uint64(x);
-
-#elif defined(TAGLIB_BYTESWAP_GCC) 
-
-    return __builtin_bswap64(x);
-
-#elif defined(TAGLIB_BYTESWAP_MAC)
-
-    return OSSwapInt64(x);
-
-#elif defined(TAGLIB_BYTESWAP_OPENBSD)
-
-    return swap64(x);
-
-#elif defined(TAGLIB_BYTESWAP_GLIBC)
-
-    return __bswap_64(x);
-
-#else
-
-    return ((x & 0xff00000000000000ull) >> 56)    
-      | ((x & 0x00ff000000000000ull) >> 40)            
-      | ((x & 0x0000ff0000000000ull) >> 24)            
-      | ((x & 0x000000ff00000000ull) >>  8)             
-      | ((x & 0x00000000ff000000ull) <<  8)             
-      | ((x & 0x0000000000ff0000ull) << 24)            
-      | ((x & 0x000000000000ff00ull) << 40)            
-      | ((x & 0x00000000000000ffull) << 56);
-
-#endif
-  }
-
-#if defined(TAGLIB_LITTLE_ENDIAN)
-
-  const bool isLittleEndianSystem = true;
-
-#elif defined(TAGLIB_BIG_ENDIAN)
-
-  const bool isLittleEndianSystem = false;
+  const bool isLittleEndianSystem = TAGLIB_IS_LITTLE_ENDIAN;
 
 #else
 

--- a/taglib/toolkit/tbyteswap.h
+++ b/taglib/toolkit/tbyteswap.h
@@ -26,30 +26,187 @@
 #ifndef TAGLIB_BYTESWAP_H
 #define TAGLIB_BYTESWAP_H
 
+#include "taglib.h"
+
+#ifndef DO_NOT_DOCUMENT // Tell Doxygen to skip this class.
+/*!
+ * \internal
+ * The functions in this file in only for internal use.
+ *
+ * \warning This <b>is not</b> part of the TagLib public API!
+ */
+
+// Determines CPU byte order at compile time rather than run time if possible.
+
+#if (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))) \
+  || (defined(__GNUC__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)) \
+  || (defined(__clang__) && defined(__LITTLE_ENDIAN__))
+
+# define TAGLIB_IS_LITTLE_ENDIAN true
+
+#elif (defined(__GNUC__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) \
+  || (defined(__clang__) && defined(__BIG_ENDIAN__))
+
+# define TAGLIB_IS_LITTLE_ENDIAN false
+
+#else
+
+# define TAGLIB_IS_LITTLE_ENDIAN isLittleEndianSystem
+
+#endif
+
+// Determines if compiler intrinsic functions are available.
+
+// MSVC: Intrinsic _byteswap_* functions.
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+# include <stdlib.h>
+# define TAGLIB_BYTESWAP_MSC
+
+// GCC 4.8 or above: __builtin_bswap16(), 32 and 64.
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
+# define TAGLIB_BYTESWAP_GCC 2
+
+// GCC 4.3 or above: __builtin_bswap16 is missing.
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+# define TAGLIB_BYTESWAP_GCC 1
+
+#endif
+
+// Determines if platform or library specific functions are available.
+
+#if defined(__APPLE__)
+#   include <libkern/OSByteOrder.h>
+#   define TAGLIB_BYTESWAP_MAC
+
+#elif defined(__OpenBSD__)
+#   include <sys/endian.h>
+#   define TAGLIB_BYTESWAP_OPENBSD
+
+#elif defined(__GLIBC__)
+#   include <byteswap.h>
+#   define TAGLIB_BYTESWAP_GLIBC
+
+#endif
+
 namespace TagLib 
 {
   // Cross-platform byte order conversion functions.
+  // In order to encourage inlining, these functions would better be 
+  // in same translation unit as callers.
 
   /*!
    * Converts the byte order of \a x as a 16-bit unsigned integer.
    */
-  ushort byteSwap16(ushort x);
+  inline ushort byteSwap16(ushort x)
+  {
+#if defined(TAGLIB_BYTESWAP_MSC)
+
+    return _byteswap_ushort(x);
+
+#elif defined(TAGLIB_BYTESWAP_GCC) && TAGLIB_BYTESWAP_GCC == 2
+
+    return __builtin_bswap16(x);
+
+#elif defined(TAGLIB_BYTESWAP_MAC)
+
+    return OSSwapInt16(x);
+
+#elif defined(TAGLIB_BYTESWAP_OPENBSD)
+
+    return swap16(x);
+
+#elif defined(TAGLIB_BYTESWAP_GLIBC)
+
+    return __bswap_16(x);
+
+#else
+
+    return ((x >> 8) & 0xff) | ((x & 0xff) << 8);
+
+#endif
+  }
 
   /*!
    * Converts the byte order of \a x as a 32-bit unsigned integer.
    */
-  uint byteSwap32(uint x);
+  inline uint byteSwap32(uint x)
+  {
+#if defined(TAGLIB_BYTESWAP_MSC)
+
+    return _byteswap_ulong(x);
+
+#elif defined(TAGLIB_BYTESWAP_GCC) 
+
+    return __builtin_bswap32(x);
+
+#elif defined(TAGLIB_BYTESWAP_MAC)
+
+    return OSSwapInt32(x);
+
+#elif defined(TAGLIB_BYTESWAP_OPENBSD)
+
+    return swap32(x);
+
+#elif defined(TAGLIB_BYTESWAP_GLIBC)
+
+    return __bswap_32(x);
+
+#else
+
+    return ((x & 0xff000000) >> 24) 
+      | ((x & 0x00ff0000) >>  8)
+      | ((x & 0x0000ff00) <<  8) 
+      | ((x & 0x000000ff) << 24);
+
+#endif
+  }
 
   /*!
    * Converts the byte order of \a x as a 64-bit unsigned integer.
    */
-  ulonglong byteSwap64(ulonglong x);
+  inline ulonglong byteSwap64(ulonglong x)
+  {
+#if defined(TAGLIB_BYTESWAP_MSC)
+
+    return _byteswap_uint64(x);
+
+#elif defined(TAGLIB_BYTESWAP_GCC) 
+
+    return __builtin_bswap64(x);
+
+#elif defined(TAGLIB_BYTESWAP_MAC)
+
+    return OSSwapInt64(x);
+
+#elif defined(TAGLIB_BYTESWAP_OPENBSD)
+
+    return swap64(x);
+
+#elif defined(TAGLIB_BYTESWAP_GLIBC)
+
+    return __bswap_64(x);
+
+#else
+
+    return ((x & 0xff00000000000000ull) >> 56)    
+      | ((x & 0x00ff000000000000ull) >> 40)            
+      | ((x & 0x0000ff0000000000ull) >> 24)            
+      | ((x & 0x000000ff00000000ull) >>  8)             
+      | ((x & 0x00000000ff000000ull) <<  8)             
+      | ((x & 0x0000000000ff0000ull) << 24)            
+      | ((x & 0x000000000000ff00ull) << 40)            
+      | ((x & 0x00000000000000ffull) << 56);
+
+#endif
+  }
 
   /*!
-   * Indicates the system byte order.
-   * \a true if little endian, \a false if big endian.
+   * Indicates the system byte order. \a true if little endian, \a false if big endian.
+   *
+   * \note Do not use this directly. Use \a TAGLIB_IS_LITTLE_ENDIAN macro instead.
    */
   extern const bool isLittleEndianSystem;
 }
 
+#endif
 #endif

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -793,13 +793,13 @@ void String::copyFromUTF16(const char *s, size_t length, Type t)
 {
 #if !defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 
-  // It's certain that sizeof(wchar_t) == 2 and alignment-tolerant.
+  // It's certain that sizeof(wchar_t) == 2 and the system is alignment-tolerant.
 
   copyFromUTF16(reinterpret_cast<const wchar_t*>(s), length / 2, t);
 
 #else
 
-  // Maybe sizeof(wchar_t) != 2 or alignment-strict.
+  // Maybe sizeof(wchar_t) != 2 or the system is alignment-strict.
 
   bool swap;
   if(t == UTF16) {
@@ -829,14 +829,15 @@ void String::copyFromUTF16(const char *s, size_t length, Type t)
 
   d->data.resize(length / 2);
   for(size_t i = 0; i < length / 2; ++i) {
-    d->data[i] = swap ? combine(*s, *(s + 1)) : combine(*(s + 1), *s);
-    s += 2;
+    d->data[i] = swap ? combine(s[0], s[1]) : combine(s[1], s[0]);
+    s += 2;             
   }
 
 #endif
 }
 
-const String::Type String::WCharByteOrder = isLittleEndianSystem ? String::UTF16LE : String::UTF16BE;
+const String::Type String::WCharByteOrder 
+  = TAGLIB_IS_LITTLE_ENDIAN ? String::UTF16LE : String::UTF16BE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Moved `byteSwap` functions from `tbytevector.cpp` to `tbytevector.h` in order to encourage inlining.
