### PR TITLE
Use snprintf instead of sprintf if possible.

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -84,12 +84,24 @@ if(NOT HAVE_STD_SHARED_PTR AND NOT HAVE_TR1_SHARED_PTR AND NOT HAVE_BOOST_SHARED
   endif()
 endif()
 
-
 # Determine whether your compiler supports codecvt header.
 check_cxx_source_compiles("
 #include <codecvt>
 int main() { std::codecvt_utf8_utf16<wchar_t> x; return 0; }
 " HAVE_CODECVT)
+
+# Determine whether your compiler supports some safer version of sprintf.
+check_cxx_source_compiles("
+  #include <cstdio>
+  int main() { char buf[20]; snprintf(buf, 20, \"%d\", 1); return 0; }
+" HAVE_SNPRINTF)
+
+if(NOT HAVE_SNPRINTF)
+  check_cxx_source_compiles("
+    #include <cstdio>
+    int main() { char buf[20]; sprintf_s(buf, \"%d\", 1);  return 0; }
+  " HAVE_SPRINTF_S)
+endif()
 
 # check for libz using the cmake supplied FindZLIB.cmake
 find_package(ZLIB)

--- a/config-taglib.h.cmake
+++ b/config-taglib.h.cmake
@@ -14,6 +14,10 @@
 #cmakedefine   HAVE_WIN_ATOMIC 1
 #cmakedefine   HAVE_IA64_ATOMIC 1
 
+/* Defined if your compiler supports some safer version of sprintf */
+#cmakedefine   HAVE_SNPRINTF 1
+#cmakedefine   HAVE_SPRINTF_S 1
+
 /* Defined if your compiler has <codecvt> header */
 #cmakedefine   HAVE_CODECVT 1
 


### PR DESCRIPTION
Changed to use safer versions of `sprintf()` if possible.
