### PR TITLE
Install config.h

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -36,6 +36,7 @@ set(tag_HDRS
   audioproperties.h
   taglib_export.h
   ${CMAKE_BINARY_DIR}/taglib_config.h
+  ${CMAKE_BINARY_DIR}/config.h
   toolkit/taglib.h
   toolkit/tstring.h
   toolkit/tlist.h


### PR DESCRIPTION
config.h contains: SIZEOF_IN, SIZEOF_LONG, etc which are required by
taglib.h. If we don't install the config file any application including
taglib.h will fail.
