### PR TITLE
Improve getting file size in Win32

### DIFF
--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -49,8 +49,8 @@ namespace TagLib {
     const std::string  &str()  const { return m_name; }  
 
   private:
-    std::string m_name;
-    std::wstring m_wname;
+    const std::string  m_name;
+    const std::wstring m_wname;
   };
 #else
   typedef const char *FileName;


### PR DESCRIPTION
Changed to get the file size directly with Win32 `GetFileSizeEx` function rather than using `tell` and `seek`. And also a few small fixes.
