### PR TITLE
Small bug fix in tstring.cpp

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -709,7 +709,7 @@ String &String::operator=(wchar_t c)
   if(d->deref())
     delete d;
 
-  d = new StringPrivate(1, static_cast<uchar>(c));
+  d = new StringPrivate(1, c);
   return *this;
 }
 


### PR DESCRIPTION
Removed a cast that may corrupt data.
