### PR TITLE
Correctly initialize std::mbstate_t.

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -78,9 +78,10 @@ namespace
     char *dstBegin = dst;
     char *dstEnd   = dstBegin + dstLength;
 
-    std::mbstate_t st = 0;
+    std::mbstate_t st;
     const wchar_t *source;
     char *target;
+    memset(&st, 0, sizeof(st));
     std::codecvt_base::result result = utf8_utf16_t().out(
       st, srcBegin, srcEnd, source, dstBegin, dstEnd, target);
 
@@ -123,9 +124,10 @@ namespace
     wchar_t *dstBegin = dst;
     wchar_t *dstEnd   = dstBegin + dstLength;
 
-    std::mbstate_t st = 0;
+    std::mbstate_t st;
     const char *source;
     wchar_t *target;
+    memset(&st, 0, sizeof(st));
     std::codecvt_base::result result = utf8_utf16_t().in(
       st, srcBegin, srcEnd, source, dstBegin, dstEnd, target);
 


### PR DESCRIPTION
mbstate_t is an opaque type that is often a union or a struct, so setting it
directly to 0 is incorrect and causes build failures with some compilers
such as clang.
