### PR TITLE
Moved some macros from taglib_config.h to config.h.

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -18,6 +18,12 @@
 #cmakedefine   HAVE_MAC_BYTESWAP 1
 #cmakedefine   HAVE_OPENBSD_BYTESWAP 1
 
+/* Defined if your compiler supports some atomic operations */
+#cmakedefine   HAVE_GCC_ATOMIC 1
+#cmakedefine   HAVE_MAC_ATOMIC 1
+#cmakedefine   HAVE_WIN_ATOMIC 1
+#cmakedefine   HAVE_IA64_ATOMIC 1
+
 /* Defined if your compiler supports some safer version of sprintf */
 #cmakedefine   HAVE_SNPRINTF 1
 #cmakedefine   HAVE_SPRINTF_S 1

--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -53,6 +53,7 @@ set(tag_HDRS
   toolkit/tmap.h
   toolkit/tmap.tcc
   toolkit/tpropertymap.h
+  toolkit/tsmartptr.h
   toolkit/trefcountptr.h
   mpeg/mpegfile.h
   mpeg/mpegproperties.h
@@ -300,6 +301,7 @@ set(toolkit_SRCS
   toolkit/tfilestream.cpp
   toolkit/tdebug.cpp
   toolkit/tpropertymap.cpp
+  toolkit/trefcountptr.cpp
   toolkit/unicode.cpp
 )
 

--- a/taglib/mpeg/mpegheader.h
+++ b/taglib/mpeg/mpegheader.h
@@ -27,7 +27,7 @@
 #define TAGLIB_MPEGHEADER_H
 
 #include "taglib_export.h"
-#include "trefcountptr.h"
+#include "tsmartptr.h"
 
 namespace TagLib {
 

--- a/taglib/taglib_config.h.cmake
+++ b/taglib/taglib_config.h.cmake
@@ -11,9 +11,3 @@
 #cmakedefine   TAGLIB_USE_TR1_SHARED_PTR 1
 #cmakedefine   TAGLIB_USE_BOOST_SHARED_PTR 1
 
-/* Defined if your compiler supports some atomic operations */
-#cmakedefine   TAGLIB_USE_GCC_ATOMIC 1
-#cmakedefine   TAGLIB_USE_MAC_ATOMIC 1
-#cmakedefine   TAGLIB_USE_WIN_ATOMIC 1
-#cmakedefine   TAGLIB_USE_IA64_ATOMIC 1
-

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -28,7 +28,7 @@
 
 #include "taglib_export.h"
 #include "taglib.h"
-#include "trefcountptr.h"
+#include "tsmartptr.h"
 #include <vector>
 #include <iostream>
 

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -27,7 +27,7 @@
 #define TAGLIB_LIST_H
 
 #include "taglib.h"
-#include "trefcountptr.h"
+#include "tsmartptr.h"
 #include <list>
 
 namespace TagLib {

--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -27,7 +27,7 @@
 #define TAGLIB_MAP_H
 
 #include "taglib.h"
-#include "trefcountptr.h"
+#include "tsmartptr.h"
 #include <map>
 
 namespace TagLib {

--- a/taglib/toolkit/trefcountptr.cpp
+++ b/taglib/toolkit/trefcountptr.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+    copyright            : (C) 2013 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "config.h"
+#include "trefcountptr.h"
+
+#if defined(HAVE_STD_ATOMIC)
+# include <atomic>
+# define ATOMIC_INT std::atomic<unsigned int>
+# define ATOMIC_INC(x) x.fetch_add(1)
+# define ATOMIC_DEC(x) (x.fetch_sub(1) - 1)
+#elif defined(HAVE_BOOST_ATOMIC)
+# include <boost/atomic.hpp>
+# define ATOMIC_INT boost::atomic<unsigned int>
+# define ATOMIC_INC(x) x.fetch_add(1)
+# define ATOMIC_DEC(x) (x.fetch_sub(1) - 1)
+#elif defined(HAVE_GCC_ATOMIC)
+# define ATOMIC_INT int
+# define ATOMIC_INC(x) __sync_add_and_fetch(&x, 1)
+# define ATOMIC_DEC(x) __sync_sub_and_fetch(&x, 1)
+#elif defined(HAVE_WIN_ATOMIC)
+# if !defined(NOMINMAX)
+#   define NOMINMAX
+# endif
+# include <windows.h>
+# define ATOMIC_INT long
+# define ATOMIC_INC(x) InterlockedIncrement(&x)
+# define ATOMIC_DEC(x) InterlockedDecrement(&x)
+#elif defined(HAVE_MAC_ATOMIC)
+# include <libkern/OSAtomic.h>
+# define ATOMIC_INT int32_t
+# define ATOMIC_INC(x) OSAtomicIncrement32Barrier(&x)
+# define ATOMIC_DEC(x) OSAtomicDecrement32Barrier(&x)
+#elif defined(HAVE_IA64_ATOMIC)
+# include <ia64intrin.h>
+# define ATOMIC_INT int
+# define ATOMIC_INC(x) __sync_add_and_fetch(&x, 1)
+# define ATOMIC_DEC(x) __sync_sub_and_fetch(&x, 1)
+#else
+# define ATOMIC_INT int
+# define ATOMIC_INC(x) (++x)
+# define ATOMIC_DEC(x) (--x)
+#endif
+
+namespace TagLib
+{
+  class RefCounter::RefCounterPrivate
+  {
+  public:
+    RefCounterPrivate() : refCount(1) {}
+
+    size_t ref() { return static_cast<size_t>(ATOMIC_INC(refCount)); }
+    size_t deref() { return static_cast<size_t>(ATOMIC_DEC(refCount)); }
+    size_t count() const { return static_cast<size_t>(refCount); }
+
+    volatile ATOMIC_INT refCount;
+  };
+
+  RefCounter::RefCounter()
+    : d(new RefCounterPrivate())
+  {
+  }
+
+  RefCounter::~RefCounter()
+  {
+    delete d;
+  }
+
+  size_t RefCounter::ref() 
+  { 
+    return d->ref(); 
+  }
+
+  size_t RefCounter::deref() 
+  { 
+    return d->deref(); 
+  }
+
+  size_t RefCounter::count() const 
+  { 
+    return d->count(); 
+  }
+}
+

--- a/taglib/toolkit/tsmartptr.h
+++ b/taglib/toolkit/tsmartptr.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+    copyright            : (C) 2013 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_SMARTPTR_H
+#define TAGLIB_SMARTPTR_H
+
+#include "taglib_config.h"
+
+#if defined(TAGLIB_USE_STD_SHARED_PTR)
+# include <memory>
+#elif defined(TAGLIB_USE_TR1_SHARED_PTR) 
+# include <tr1/memory>
+#elif defined(TAGLIB_USE_BOOST_SHARED_PTR) 
+# include <boost/shared_ptr.hpp>
+#else
+# include "trefcountptr.h"
+#endif
+
+#if defined(TAGLIB_USE_STD_SHARED_PTR) || defined(TAGLIB_USE_TR1_SHARED_PTR) 
+
+# define TAGLIB_SHARED_PTR std::tr1::shared_ptr
+
+#elif defined(TAGLIB_USE_BOOST_SHARED_PTR)
+
+# define TAGLIB_SHARED_PTR boost::shared_ptr
+
+#else
+
+# define TAGLIB_SHARED_PTR TagLib::RefCountPtr
+
+#endif
+#endif

--- a/tests/test_smartptr.cpp
+++ b/tests/test_smartptr.cpp
@@ -1,5 +1,6 @@
-#include <trefcountptr.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include "taglib.h"
+#include "tsmartptr.h"
 #include "utils.h"
 
 using namespace std;


### PR DESCRIPTION
Hid a part of the implementation detail of `RefCountPtr` to move some macros from taglib_config.h to config.h and hide them from public headers.
