### PR TITLE
Changed names of derived classes of AudioProperties

### DIFF
--- a/taglib/ape/apefile.cpp
+++ b/taglib/ape/apefile.cpp
@@ -73,7 +73,7 @@ public:
 
   TagUnion tag;
 
-  Properties *properties;
+  AudioProperties *properties;
 
   // These indicate whether the file *on disk* has these tags, not if
   // this data structure does.  This is used in computing offsets.
@@ -87,7 +87,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 APE::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                AudioProperties::ReadStyle propertiesStyle) : TagLib::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -95,7 +95,7 @@ APE::File::File(FileName file, bool readProperties,
 }
 
 APE::File::File(IOStream *stream, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(stream)
+                AudioProperties::ReadStyle propertiesStyle) : TagLib::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -119,7 +119,7 @@ PropertyMap APE::File::setProperties(const PropertyMap &properties)
   return d->tag.access<APE::Tag>(ApeAPEIndex, true)->setProperties(properties);
 }
 
-APE::Properties *APE::File::audioProperties() const
+APE::AudioProperties *APE::File::audioProperties() const
 {
   return d->properties;
 }
@@ -222,7 +222,7 @@ void APE::File::strip(int tags)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void APE::File::read(bool readProperties, Properties::ReadStyle /* propertiesStyle */)
+void APE::File::read(bool readProperties, AudioProperties::ReadStyle /* propertiesStyle */)
 {
   // Look for an ID3v1 tag
 
@@ -250,7 +250,7 @@ void APE::File::read(bool readProperties, Properties::ReadStyle /* propertiesSty
   // Look for APE audio properties
 
   if(readProperties) {
-    d->properties = new Properties(this);
+    d->properties = new AudioProperties(this);
   }
 }
 

--- a/taglib/ape/apefile.h
+++ b/taglib/ape/apefile.h
@@ -89,7 +89,7 @@ namespace TagLib {
        * false, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an WavPack file from \a file.  If \a readProperties is true the
@@ -100,7 +100,7 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -124,7 +124,7 @@ namespace TagLib {
        * Returns the APE::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Saves the file.
@@ -175,7 +175,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       void scan();
       offset_t findID3v1();
       offset_t findAPE();

--- a/taglib/ape/apeproperties.cpp
+++ b/taglib/ape/apeproperties.cpp
@@ -36,7 +36,7 @@
 
 using namespace TagLib;
 
-class APE::Properties::PropertiesPrivate
+class APE::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(File *file, offset_t streamLength) :
@@ -65,48 +65,49 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-APE::Properties::Properties(File *file, ReadStyle style) : AudioProperties(style)
+APE::AudioProperties::AudioProperties(File *file, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(file, file->length());
   read();
 }
 
-APE::Properties::~Properties()
+APE::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int APE::Properties::length() const
+int APE::AudioProperties::length() const
 {
   return d->length;
 }
 
-int APE::Properties::bitrate() const
+int APE::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int APE::Properties::sampleRate() const
+int APE::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int APE::Properties::channels() const
+int APE::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int APE::Properties::version() const
+int APE::AudioProperties::version() const
 {
   return d->version;
 }
 
-int APE::Properties::bitsPerSample() const
+int APE::AudioProperties::bitsPerSample() const
 {
   return d->bitsPerSample;
 }
 
-TagLib::uint APE::Properties::sampleFrames() const
+TagLib::uint APE::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
@@ -116,7 +117,7 @@ TagLib::uint APE::Properties::sampleFrames() const
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void APE::Properties::read()
+void APE::AudioProperties::read()
 {
   // First we are searching the descriptor
   offset_t offset = findDescriptor();
@@ -138,7 +139,7 @@ void APE::Properties::read()
   }
 }
 
-offset_t APE::Properties::findDescriptor()
+offset_t APE::AudioProperties::findDescriptor()
 {
   offset_t ID3v2Location = findID3v2();
   long ID3v2OriginalSize = 0;
@@ -164,7 +165,7 @@ offset_t APE::Properties::findDescriptor()
   return offset;
 }
 
-offset_t APE::Properties::findID3v2()
+offset_t APE::AudioProperties::findID3v2()
 {
   if(!d->file->isValid())
     return -1;
@@ -177,7 +178,7 @@ offset_t APE::Properties::findID3v2()
   return -1;
 }
 
-void APE::Properties::analyzeCurrent()
+void APE::AudioProperties::analyzeCurrent()
 {
   // Read the descriptor
   d->file->seek(2, File::Current);
@@ -205,7 +206,7 @@ void APE::Properties::analyzeCurrent()
   d->bitrate = d->length > 0 ? static_cast<int>(d->streamLength * 8L / d->length / 1000) : 0;
 }
 
-void APE::Properties::analyzeOld()
+void APE::AudioProperties::analyzeOld()
 {
   ByteVector header = d->file->readBlock(26);
   const uint totalFrames = header.toUInt32LE(18);

--- a/taglib/ape/apeproperties.h
+++ b/taglib/ape/apeproperties.h
@@ -46,19 +46,19 @@ namespace TagLib {
      * API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
-       * Create an instance of APE::Properties with the data read from the
-       * ByteVector \a data.
+       * Create an instance of APE::AudioProperties with the data read from
+       * the ByteVector \a data.
        */
-      Properties(File *f, ReadStyle style = Average);
+      AudioProperties(File *f, ReadStyle style = Average);
 
       /*!
-       * Destroys this APE::Properties instance.
+       * Destroys this APE::AudioProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -79,8 +79,8 @@ namespace TagLib {
       int version() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void read();
 

--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -47,7 +47,7 @@ public:
     metadataLibraryObject(0) {}
   unsigned long long size;
   ASF::Tag *tag;
-  ASF::Properties *properties;
+  ASF::AudioProperties *properties;
   List<ASF::File::BaseObject *> objects;
   ASF::File::ContentDescriptionObject *contentDescriptionObject;
   ASF::File::ExtendedContentDescriptionObject *extendedContentDescriptionObject;
@@ -365,7 +365,7 @@ ByteVector ASF::File::HeaderExtensionObject::render(ASF::File *file)
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-ASF::File::File(FileName file, bool readProperties, Properties::ReadStyle propertiesStyle)
+ASF::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle propertiesStyle)
   : TagLib::File(file)
 {
   d = new FilePrivate;
@@ -373,7 +373,7 @@ ASF::File::File(FileName file, bool readProperties, Properties::ReadStyle proper
     read(readProperties, propertiesStyle);
 }
 
-ASF::File::File(IOStream *stream, bool readProperties, Properties::ReadStyle propertiesStyle)
+ASF::File::File(IOStream *stream, bool readProperties, AudioProperties::ReadStyle propertiesStyle)
   : TagLib::File(stream)
 {
   d = new FilePrivate;
@@ -415,12 +415,12 @@ PropertyMap ASF::File::setProperties(const PropertyMap &properties)
   return d->tag->setProperties(properties);
 }
 
-ASF::Properties *ASF::File::audioProperties() const
+ASF::AudioProperties *ASF::File::audioProperties() const
 {
   return d->properties;
 }
 
-void ASF::File::read(bool /*readProperties*/, Properties::ReadStyle /*propertiesStyle*/)
+void ASF::File::read(bool /*readProperties*/, AudioProperties::ReadStyle /*propertiesStyle*/)
 {
   if(!isValid())
     return;
@@ -433,7 +433,7 @@ void ASF::File::read(bool /*readProperties*/, Properties::ReadStyle /*properties
   }
 
   d->tag = new ASF::Tag();
-  d->properties = new ASF::Properties();
+  d->properties = new ASF::AudioProperties();
 
   bool ok;
   d->size = readQWORD(&ok);

--- a/taglib/asf/asffile.h
+++ b/taglib/asf/asffile.h
@@ -58,7 +58,7 @@ namespace TagLib {
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        */
-      File(FileName file, bool readProperties = true, Properties::ReadStyle propertiesStyle = Properties::Average);
+      File(FileName file, bool readProperties = true, AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an ASF file from \a file.  If \a readProperties is true the
@@ -71,7 +71,7 @@ namespace TagLib {
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        */
-      File(IOStream *stream, bool readProperties = true, Properties::ReadStyle propertiesStyle = Properties::Average);
+      File(IOStream *stream, bool readProperties = true, AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -109,7 +109,7 @@ namespace TagLib {
       /*!
        * Returns the ASF audio properties for this file.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Save the file.
@@ -126,7 +126,7 @@ namespace TagLib {
       long long readQWORD(bool *ok = 0);
       static ByteVector renderString(const String &str, bool includeLength = false);
       String readString(int len);
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
 
       friend class Attribute;
       friend class Picture;

--- a/taglib/asf/asfproperties.cpp
+++ b/taglib/asf/asfproperties.cpp
@@ -30,7 +30,7 @@
 
 using namespace TagLib;
 
-class ASF::Properties::PropertiesPrivate
+class ASF::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(): length(0), bitrate(0), sampleRate(0), channels(0), encrypted(false) {}
@@ -45,38 +45,39 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-ASF::Properties::Properties() : AudioProperties(AudioProperties::Average)
+ASF::AudioProperties::AudioProperties() 
+  : TagLib::AudioProperties(AudioProperties::Average)
 {
   d = new PropertiesPrivate;
 }
 
-ASF::Properties::~Properties()
+ASF::AudioProperties::~AudioProperties()
 {
   if(d)
     delete d;
 }
 
-int ASF::Properties::length() const
+int ASF::AudioProperties::length() const
 {
   return d->length;
 }
 
-int ASF::Properties::bitrate() const
+int ASF::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int ASF::Properties::sampleRate() const
+int ASF::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int ASF::Properties::channels() const
+int ASF::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-bool ASF::Properties::isEncrypted() const
+bool ASF::AudioProperties::isEncrypted() const
 {
   return d->encrypted;
 }
@@ -85,27 +86,27 @@ bool ASF::Properties::isEncrypted() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void ASF::Properties::setLength(int length)
+void ASF::AudioProperties::setLength(int length)
 {
   d->length = length;
 }
 
-void ASF::Properties::setBitrate(int length)
+void ASF::AudioProperties::setBitrate(int length)
 {
   d->bitrate = length;
 }
 
-void ASF::Properties::setSampleRate(int length)
+void ASF::AudioProperties::setSampleRate(int length)
 {
   d->sampleRate = length;
 }
 
-void ASF::Properties::setChannels(int length)
+void ASF::AudioProperties::setChannels(int length)
 {
   d->channels = length;
 }
 
-void ASF::Properties::setEncrypted(bool encrypted)
+void ASF::AudioProperties::setEncrypted(bool encrypted)
 {
   d->encrypted = encrypted;
 }

--- a/taglib/asf/asfproperties.h
+++ b/taglib/asf/asfproperties.h
@@ -35,19 +35,19 @@ namespace TagLib {
   namespace ASF {
 
     //! An implementation of ASF audio properties
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
 
       /*!
-       * Create an instance of ASF::Properties.
+       * Create an instance of ASF::AudioProperties.
        */
-      Properties();
+      AudioProperties();
 
       /*!
-       * Destroys this ASF::Properties instance.
+       * Destroys this ASF::AudioProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
       virtual int length() const;

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -85,7 +85,7 @@ public:
 
   TagUnion tag;
 
-  Properties *properties;
+  AudioProperties *properties;
   ByteVector streamInfoData;
   ByteVector xiphCommentData;
   List<MetadataBlock *> blocks;
@@ -105,7 +105,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 FLAC::File::File(FileName file,
-                 bool readProperties, Properties::ReadStyle propertiesStyle,
+                 bool readProperties, AudioProperties::ReadStyle propertiesStyle,
                  ID3v2::FrameFactory *frameFactory) :
   TagLib::File(file)
 {
@@ -117,7 +117,7 @@ FLAC::File::File(FileName file,
 }
 
 FLAC::File::File(IOStream *stream,
-                 bool readProperties, Properties::ReadStyle propertiesStyle,
+                 bool readProperties, AudioProperties::ReadStyle propertiesStyle,
                  ID3v2::FrameFactory *frameFactory) :
   TagLib::File(stream)
 {
@@ -143,7 +143,7 @@ PropertyMap FLAC::File::setProperties(const PropertyMap &properties)
   return d->tag.access<Ogg::XiphComment>(FlacXiphIndex, true)->setProperties(properties);
 }
 
-FLAC::Properties *FLAC::File::audioProperties() const
+FLAC::AudioProperties *FLAC::File::audioProperties() const
 {
   return d->properties;
 }
@@ -271,7 +271,7 @@ void FLAC::File::setID3v2FrameFactory(const ID3v2::FrameFactory *factory)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void FLAC::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void FLAC::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   // Look for an ID3v2 tag
 
@@ -311,7 +311,7 @@ void FLAC::File::read(bool readProperties, Properties::ReadStyle propertiesStyle
     d->tag.set(FlacXiphIndex, new Ogg::XiphComment);
 
   if(readProperties)
-    d->properties = new Properties(d->streamInfoData, d->streamLength, propertiesStyle);
+    d->properties = new AudioProperties(d->streamInfoData, d->streamLength, propertiesStyle);
 }
 
 ByteVector FLAC::File::xiphCommentData() const

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -76,7 +76,7 @@ namespace TagLib {
        */
       File(FileName file,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average,
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
            ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
@@ -92,7 +92,7 @@ namespace TagLib {
        */
       File(IOStream *stream,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average,
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
            ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
@@ -123,7 +123,7 @@ namespace TagLib {
        * Returns the FLAC::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Save the file.  This will primarily save the XiphComment, but
@@ -210,7 +210,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       void scan();
       offset_t findID3v2();
       offset_t findID3v1();

--- a/taglib/flac/flacproperties.cpp
+++ b/taglib/flac/flacproperties.cpp
@@ -31,7 +31,7 @@
 
 using namespace TagLib;
 
-class FLAC::Properties::PropertiesPrivate
+class FLAC::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(const ByteVector &d, offset_t st, ReadStyle s) :
@@ -61,48 +61,49 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-FLAC::Properties::Properties(const ByteVector &data, offset_t streamLength, ReadStyle style) : AudioProperties(style)
+FLAC::AudioProperties::AudioProperties(const ByteVector &data, offset_t streamLength, ReadStyle style)
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(data, streamLength, style);
   read();
 }
 
-FLAC::Properties::~Properties()
+FLAC::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int FLAC::Properties::length() const
+int FLAC::AudioProperties::length() const
 {
   return d->length;
 }
 
-int FLAC::Properties::bitrate() const
+int FLAC::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int FLAC::Properties::sampleRate() const
+int FLAC::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int FLAC::Properties::sampleWidth() const
+int FLAC::AudioProperties::sampleWidth() const
 {
   return d->sampleWidth;
 }
 
-int FLAC::Properties::channels() const
+int FLAC::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-unsigned long long FLAC::Properties::sampleFrames() const
+unsigned long long FLAC::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
 
-ByteVector FLAC::Properties::signature() const
+ByteVector FLAC::AudioProperties::signature() const
 {
   return d->signature;
 }
@@ -111,7 +112,7 @@ ByteVector FLAC::Properties::signature() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void FLAC::Properties::read()
+void FLAC::AudioProperties::read()
 {
   if(d->data.size() < 18) {
     debug("FLAC::Properties::read() - FLAC properties must contain at least 18 bytes.");

--- a/taglib/flac/flacproperties.h
+++ b/taglib/flac/flacproperties.h
@@ -42,19 +42,19 @@ namespace TagLib {
      * API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
-       * Create an instance of FLAC::Properties with the data read from the
-       * ByteVector \a data.
+       * Create an instance of FLAC::AudioProperties with the data read from 
+       * the ByteVector \a data.
        */
-      Properties(const ByteVector &data, offset_t streamLength, ReadStyle style = Average);
+      AudioProperties(const ByteVector &data, offset_t streamLength, ReadStyle style = Average);
 
       /*!
-       * Destroys this FLAC::Properties instance.
+       * Destroys this FLAC::AudioProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -81,8 +81,8 @@ namespace TagLib {
       ByteVector signature() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void read();
 

--- a/taglib/it/itfile.cpp
+++ b/taglib/it/itfile.cpp
@@ -37,7 +37,7 @@ public:
   }
 
   Mod::Tag       tag;
-  IT::Properties properties;
+  IT::AudioProperties properties;
 };
 
 IT::File::File(FileName file, bool readProperties,
@@ -68,7 +68,7 @@ Mod::Tag *IT::File::tag() const
   return &d->tag;
 }
 
-IT::Properties *IT::File::audioProperties() const
+IT::AudioProperties *IT::File::audioProperties() const
 {
   return &d->properties;
 }
@@ -148,7 +148,7 @@ bool IT::File::save()
     return false;
 
   uint fileSize = static_cast<uint>(File::length());
-  if(special & Properties::MessageAttached) {
+  if(special & AudioProperties::MessageAttached) {
     seek(54);
     if(!readU16L(messageLength) || !readU32L(messageOffset))
       return false;
@@ -218,7 +218,7 @@ void IT::File::read(bool)
   // sample/instrument names are abused as comments so
   // I just add all together.
   String message;
-  if(special & Properties::MessageAttached) {
+  if(special & AudioProperties::MessageAttached) {
     READ_U16L_AS(messageLength);
     READ_U32L_AS(messageOffset);
     seek(messageOffset);

--- a/taglib/it/itfile.h
+++ b/taglib/it/itfile.h
@@ -67,7 +67,7 @@ namespace TagLib {
          * Returns the IT::Properties for this file. If no audio properties
          * were read then this will return a null pointer.
          */
-        IT::Properties *audioProperties() const;
+        IT::AudioProperties *audioProperties() const;
 
         /*!
          * Save the file.

--- a/taglib/it/itproperties.cpp
+++ b/taglib/it/itproperties.cpp
@@ -24,7 +24,7 @@
 using namespace TagLib;
 using namespace IT;
 
-class IT::Properties::PropertiesPrivate
+class IT::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate() :
@@ -63,183 +63,183 @@ public:
   uchar  pitchWheelDepth;
 };
 
-IT::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
-  AudioProperties(propertiesStyle),
-  d(new PropertiesPrivate)
+IT::AudioProperties::AudioProperties(AudioProperties::ReadStyle propertiesStyle)
+  : TagLib::AudioProperties(propertiesStyle)
+  , d(new PropertiesPrivate)
 {
 }
 
-IT::Properties::~Properties()
+IT::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int IT::Properties::length() const
+int IT::AudioProperties::length() const
 {
   return 0;
 }
 
-int IT::Properties::bitrate() const
+int IT::AudioProperties::bitrate() const
 {
   return 0;
 }
 
-int IT::Properties::sampleRate() const
+int IT::AudioProperties::sampleRate() const
 {
   return 0;
 }
 
-int IT::Properties::channels() const
+int IT::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-TagLib::ushort IT::Properties::lengthInPatterns() const
+TagLib::ushort IT::AudioProperties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
 
-bool IT::Properties::stereo() const
+bool IT::AudioProperties::stereo() const
 {
   return d->flags & Stereo;
 }
 
-TagLib::ushort IT::Properties::instrumentCount() const
+TagLib::ushort IT::AudioProperties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-TagLib::ushort IT::Properties::sampleCount() const
+TagLib::ushort IT::AudioProperties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-TagLib::ushort IT::Properties::patternCount() const
+TagLib::ushort IT::AudioProperties::patternCount() const
 {
   return d->patternCount;
 }
 
-TagLib::ushort IT::Properties::version() const
+TagLib::ushort IT::AudioProperties::version() const
 {
   return d->version;
 }
 
-TagLib::ushort IT::Properties::compatibleVersion() const
+TagLib::ushort IT::AudioProperties::compatibleVersion() const
 {
   return d->compatibleVersion;
 }
 
-TagLib::ushort IT::Properties::flags() const
+TagLib::ushort IT::AudioProperties::flags() const
 {
   return d->flags;
 }
 
-TagLib::ushort IT::Properties::special() const
+TagLib::ushort IT::AudioProperties::special() const
 {
   return d->special;
 }
 
-uchar IT::Properties::globalVolume() const
+uchar IT::AudioProperties::globalVolume() const
 {
   return d->globalVolume;
 }
 
-uchar IT::Properties::mixVolume() const
+uchar IT::AudioProperties::mixVolume() const
 {
   return d->mixVolume;
 }
 
-uchar IT::Properties::tempo() const
+uchar IT::AudioProperties::tempo() const
 {
   return d->tempo;
 }
 
-uchar IT::Properties::bpmSpeed() const
+uchar IT::AudioProperties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }
 
-uchar IT::Properties::panningSeparation() const
+uchar IT::AudioProperties::panningSeparation() const
 {
   return d->panningSeparation;
 }
 
-uchar IT::Properties::pitchWheelDepth() const
+uchar IT::AudioProperties::pitchWheelDepth() const
 {
   return d->pitchWheelDepth;
 }
 
-void IT::Properties::setChannels(int channels)
+void IT::AudioProperties::setChannels(int channels)
 {
   d->channels = channels;
 }
 
-void IT::Properties::setLengthInPatterns(ushort lengthInPatterns)
+void IT::AudioProperties::setLengthInPatterns(ushort lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }
 
-void IT::Properties::setInstrumentCount(ushort instrumentCount)
+void IT::AudioProperties::setInstrumentCount(ushort instrumentCount)
 {
   d->instrumentCount = instrumentCount;
 }
 
-void IT::Properties::setSampleCount(ushort sampleCount)
+void IT::AudioProperties::setSampleCount(ushort sampleCount)
 {
   d->sampleCount = sampleCount;
 }
 
-void IT::Properties::setPatternCount(ushort patternCount)
+void IT::AudioProperties::setPatternCount(ushort patternCount)
 {
   d->patternCount = patternCount;
 }
 
-void IT::Properties::setFlags(ushort flags)
+void IT::AudioProperties::setFlags(ushort flags)
 {
   d->flags = flags;
 }
 
-void IT::Properties::setSpecial(ushort special)
+void IT::AudioProperties::setSpecial(ushort special)
 {
   d->special = special;
 }
 
-void IT::Properties::setCompatibleVersion(ushort compatibleVersion)
+void IT::AudioProperties::setCompatibleVersion(ushort compatibleVersion)
 {
   d->compatibleVersion = compatibleVersion;
 }
 
-void IT::Properties::setVersion(ushort version)
+void IT::AudioProperties::setVersion(ushort version)
 {
   d->version = version;
 }
 
-void IT::Properties::setGlobalVolume(uchar globalVolume)
+void IT::AudioProperties::setGlobalVolume(uchar globalVolume)
 {
   d->globalVolume = globalVolume;
 }
 
-void IT::Properties::setMixVolume(uchar mixVolume)
+void IT::AudioProperties::setMixVolume(uchar mixVolume)
 {
   d->mixVolume = mixVolume;
 }
 
-void IT::Properties::setTempo(uchar tempo)
+void IT::AudioProperties::setTempo(uchar tempo)
 {
   d->tempo = tempo;
 }
 
-void IT::Properties::setBpmSpeed(uchar bpmSpeed)
+void IT::AudioProperties::setBpmSpeed(uchar bpmSpeed)
 {
   d->bpmSpeed = bpmSpeed;
 }
 
-void IT::Properties::setPanningSeparation(uchar panningSeparation)
+void IT::AudioProperties::setPanningSeparation(uchar panningSeparation)
 {
   d->panningSeparation = panningSeparation;
 }
 
-void IT::Properties::setPitchWheelDepth(uchar pitchWheelDepth)
+void IT::AudioProperties::setPitchWheelDepth(uchar pitchWheelDepth)
 {
   d->pitchWheelDepth = pitchWheelDepth;
 }

--- a/taglib/it/itproperties.h
+++ b/taglib/it/itproperties.h
@@ -27,7 +27,7 @@
 
 namespace TagLib {
   namespace IT {
-    class TAGLIB_EXPORT Properties : public AudioProperties {
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties {
       friend class File;
     public:
       /*! Flag bits. */
@@ -48,8 +48,8 @@ namespace TagLib {
         MidiConfEmbedded = 8
       };
 
-      Properties(AudioProperties::ReadStyle propertiesStyle);
-      virtual ~Properties();
+      AudioProperties(AudioProperties::ReadStyle propertiesStyle);
+      virtual ~AudioProperties();
 
       int length()     const;
       int bitrate()    const;
@@ -89,8 +89,8 @@ namespace TagLib {
       void setPitchWheelDepth  (uchar pitchWheelDepth);
 
     private:
-      Properties(const Properties&);
-      Properties &operator=(const Properties&);
+      AudioProperties(const AudioProperties&);
+      AudioProperties &operator=(const AudioProperties&);
 
       class PropertiesPrivate;
       PropertiesPrivate *d;

--- a/taglib/mod/modfile.cpp
+++ b/taglib/mod/modfile.cpp
@@ -37,7 +37,7 @@ public:
   }
 
   Mod::Tag        tag;
-  Mod::Properties properties;
+  Mod::AudioProperties properties;
 };
 
 Mod::File::File(FileName file, bool readProperties,
@@ -68,7 +68,7 @@ Mod::Tag *Mod::File::tag() const
   return &d->tag;
 }
 
-Mod::Properties *Mod::File::audioProperties() const
+Mod::AudioProperties *Mod::File::audioProperties() const
 {
   return &d->properties;
 }

--- a/taglib/mod/modfile.h
+++ b/taglib/mod/modfile.h
@@ -68,7 +68,7 @@ namespace TagLib {
        * Returns the Mod::Properties for this file. If no audio properties
        * were read then this will return a null pointer.
        */
-      Mod::Properties *audioProperties() const;
+      Mod::AudioProperties *audioProperties() const;
 
       /*!
        * Save the file.

--- a/taglib/mod/modproperties.cpp
+++ b/taglib/mod/modproperties.cpp
@@ -24,7 +24,7 @@
 using namespace TagLib;
 using namespace Mod;
 
-class Mod::Properties::PropertiesPrivate
+class Mod::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate() :
@@ -39,58 +39,58 @@ public:
   uchar lengthInPatterns;
 };
 
-Mod::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
-  AudioProperties(propertiesStyle),
-  d(new PropertiesPrivate)
+Mod::AudioProperties::AudioProperties(AudioProperties::ReadStyle propertiesStyle) 
+  : TagLib::AudioProperties(propertiesStyle)
+  , d(new PropertiesPrivate)
 {
 }
 
-Mod::Properties::~Properties()
+Mod::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int Mod::Properties::length() const
+int Mod::AudioProperties::length() const
 {
   return 0;
 }
 
-int Mod::Properties::bitrate() const
+int Mod::AudioProperties::bitrate() const
 {
   return 0;
 }
 
-int Mod::Properties::sampleRate() const
+int Mod::AudioProperties::sampleRate() const
 {
   return 0;
 }
 
-int Mod::Properties::channels() const
+int Mod::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-TagLib::uint Mod::Properties::instrumentCount() const
+TagLib::uint Mod::AudioProperties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-uchar Mod::Properties::lengthInPatterns() const
+uchar Mod::AudioProperties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
 
-void Mod::Properties::setChannels(int channels)
+void Mod::AudioProperties::setChannels(int channels)
 {
   d->channels = channels;
 }
 
-void Mod::Properties::setInstrumentCount(uint instrumentCount)
+void Mod::AudioProperties::setInstrumentCount(uint instrumentCount)
 {
   d->instrumentCount = instrumentCount;
 }
 
-void Mod::Properties::setLengthInPatterns(uchar lengthInPatterns)
+void Mod::AudioProperties::setLengthInPatterns(uchar lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }

--- a/taglib/mod/modproperties.h
+++ b/taglib/mod/modproperties.h
@@ -29,11 +29,11 @@ namespace TagLib {
 
   namespace Mod {
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
-      Properties(AudioProperties::ReadStyle propertiesStyle);
-      virtual ~Properties();
+      AudioProperties(AudioProperties::ReadStyle propertiesStyle);
+      virtual ~AudioProperties();
 
       int length() const;
       int bitrate() const;
@@ -51,8 +51,8 @@ namespace TagLib {
     private:
       friend class File;
 
-      Properties(const Properties&);
-      Properties &operator=(const Properties&);
+      AudioProperties(const AudioProperties&);
+      AudioProperties &operator=(const AudioProperties&);
 
       class PropertiesPrivate;
       PropertiesPrivate *d;

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -57,7 +57,7 @@ public:
 
   MP4::Tag *tag;
   MP4::Atoms *atoms;
-  MP4::Properties *properties;
+  MP4::AudioProperties *properties;
 };
 
 MP4::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
@@ -87,7 +87,7 @@ MP4::File::tag() const
   return d->tag;
 }
 
-MP4::Properties *
+MP4::AudioProperties *
 MP4::File::audioProperties() const
 {
   return d->properties;
@@ -106,7 +106,7 @@ MP4::File::checkValid(const MP4::AtomList &list)
 }
 
 void
-MP4::File::read(bool readProperties, Properties::ReadStyle audioPropertiesStyle)
+MP4::File::read(bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
 {
   if(!isValid())
     return;
@@ -126,7 +126,7 @@ MP4::File::read(bool readProperties, Properties::ReadStyle audioPropertiesStyle)
 
   d->tag = new Tag(this, d->atoms);
   if(readProperties) {
-    d->properties = new Properties(this, d->atoms, audioPropertiesStyle);
+    d->properties = new AudioProperties(this, d->atoms, audioPropertiesStyle);
   }
 }
 

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -56,7 +56,7 @@ namespace TagLib {
        * \note In the current implementation, both \a readProperties and
        * \a propertiesStyle are ignored.
        */
-      File(FileName file, bool readProperties = true, Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+      File(FileName file, bool readProperties = true, AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs a MP4 file from \a file.  If \a readProperties is true the
@@ -69,7 +69,7 @@ namespace TagLib {
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        */
-      File(IOStream *stream, bool readProperties = true, Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+      File(IOStream *stream, bool readProperties = true, AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -91,7 +91,7 @@ namespace TagLib {
       /*!
        * Returns the MP4 audio properties for this file.
        */
-      Properties *audioProperties() const;
+      AudioProperties *audioProperties() const;
 
       /*!
        * Save the file.
@@ -102,7 +102,7 @@ namespace TagLib {
 
     private:
 
-      void read(bool readProperties, Properties::ReadStyle audioPropertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle);
       bool checkValid(const MP4::AtomList &list);
 
       class FilePrivate;

--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -32,7 +32,7 @@
 
 using namespace TagLib;
 
-class MP4::Properties::PropertiesPrivate
+class MP4::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate() : length(0), bitrate(0), sampleRate(0), channels(0), bitsPerSample(0), encrypted(false), format(Unknown) {}
@@ -52,8 +52,8 @@ public:
   Format format;
 };
 
-MP4::Properties::Properties(File *file, MP4::Atoms *atoms, ReadStyle style)
-  : AudioProperties(style)
+MP4::AudioProperties::AudioProperties(File *file, MP4::Atoms *atoms, ReadStyle style)
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate;
 
@@ -158,49 +158,49 @@ MP4::Properties::Properties(File *file, MP4::Atoms *atoms, ReadStyle style)
   }
 }
 
-MP4::Properties::~Properties()
+MP4::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
 int
-MP4::Properties::channels() const
+MP4::AudioProperties::channels() const
 {
   return d->channels;
 }
 
 int
-MP4::Properties::sampleRate() const
+MP4::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
 int
-MP4::Properties::length() const
+MP4::AudioProperties::length() const
 {
   return d->length;
 }
 
 int
-MP4::Properties::bitrate() const
+MP4::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
 int
-MP4::Properties::bitsPerSample() const
+MP4::AudioProperties::bitsPerSample() const
 {
   return d->bitsPerSample;
 }
 
 bool
-MP4::Properties::isEncrypted() const
+MP4::AudioProperties::isEncrypted() const
 {
   return d->encrypted;
 }
 
 String
-MP4::Properties::toString() const
+MP4::AudioProperties::toString() const
 {
   String format;
   if(d->format == PropertiesPrivate::AAC) {

--- a/taglib/mp4/mp4properties.h
+++ b/taglib/mp4/mp4properties.h
@@ -37,11 +37,11 @@ namespace TagLib {
     class File;
 
     //! An implementation of MP4 audio properties
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
-      Properties(File *file, Atoms *atoms, ReadStyle style = Average);
-      virtual ~Properties();
+      AudioProperties(File *file, Atoms *atoms, ReadStyle style = Average);
+      virtual ~AudioProperties();
 
       virtual int length() const;
       virtual int bitrate() const;

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -75,7 +75,7 @@ public:
 
   TagUnion tag;
 
-  Properties *properties;
+  AudioProperties *properties;
   bool scanned;
 
   // These indicate whether the file *on disk* has these tags, not if
@@ -91,7 +91,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 MPC::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                AudioProperties::ReadStyle propertiesStyle) : TagLib::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -99,7 +99,7 @@ MPC::File::File(FileName file, bool readProperties,
 }
 
 MPC::File::File(IOStream *stream, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(stream)
+                AudioProperties::ReadStyle propertiesStyle) : TagLib::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -123,7 +123,7 @@ PropertyMap MPC::File::setProperties(const PropertyMap &properties)
   return d->tag.access<APE::Tag>(MPCAPEIndex, true)->setProperties(properties);
 }
 
-MPC::Properties *MPC::File::audioProperties() const
+MPC::AudioProperties *MPC::File::audioProperties() const
 {
   return d->properties;
 }
@@ -244,7 +244,7 @@ void MPC::File::remove(int tags)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void MPC::File::read(bool readProperties, Properties::ReadStyle /* propertiesStyle */)
+void MPC::File::read(bool readProperties, AudioProperties::ReadStyle /* propertiesStyle */)
 {
   // Look for an ID3v1 tag
 
@@ -291,7 +291,7 @@ void MPC::File::read(bool readProperties, Properties::ReadStyle /* propertiesSty
   // Look for MPC metadata
 
   if(readProperties) {
-    d->properties = new Properties(this, length() - d->ID3v2Size - d->APESize);
+    d->properties = new AudioProperties(this, length() - d->ID3v2Size - d->APESize);
   }
 }
 

--- a/taglib/mpc/mpcfile.h
+++ b/taglib/mpc/mpcfile.h
@@ -89,7 +89,7 @@ namespace TagLib {
        * false, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an MPC file from \a file.  If \a readProperties is true the
@@ -100,7 +100,7 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -124,7 +124,7 @@ namespace TagLib {
        * Returns the MPC::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Saves the file.
@@ -180,7 +180,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       void scan();
       offset_t findAPE();
       offset_t findID3v1();

--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -33,7 +33,7 @@
 
 using namespace TagLib;
 
-class MPC::Properties::PropertiesPrivate
+class MPC::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(offset_t length, ReadStyle s) :
@@ -71,13 +71,15 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-MPC::Properties::Properties(const ByteVector &data, offset_t streamLength, ReadStyle style) : AudioProperties(style)
+MPC::AudioProperties::AudioProperties(const ByteVector &data, offset_t streamLength, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(streamLength, style);
   readSV7(data);
 }
 
-MPC::Properties::Properties(File *file, offset_t streamLength, ReadStyle style) : AudioProperties(style)
+MPC::AudioProperties::AudioProperties(File *file, offset_t streamLength, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(streamLength, style);
   ByteVector magic = file->readBlock(4);
@@ -91,62 +93,62 @@ MPC::Properties::Properties(File *file, offset_t streamLength, ReadStyle style) 
   }
 }
 
-MPC::Properties::~Properties()
+MPC::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int MPC::Properties::length() const
+int MPC::AudioProperties::length() const
 {
   return d->length;
 }
 
-int MPC::Properties::bitrate() const
+int MPC::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int MPC::Properties::sampleRate() const
+int MPC::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int MPC::Properties::channels() const
+int MPC::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int MPC::Properties::mpcVersion() const
+int MPC::AudioProperties::mpcVersion() const
 {
   return d->version;
 }
 
-TagLib::uint MPC::Properties::totalFrames() const
+TagLib::uint MPC::AudioProperties::totalFrames() const
 {
   return d->totalFrames;
 }
 
-TagLib::uint MPC::Properties::sampleFrames() const
+TagLib::uint MPC::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
 
-int MPC::Properties::trackGain() const
+int MPC::AudioProperties::trackGain() const
 {
   return d->trackGain;
 }
 
-int MPC::Properties::trackPeak() const
+int MPC::AudioProperties::trackPeak() const
 {
   return d->trackPeak;
 }
 
-int MPC::Properties::albumGain() const
+int MPC::AudioProperties::albumGain() const
 {
   return d->albumGain;
 }
 
-int MPC::Properties::albumPeak() const
+int MPC::AudioProperties::albumPeak() const
 {
   return d->albumPeak;
 }
@@ -185,7 +187,7 @@ unsigned long readSize(const ByteVector &data, size_t &sizelength)
 
 static const unsigned short sftable [4] = { 44100, 48000, 37800, 32000 };
 
-void MPC::Properties::readSV8(File *file)
+void MPC::AudioProperties::readSV8(File *file)
 {
   bool readSH = false, readRG = false;
 
@@ -245,7 +247,7 @@ void MPC::Properties::readSV8(File *file)
   }
 }
 
-void MPC::Properties::readSV7(const ByteVector &data)
+void MPC::AudioProperties::readSV7(const ByteVector &data)
 {
   if(data.startsWith("MP+")) {
     d->version = data[3] & 15;

--- a/taglib/mpc/mpcproperties.h
+++ b/taglib/mpc/mpcproperties.h
@@ -44,27 +44,27 @@ namespace TagLib {
      * API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
-       * Create an instance of MPC::Properties with the data read from the
-       * ByteVector \a data.
+       * Create an instance of MPC::AudioProperties with the data read from 
+       * the ByteVector \a data.
        *
        * This constructor is deprecated. It only works for MPC version up to 7.
        */
-      Properties(const ByteVector &data, offset_t streamLength, ReadStyle style = Average);
+      AudioProperties(const ByteVector &data, offset_t streamLength, ReadStyle style = Average);
 
       /*!
-       * Create an instance of MPC::Properties with the data read directly
+       * Create an instance of MPC::AudioProperties with the data read directly
        * from a MPC::File.
        */
-      Properties(File *file, offset_t streamLength, ReadStyle style = Average);
+      AudioProperties(File *file, offset_t streamLength, ReadStyle style = Average);
 
       /*!
        * Destroys this MPC::Properties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -107,8 +107,8 @@ namespace TagLib {
       int albumPeak() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void readSV7(const ByteVector &data);
       void readSV8(File *file);

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -88,7 +88,7 @@ public:
   bool hasID3v1;
   bool hasAPE;
 
-  Properties *properties;
+  AudioProperties *properties;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -96,7 +96,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 MPEG::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                 AudioProperties::ReadStyle propertiesStyle) : TagLib::File(file)
 {
   d = new FilePrivate;
 
@@ -105,7 +105,7 @@ MPEG::File::File(FileName file, bool readProperties,
 }
 
 MPEG::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
+                 bool readProperties, AudioProperties::ReadStyle propertiesStyle) :
   TagLib::File(file)
 {
   d = new FilePrivate(frameFactory);
@@ -115,7 +115,7 @@ MPEG::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
 }
 
 MPEG::File::File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
+                 bool readProperties, AudioProperties::ReadStyle propertiesStyle) :
   TagLib::File(stream)
 {
   d = new FilePrivate(frameFactory);
@@ -142,7 +142,7 @@ PropertyMap MPEG::File::setProperties(const PropertyMap &properties)
   return d->tag.access<ID3v2::Tag>(ID3v2Index, true)->setProperties(properties);
 }
 
-MPEG::Properties *MPEG::File::audioProperties() const
+MPEG::AudioProperties *MPEG::File::audioProperties() const
 {
   return d->properties;
 }
@@ -431,7 +431,7 @@ bool MPEG::File::hasAPETag() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void MPEG::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void MPEG::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   // Look for an ID3v2 tag
 
@@ -470,7 +470,7 @@ void MPEG::File::read(bool readProperties, Properties::ReadStyle propertiesStyle
   }
 
   if(readProperties)
-    d->properties = new Properties(this, propertiesStyle);
+    d->properties = new AudioProperties(this, propertiesStyle);
 
   // Make sure that we have our default tag types available.
 

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -79,7 +79,7 @@ namespace TagLib {
        * in a future version.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an MPEG file from \a file.  If \a readProperties is true the
@@ -92,7 +92,7 @@ namespace TagLib {
        */
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an MPEG file from \a stream.  If \a readProperties is true the
@@ -106,7 +106,7 @@ namespace TagLib {
       // BIC: merge with the above constructor
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -146,7 +146,7 @@ namespace TagLib {
        * Returns the MPEG::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Save the file.  If at least one tag -- ID3v1 or ID3v2 -- exists this
@@ -307,7 +307,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       offset_t findID3v2();
       offset_t findID3v1();
       void findAPE();

--- a/taglib/mpeg/mpegproperties.cpp
+++ b/taglib/mpeg/mpegproperties.cpp
@@ -32,7 +32,7 @@
 
 using namespace TagLib;
 
-class MPEG::Properties::PropertiesPrivate
+class MPEG::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(File *f, ReadStyle s) :
@@ -74,7 +74,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-MPEG::Properties::Properties(File *file, ReadStyle style) : AudioProperties(style)
+MPEG::AudioProperties::AudioProperties(File *file, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(file, style);
 
@@ -82,62 +83,62 @@ MPEG::Properties::Properties(File *file, ReadStyle style) : AudioProperties(styl
     read();
 }
 
-MPEG::Properties::~Properties()
+MPEG::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int MPEG::Properties::length() const
+int MPEG::AudioProperties::length() const
 {
   return d->length;
 }
 
-int MPEG::Properties::bitrate() const
+int MPEG::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int MPEG::Properties::sampleRate() const
+int MPEG::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int MPEG::Properties::channels() const
+int MPEG::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-const MPEG::XingHeader *MPEG::Properties::xingHeader() const
+const MPEG::XingHeader *MPEG::AudioProperties::xingHeader() const
 {
   return d->xingHeader;
 }
 
-MPEG::Header::Version MPEG::Properties::version() const
+MPEG::Header::Version MPEG::AudioProperties::version() const
 {
   return d->version;
 }
 
-int MPEG::Properties::layer() const
+int MPEG::AudioProperties::layer() const
 {
   return d->layer;
 }
 
-bool MPEG::Properties::protectionEnabled() const
+bool MPEG::AudioProperties::protectionEnabled() const
 {
   return d->protectionEnabled;
 }
 
-MPEG::Header::ChannelMode MPEG::Properties::channelMode() const
+MPEG::Header::ChannelMode MPEG::AudioProperties::channelMode() const
 {
   return d->channelMode;
 }
 
-bool MPEG::Properties::isCopyrighted() const
+bool MPEG::AudioProperties::isCopyrighted() const
 {
   return d->isCopyrighted;
 }
 
-bool MPEG::Properties::isOriginal() const
+bool MPEG::AudioProperties::isOriginal() const
 {
   return d->isOriginal;
 }
@@ -146,7 +147,7 @@ bool MPEG::Properties::isOriginal() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void MPEG::Properties::read()
+void MPEG::AudioProperties::read()
 {
   // Since we've likely just looked for the ID3v1 tag, start at the end of the
   // file where we're least likely to have to have to move the disk head.

--- a/taglib/mpeg/mpegproperties.h
+++ b/taglib/mpeg/mpegproperties.h
@@ -45,19 +45,19 @@ namespace TagLib {
      * AudioProperties API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
-       * Create an instance of MPEG::Properties with the data read from the
-       * MPEG::File \a file.
+       * Create an instance of MPEG::AudioProperties with the data read from 
+       * the MPEG::File \a file.
        */
-      Properties(File *file, ReadStyle style = Average);
+      AudioProperties(File *file, ReadStyle style = Average);
 
       /*!
-       * Destroys this MPEG Properties instance.
+       * Destroys this MPEG::AudioProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -104,8 +104,8 @@ namespace TagLib {
       bool isOriginal() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void read();
 

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -32,7 +32,7 @@
 #include "oggflacfile.h"
 
 using namespace TagLib;
-using TagLib::FLAC::Properties;
+using TagLib::FLAC::AudioProperties;
 
 class Ogg::FLAC::File::FilePrivate
 {
@@ -54,7 +54,7 @@ public:
 
   Ogg::XiphComment *comment;
 
-  Properties *properties;
+  AudioProperties *properties;
   ByteVector streamInfoData;
   ByteVector xiphCommentData;
   offset_t streamStart;
@@ -70,7 +70,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 Ogg::FLAC::File::File(FileName file, bool readProperties,
-                      Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                      AudioProperties::ReadStyle propertiesStyle) : Ogg::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -78,7 +78,7 @@ Ogg::FLAC::File::File(FileName file, bool readProperties,
 }
 
 Ogg::FLAC::File::File(IOStream *stream, bool readProperties,
-                      Properties::ReadStyle propertiesStyle) : Ogg::File(stream)
+                      AudioProperties::ReadStyle propertiesStyle) : Ogg::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -105,7 +105,7 @@ PropertyMap Ogg::FLAC::File::setProperties(const PropertyMap &properties)
   return d->comment->setProperties(properties);
 }  
 
-Properties *Ogg::FLAC::File::audioProperties() const
+FLAC::AudioProperties *Ogg::FLAC::File::audioProperties() const
 {
   return d->properties;
 }
@@ -141,7 +141,7 @@ bool Ogg::FLAC::File::save()
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Ogg::FLAC::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void Ogg::FLAC::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   // Sanity: Check if we really have an Ogg/FLAC file
 
@@ -171,7 +171,7 @@ void Ogg::FLAC::File::read(bool readProperties, Properties::ReadStyle properties
 
 
   if(readProperties)
-    d->properties = new Properties(streamInfoData(), streamLength(), propertiesStyle);
+    d->properties = new AudioProperties(streamInfoData(), streamLength(), propertiesStyle);
 }
 
 ByteVector Ogg::FLAC::File::streamInfoData()

--- a/taglib/ogg/flac/oggflacfile.h
+++ b/taglib/ogg/flac/oggflacfile.h
@@ -49,7 +49,7 @@ namespace TagLib {
    */
   namespace FLAC {
 
-    using TagLib::FLAC::Properties;
+    using TagLib::FLAC::AudioProperties;
 
     //! An implementation of TagLib::File with Ogg/FLAC specific methods
 
@@ -69,7 +69,7 @@ namespace TagLib {
        * If false, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an Ogg/FLAC file from \a file.  If \a readProperties is true
@@ -80,7 +80,7 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -98,7 +98,7 @@ namespace TagLib {
        * Returns the FLAC::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
 
       /*! 
@@ -130,7 +130,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       void scan();
       ByteVector streamInfoData();
       ByteVector xiphCommentData();

--- a/taglib/ogg/opus/opusfile.cpp
+++ b/taglib/ogg/opus/opusfile.cpp
@@ -52,7 +52,7 @@ public:
   }
 
   Ogg::XiphComment *comment;
-  Properties *properties;
+  AudioProperties *properties;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,14 +60,14 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 Opus::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                   AudioProperties::ReadStyle propertiesStyle) : Ogg::File(file)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);
 }
 
 Opus::File::File(IOStream *stream, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(stream)
+                   AudioProperties::ReadStyle propertiesStyle) : Ogg::File(stream)
 {
   d = new FilePrivate;
   read(readProperties, propertiesStyle);
@@ -93,7 +93,7 @@ PropertyMap Opus::File::setProperties(const PropertyMap &properties)
   return d->comment->setProperties(properties);
 }
 
-Opus::Properties *Opus::File::audioProperties() const
+Opus::AudioProperties *Opus::File::audioProperties() const
 {
   return d->properties;
 }
@@ -112,7 +112,7 @@ bool Opus::File::save()
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Opus::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void Opus::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   ByteVector opusHeaderData = packet(0);
 
@@ -133,5 +133,5 @@ void Opus::File::read(bool readProperties, Properties::ReadStyle propertiesStyle
   d->comment = new Ogg::XiphComment(commentHeaderData.mid(8));
 
   if(readProperties)
-    d->properties = new Properties(this, propertiesStyle);
+    d->properties = new AudioProperties(this, propertiesStyle);
 }

--- a/taglib/ogg/opus/opusfile.h
+++ b/taglib/ogg/opus/opusfile.h
@@ -61,7 +61,7 @@ namespace TagLib {
          * false, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Contructs a Opus file from \a file.  If \a readProperties is true the
@@ -72,7 +72,7 @@ namespace TagLib {
          * responsible for deleting it after the File object.
          */
         File(IOStream *stream, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Destroys this instance of the File.
@@ -102,7 +102,7 @@ namespace TagLib {
          * Returns the Opus::Properties for this file.  If no audio properties
          * were read then this will return a null pointer.
          */
-        virtual Properties *audioProperties() const;
+        virtual AudioProperties *audioProperties() const;
 
         virtual bool save();
 
@@ -110,7 +110,7 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
 
         class FilePrivate;
         FilePrivate *d;

--- a/taglib/ogg/opus/opusproperties.cpp
+++ b/taglib/ogg/opus/opusproperties.cpp
@@ -38,7 +38,7 @@
 using namespace TagLib;
 using namespace TagLib::Ogg;
 
-class Opus::Properties::PropertiesPrivate
+class Opus::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(File *f, ReadStyle s) :
@@ -61,28 +61,29 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Opus::Properties::Properties(File *file, ReadStyle style) : AudioProperties(style)
+Opus::AudioProperties::AudioProperties(File *file, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(file, style);
   read();
 }
 
-Opus::Properties::~Properties()
+Opus::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int Opus::Properties::length() const
+int Opus::AudioProperties::length() const
 {
   return d->length;
 }
 
-int Opus::Properties::bitrate() const
+int Opus::AudioProperties::bitrate() const
 {
   return 0;
 }
 
-int Opus::Properties::sampleRate() const
+int Opus::AudioProperties::sampleRate() const
 {
   // Opus can decode any stream at a sample rate of 8, 12, 16, 24, or 48 kHz,
   // so there is no single sample rate. Let's assume it's the highest
@@ -90,17 +91,17 @@ int Opus::Properties::sampleRate() const
   return 48000;
 }
 
-int Opus::Properties::channels() const
+int Opus::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int Opus::Properties::inputSampleRate() const
+int Opus::AudioProperties::inputSampleRate() const
 {
   return d->inputSampleRate;
 }
 
-int Opus::Properties::opusVersion() const
+int Opus::AudioProperties::opusVersion() const
 {
   return d->opusVersion;
 }
@@ -109,7 +110,7 @@ int Opus::Properties::opusVersion() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Opus::Properties::read()
+void Opus::AudioProperties::read()
 {
   // Get the identification header from the Ogg implementation.
 

--- a/taglib/ogg/opus/opusproperties.h
+++ b/taglib/ogg/opus/opusproperties.h
@@ -47,19 +47,19 @@ namespace TagLib {
        * API.
        */
 
-      class TAGLIB_EXPORT Properties : public AudioProperties
+      class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
       {
       public:
         /*!
-         * Create an instance of Opus::Properties with the data read from the
-         * Opus::File \a file.
+         * Create an instance of Opus::AudioProperties with the data read from 
+         * the Opus::File \a file.
          */
-        Properties(File *file, ReadStyle style = Average);
+        AudioProperties(File *file, ReadStyle style = Average);
 
         /*!
-         * Destroys this Opus::Properties instance.
+         * Destroys this Opus::AudioProperties instance.
          */
-        virtual ~Properties();
+        virtual ~AudioProperties();
 
         // Reimplementations.
 
@@ -81,8 +81,8 @@ namespace TagLib {
         int opusVersion() const;
 
       private:
-        Properties(const Properties &);
-        Properties &operator=(const Properties &);
+        AudioProperties(const AudioProperties &);
+        AudioProperties &operator=(const AudioProperties &);
 
         void read();
 

--- a/taglib/ogg/speex/speexfile.cpp
+++ b/taglib/ogg/speex/speexfile.cpp
@@ -52,7 +52,7 @@ public:
   }
 
   Ogg::XiphComment *comment;
-  Properties *properties;
+  AudioProperties *properties;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 Speex::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                   AudioProperties::ReadStyle propertiesStyle) : Ogg::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -68,7 +68,7 @@ Speex::File::File(FileName file, bool readProperties,
 }
 
 Speex::File::File(IOStream *stream, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(stream)
+                   AudioProperties::ReadStyle propertiesStyle) : Ogg::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -95,7 +95,7 @@ PropertyMap Speex::File::setProperties(const PropertyMap &properties)
   return d->comment->setProperties(properties);
 }
 
-Speex::Properties *Speex::File::audioProperties() const
+Speex::AudioProperties *Speex::File::audioProperties() const
 {
   return d->properties;
 }
@@ -114,7 +114,7 @@ bool Speex::File::save()
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Speex::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void Speex::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   ByteVector speexHeaderData = packet(0);
 
@@ -128,5 +128,5 @@ void Speex::File::read(bool readProperties, Properties::ReadStyle propertiesStyl
   d->comment = new Ogg::XiphComment(commentHeaderData);
 
   if(readProperties)
-    d->properties = new Properties(this, propertiesStyle);
+    d->properties = new AudioProperties(this, propertiesStyle);
 }

--- a/taglib/ogg/speex/speexfile.h
+++ b/taglib/ogg/speex/speexfile.h
@@ -61,7 +61,7 @@ namespace TagLib {
          * false, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Contructs a Speex file from \a file.  If \a readProperties is true the
@@ -72,7 +72,7 @@ namespace TagLib {
          * responsible for deleting it after the File object.
          */
         File(IOStream *stream, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Destroys this instance of the File.
@@ -102,7 +102,7 @@ namespace TagLib {
          * Returns the Speex::Properties for this file.  If no audio properties
          * were read then this will return a null pointer.
          */
-        virtual Properties *audioProperties() const;
+        virtual AudioProperties *audioProperties() const;
 
 
 
@@ -112,7 +112,7 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
 
         class FilePrivate;
         FilePrivate *d;

--- a/taglib/ogg/speex/speexproperties.cpp
+++ b/taglib/ogg/speex/speexproperties.cpp
@@ -38,7 +38,7 @@
 using namespace TagLib;
 using namespace TagLib::Ogg;
 
-class Speex::Properties::PropertiesPrivate
+class Speex::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(File *f, ReadStyle s) :
@@ -67,38 +67,39 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Speex::Properties::Properties(File *file, ReadStyle style) : AudioProperties(style)
+Speex::AudioProperties::AudioProperties(File *file, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(file, style);
   read();
 }
 
-Speex::Properties::~Properties()
+Speex::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int Speex::Properties::length() const
+int Speex::AudioProperties::length() const
 {
   return d->length;
 }
 
-int Speex::Properties::bitrate() const
+int Speex::AudioProperties::bitrate() const
 {
   return int(float(d->bitrate) / float(1000) + 0.5);
 }
 
-int Speex::Properties::sampleRate() const
+int Speex::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int Speex::Properties::channels() const
+int Speex::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int Speex::Properties::speexVersion() const
+int Speex::AudioProperties::speexVersion() const
 {
   return d->speexVersion;
 }
@@ -107,7 +108,7 @@ int Speex::Properties::speexVersion() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Speex::Properties::read()
+void Speex::AudioProperties::read()
 {
   // Get the identification header from the Ogg implementation.
 

--- a/taglib/ogg/speex/speexproperties.h
+++ b/taglib/ogg/speex/speexproperties.h
@@ -47,19 +47,19 @@ namespace TagLib {
        * API.
        */
 
-      class TAGLIB_EXPORT Properties : public AudioProperties
+      class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
       {
       public:
         /*!
-         * Create an instance of Speex::Properties with the data read from the
-         * Speex::File \a file.
+         * Create an instance of Speex::AudioProperties with the data read from 
+         * the Speex::File \a file.
          */
-        Properties(File *file, ReadStyle style = Average);
+        AudioProperties(File *file, ReadStyle style = Average);
 
         /*!
-         * Destroys this Speex::Properties instance.
+         * Destroys this Speex::AudioProperties instance.
          */
-        virtual ~Properties();
+        virtual ~AudioProperties();
 
         // Reimplementations.
 
@@ -74,8 +74,8 @@ namespace TagLib {
         int speexVersion() const;
 
       private:
-        Properties(const Properties &);
-        Properties &operator=(const Properties &);
+        AudioProperties(const AudioProperties &);
+        AudioProperties &operator=(const AudioProperties &);
 
         void read();
 

--- a/taglib/ogg/vorbis/vorbisfile.cpp
+++ b/taglib/ogg/vorbis/vorbisfile.cpp
@@ -48,7 +48,7 @@ public:
   }
 
   Ogg::XiphComment *comment;
-  Properties *properties;
+  AudioProperties *properties;
 };
 
 namespace TagLib {
@@ -64,7 +64,7 @@ namespace TagLib {
 ////////////////////////////////////////////////////////////////////////////////
 
 Ogg::Vorbis::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                   AudioProperties::ReadStyle propertiesStyle) : Ogg::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -72,7 +72,7 @@ Ogg::Vorbis::File::File(FileName file, bool readProperties,
 }
 
 Ogg::Vorbis::File::File(IOStream *stream, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(stream)
+                   AudioProperties::ReadStyle propertiesStyle) : Ogg::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -99,7 +99,7 @@ PropertyMap Ogg::Vorbis::File::setProperties(const PropertyMap &properties)
   return d->comment->setProperties(properties);
 }
 
-Ogg::Vorbis::Properties *Ogg::Vorbis::File::audioProperties() const
+Ogg::Vorbis::AudioProperties *Ogg::Vorbis::File::audioProperties() const
 {
   return d->properties;
 }
@@ -121,7 +121,7 @@ bool Ogg::Vorbis::File::save()
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Ogg::Vorbis::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void Ogg::Vorbis::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   ByteVector commentHeaderData = packet(1);
 
@@ -134,5 +134,5 @@ void Ogg::Vorbis::File::read(bool readProperties, Properties::ReadStyle properti
   d->comment = new Ogg::XiphComment(commentHeaderData.mid(7));
 
   if(readProperties)
-    d->properties = new Properties(this, propertiesStyle);
+    d->properties = new AudioProperties(this, propertiesStyle);
 }

--- a/taglib/ogg/vorbis/vorbisfile.h
+++ b/taglib/ogg/vorbis/vorbisfile.h
@@ -59,7 +59,7 @@ namespace TagLib {
        * false, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs a Vorbis file from \a file.  If \a readProperties is true the
@@ -70,7 +70,7 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -101,7 +101,7 @@ namespace TagLib {
        * Returns the Vorbis::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       virtual bool save();
 
@@ -109,7 +109,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
 
       class FilePrivate;
       FilePrivate *d;

--- a/taglib/ogg/vorbis/vorbisproperties.cpp
+++ b/taglib/ogg/vorbis/vorbisproperties.cpp
@@ -33,7 +33,7 @@
 
 using namespace TagLib;
 
-class Ogg::Vorbis::Properties::PropertiesPrivate
+class Ogg::Vorbis::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(File *f, ReadStyle s) :
@@ -72,58 +72,59 @@ namespace TagLib {
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Ogg::Vorbis::Properties::Properties(File *file, ReadStyle style) : AudioProperties(style)
+Ogg::Vorbis::AudioProperties::AudioProperties(File *file, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(file, style);
   read();
 }
 
-Ogg::Vorbis::Properties::~Properties()
+Ogg::Vorbis::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int Ogg::Vorbis::Properties::length() const
+int Ogg::Vorbis::AudioProperties::length() const
 {
   return d->length;
 }
 
-int Ogg::Vorbis::Properties::bitrate() const
+int Ogg::Vorbis::AudioProperties::bitrate() const
 {
   return int(float(d->bitrate) / float(1000) + 0.5);
 }
 
-int Ogg::Vorbis::Properties::sampleRate() const
+int Ogg::Vorbis::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int Ogg::Vorbis::Properties::channels() const
+int Ogg::Vorbis::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int Ogg::Vorbis::Properties::vorbisVersion() const
+int Ogg::Vorbis::AudioProperties::vorbisVersion() const
 {
   return d->vorbisVersion;
 }
 
-int Ogg::Vorbis::Properties::bitrateMaximum() const
+int Ogg::Vorbis::AudioProperties::bitrateMaximum() const
 {
   return d->bitrateMaximum;
 }
 
-int Ogg::Vorbis::Properties::bitrateNominal() const
+int Ogg::Vorbis::AudioProperties::bitrateNominal() const
 {
   return d->bitrateNominal;
 }
 
-int Ogg::Vorbis::Properties::bitrateMinimum() const
+int Ogg::Vorbis::AudioProperties::bitrateMinimum() const
 {
   return d->bitrateMinimum;
 }
 
-String Ogg::Vorbis::Properties::toString() const
+String Ogg::Vorbis::AudioProperties::toString() const
 {
   StringList desc;
   desc.append("Ogg Vorbis audio (version " + String::number(vorbisVersion()) + ")");
@@ -136,7 +137,7 @@ String Ogg::Vorbis::Properties::toString() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void Ogg::Vorbis::Properties::read()
+void Ogg::Vorbis::AudioProperties::read()
 {
   // Get the identification header from the Ogg implementation.
 

--- a/taglib/ogg/vorbis/vorbisproperties.h
+++ b/taglib/ogg/vorbis/vorbisproperties.h
@@ -44,19 +44,19 @@ namespace TagLib {
      * API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
        * Create an instance of Vorbis::Properties with the data read from the
        * Vorbis::File \a file.
        */
-      Properties(File *file, ReadStyle style = Average);
+      AudioProperties(File *file, ReadStyle style = Average);
 
       /*!
        * Destroys this VorbisProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -90,8 +90,8 @@ namespace TagLib {
       int bitrateMinimum() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void read();
 

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -50,7 +50,7 @@ public:
     delete tag;
   }
 
-  Properties *properties;
+  AudioProperties *properties;
   ID3v2::Tag *tag;
   ByteVector tagChunkID;
 };
@@ -60,7 +60,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 RIFF::AIFF::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, BigEndian)
+                       AudioProperties::ReadStyle propertiesStyle) : RIFF::File(file, BigEndian)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -68,7 +68,7 @@ RIFF::AIFF::File::File(FileName file, bool readProperties,
 }
 
 RIFF::AIFF::File::File(IOStream *stream, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(stream, BigEndian)
+                       AudioProperties::ReadStyle propertiesStyle) : RIFF::File(stream, BigEndian)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -101,7 +101,7 @@ PropertyMap RIFF::AIFF::File::setProperties(const PropertyMap &properties)
 }
 
 
-RIFF::AIFF::Properties *RIFF::AIFF::File::audioProperties() const
+RIFF::AIFF::AudioProperties *RIFF::AIFF::File::audioProperties() const
 {
   return d->properties;
 }
@@ -127,7 +127,7 @@ bool RIFF::AIFF::File::save()
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void RIFF::AIFF::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   for(uint i = 0; i < chunkCount(); i++) {
     if(chunkName(i) == "ID3 " || chunkName(i) == "id3 ") {
@@ -135,7 +135,7 @@ void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertie
       d->tag = new ID3v2::Tag(this, chunkOffset(i));
     }
     else if(chunkName(i) == "COMM" && readProperties)
-      d->properties = new Properties(chunkData(i), propertiesStyle);
+      d->properties = new AudioProperties(chunkData(i), propertiesStyle);
   }
 
   if(!d->tag)

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -63,7 +63,7 @@ namespace TagLib {
          * false, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Contructs an AIFF file from \a file.  If \a readProperties is true the
@@ -74,7 +74,7 @@ namespace TagLib {
          * responsible for deleting it after the File object.
          */
         File(IOStream *stream, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Destroys this instance of the File.
@@ -104,7 +104,7 @@ namespace TagLib {
          * Returns the AIFF::Properties for this file.  If no audio properties
          * were read then this will return a null pointer.
          */
-        virtual Properties *audioProperties() const;
+        virtual AudioProperties *audioProperties() const;
 
         /*!
          * Saves the file.
@@ -115,7 +115,7 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
 
         class FilePrivate;
         FilePrivate *d;

--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -29,7 +29,7 @@
 
 using namespace TagLib;
 
-class RIFF::AIFF::Properties::PropertiesPrivate
+class RIFF::AIFF::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate() :
@@ -55,43 +55,48 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::AIFF::Properties::Properties(const ByteVector &data, ReadStyle style) : AudioProperties(style)
+RIFF::AIFF::AudioProperties::AudioProperties(const ByteVector &data, ReadStyle style) 
+  : TagLib::AudioProperties(style)
+  , d(new PropertiesPrivate())
 {
-  d = new PropertiesPrivate;
   read(data);
 }
 
-RIFF::AIFF::Properties::~Properties()
+RIFF::AIFF::AudioProperties::~AudioProperties()
 {
-  delete d;
 }
 
-int RIFF::AIFF::Properties::length() const
+bool RIFF::AIFF::AudioProperties::isNull() const
+{
+  return (static_cast<bool>(d));
+}
+
+int RIFF::AIFF::AudioProperties::length() const
 {
   return d->length;
 }
 
-int RIFF::AIFF::Properties::bitrate() const
+int RIFF::AIFF::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int RIFF::AIFF::Properties::sampleRate() const
+int RIFF::AIFF::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int RIFF::AIFF::Properties::channels() const
+int RIFF::AIFF::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int RIFF::AIFF::Properties::sampleWidth() const
+int RIFF::AIFF::AudioProperties::sampleWidth() const
 {
   return d->sampleWidth;
 }
 
-TagLib::uint RIFF::AIFF::Properties::sampleFrames() const
+TagLib::uint RIFF::AIFF::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
@@ -100,7 +105,7 @@ TagLib::uint RIFF::AIFF::Properties::sampleFrames() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void RIFF::AIFF::Properties::read(const ByteVector &data)
+void RIFF::AIFF::AudioProperties::read(const ByteVector &data)
 {
   d->channels       = data.toInt16BE(0);
   d->sampleFrames   = data.toUInt32BE(2);

--- a/taglib/riff/aiff/aiffproperties.h
+++ b/taglib/riff/aiff/aiffproperties.h
@@ -43,19 +43,21 @@ namespace TagLib {
        * API.
        */
 
-      class TAGLIB_EXPORT Properties : public AudioProperties
+      class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
       {
       public:
         /*!
-         * Create an instance of AIFF::Properties with the data read from the
-         * ByteVector \a data.
+         * Create an instance of AIFF::AudioProperties with the data read from 
+         * the ByteVector \a data.
          */
-        Properties(const ByteVector &data, ReadStyle style);
+        AudioProperties(const ByteVector &data, ReadStyle style);
 
         /*!
-         * Destroys this AIFF::Properties instance.
+         * Destroys this AIFF::AudioProperties instance.
          */
-        virtual ~Properties();
+        virtual ~AudioProperties();
+
+        virtual bool isNull() const;
 
         // Reimplementations.
 
@@ -68,13 +70,10 @@ namespace TagLib {
         uint sampleFrames() const;
 
       private:
-        Properties(const Properties &);
-        Properties &operator=(const Properties &);
-
         void read(const ByteVector &data);
 
         class PropertiesPrivate;
-        PropertiesPrivate *d;
+        TAGLIB_SHARED_PTR<PropertiesPrivate> d;
       };
     }
   }

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -54,7 +54,7 @@ public:
     delete properties;
   }
 
-  Properties *properties;
+  AudioProperties *properties;
   
   ByteVector tagChunkID;
 
@@ -66,7 +66,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 RIFF::WAV::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, LittleEndian)
+                       AudioProperties::ReadStyle propertiesStyle) : RIFF::File(file, LittleEndian)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -74,7 +74,7 @@ RIFF::WAV::File::File(FileName file, bool readProperties,
 }
 
 RIFF::WAV::File::File(IOStream *stream, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(stream, LittleEndian)
+                       AudioProperties::ReadStyle propertiesStyle) : RIFF::File(stream, LittleEndian)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -116,7 +116,7 @@ PropertyMap RIFF::WAV::File::setProperties(const PropertyMap &properties)
   return tag()->setProperties(properties);
 }
 
-RIFF::WAV::Properties *RIFF::WAV::File::audioProperties() const
+RIFF::WAV::AudioProperties *RIFF::WAV::File::audioProperties() const
 {
   return d->properties;
 }
@@ -165,7 +165,7 @@ bool RIFF::WAV::File::save(TagTypes tags, bool stripOthers, int id3v2Version)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void RIFF::WAV::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void RIFF::WAV::File::read(bool readProperties, AudioProperties::ReadStyle propertiesStyle)
 {
   ByteVector formatData;
   uint streamLength = 0;
@@ -195,7 +195,7 @@ void RIFF::WAV::File::read(bool readProperties, Properties::ReadStyle properties
     d->tag.set(InfoIndex, new RIFF::Info::Tag);
 
   if(!formatData.isEmpty())
-    d->properties = new Properties(formatData, streamLength, propertiesStyle);
+    d->properties = new AudioProperties(formatData, streamLength, propertiesStyle);
 }
 
 void RIFF::WAV::File::strip(TagTypes tags)

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -75,7 +75,7 @@ namespace TagLib {
          * false, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Contructs an WAV file from \a file.  If \a readProperties is true the
@@ -86,7 +86,7 @@ namespace TagLib {
          * responsible for deleting it after the File object.
          */
         File(IOStream *stream, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Destroys this instance of the File.
@@ -129,7 +129,7 @@ namespace TagLib {
          * Returns the WAV::Properties for this file.  If no audio properties
          * were read then this will return a null pointer.
          */
-        virtual Properties *audioProperties() const;
+        virtual AudioProperties *audioProperties() const;
 
         /*!
          * Saves the file.
@@ -142,7 +142,7 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
 
         void strip(TagTypes tags);
 

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -32,7 +32,7 @@
 
 using namespace TagLib;
 
-class RIFF::WAV::Properties::PropertiesPrivate
+class RIFF::WAV::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(uint streamLength = 0) :
@@ -62,49 +62,51 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::WAV::Properties::Properties(const ByteVector &data, ReadStyle style) : AudioProperties(style)
+RIFF::WAV::AudioProperties::AudioProperties(const ByteVector &data, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate();
   read(data);
 }
 
-RIFF::WAV::Properties::Properties(const ByteVector &data, uint streamLength, ReadStyle style) : AudioProperties(style)
+RIFF::WAV::AudioProperties::AudioProperties(const ByteVector &data, uint streamLength, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(streamLength);
   read(data);
 }
 
-RIFF::WAV::Properties::~Properties()
+RIFF::WAV::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int RIFF::WAV::Properties::length() const
+int RIFF::WAV::AudioProperties::length() const
 {
   return d->length;
 }
 
-int RIFF::WAV::Properties::bitrate() const
+int RIFF::WAV::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int RIFF::WAV::Properties::sampleRate() const
+int RIFF::WAV::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int RIFF::WAV::Properties::channels() const
+int RIFF::WAV::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int RIFF::WAV::Properties::sampleWidth() const
+int RIFF::WAV::AudioProperties::sampleWidth() const
 {
   return d->sampleWidth;
 }
 
-TagLib::uint RIFF::WAV::Properties::sampleFrames() const
+TagLib::uint RIFF::WAV::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
@@ -113,7 +115,7 @@ TagLib::uint RIFF::WAV::Properties::sampleFrames() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void RIFF::WAV::Properties::read(const ByteVector &data)
+void RIFF::WAV::AudioProperties::read(const ByteVector &data)
 {
   d->format      = data.toInt16LE(0);
   d->channels    = data.toInt16LE(2);

--- a/taglib/riff/wav/wavproperties.h
+++ b/taglib/riff/wav/wavproperties.h
@@ -46,25 +46,25 @@ namespace TagLib {
        * API.
        */
 
-      class TAGLIB_EXPORT Properties : public AudioProperties
+      class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
       {
       public:
         /*!
-         * Create an instance of WAV::Properties with the data read from the
-         * ByteVector \a data.
+         * Create an instance of WAV::AudioProperties with the data read from 
+         * the ByteVector \a data.
          */
-        Properties(const ByteVector &data, ReadStyle style);
+        AudioProperties(const ByteVector &data, ReadStyle style);
 
         /*!
          * Create an instance of WAV::Properties with the data read from the
          * ByteVector \a data and the length calculated using \a streamLength.
          */
-        Properties(const ByteVector &data, uint streamLength, ReadStyle style);
+        AudioProperties(const ByteVector &data, uint streamLength, ReadStyle style);
 
         /*!
-         * Destroys this WAV::Properties instance.
+         * Destroys this WAV::AudioProperties instance.
          */
-        virtual ~Properties();
+        virtual ~AudioProperties();
 
         // Reimplementations.
 
@@ -77,8 +77,8 @@ namespace TagLib {
         uint sampleFrames() const;
 
       private:
-        Properties(const Properties &);
-        Properties &operator=(const Properties &);
+        AudioProperties(const AudioProperties &);
+        AudioProperties &operator=(const AudioProperties &);
 
         void read(const ByteVector &data);
 

--- a/taglib/s3m/s3mfile.cpp
+++ b/taglib/s3m/s3mfile.cpp
@@ -39,7 +39,7 @@ public:
   }
 
   Mod::Tag        tag;
-  S3M::Properties properties;
+  S3M::AudioProperties properties;
 };
 
 S3M::File::File(FileName file, bool readProperties,
@@ -70,7 +70,7 @@ Mod::Tag *S3M::File::tag() const
   return &d->tag;
 }
 
-S3M::Properties *S3M::File::audioProperties() const
+S3M::AudioProperties *S3M::File::audioProperties() const
 {
   return &d->properties;
 }

--- a/taglib/s3m/s3mfile.h
+++ b/taglib/s3m/s3mfile.h
@@ -67,7 +67,7 @@ namespace TagLib {
          * Returns the S3M::Properties for this file. If no audio properties
          * were read then this will return a null pointer.
          */
-        S3M::Properties *audioProperties() const;
+        S3M::AudioProperties *audioProperties() const;
 
         /*!
          * Save the file.

--- a/taglib/s3m/s3mproperties.cpp
+++ b/taglib/s3m/s3mproperties.cpp
@@ -24,7 +24,7 @@
 using namespace TagLib;
 using namespace S3M;
 
-class S3M::Properties::PropertiesPrivate
+class S3M::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate() :
@@ -57,148 +57,148 @@ public:
   uchar  bpmSpeed;
 };
 
-S3M::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
-  AudioProperties(propertiesStyle),
-  d(new PropertiesPrivate)
+S3M::AudioProperties::AudioProperties(AudioProperties::ReadStyle propertiesStyle)
+  : TagLib::AudioProperties(propertiesStyle)
+  , d(new PropertiesPrivate)
 {
 }
 
-S3M::Properties::~Properties()
+S3M::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int S3M::Properties::length() const
+int S3M::AudioProperties::length() const
 {
   return 0;
 }
 
-int S3M::Properties::bitrate() const
+int S3M::AudioProperties::bitrate() const
 {
   return 0;
 }
 
-int S3M::Properties::sampleRate() const
+int S3M::AudioProperties::sampleRate() const
 {
   return 0;
 }
 
-int S3M::Properties::channels() const
+int S3M::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-TagLib::ushort S3M::Properties::lengthInPatterns() const
+TagLib::ushort S3M::AudioProperties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
 
-bool S3M::Properties::stereo() const
+bool S3M::AudioProperties::stereo() const
 {
   return d->stereo;
 }
 
-TagLib::ushort S3M::Properties::sampleCount() const
+TagLib::ushort S3M::AudioProperties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-TagLib::ushort S3M::Properties::patternCount() const
+TagLib::ushort S3M::AudioProperties::patternCount() const
 {
   return d->patternCount;
 }
 
-TagLib::ushort S3M::Properties::flags() const
+TagLib::ushort S3M::AudioProperties::flags() const
 {
   return d->flags;
 }
 
-TagLib::ushort S3M::Properties::trackerVersion() const
+TagLib::ushort S3M::AudioProperties::trackerVersion() const
 {
   return d->trackerVersion;
 }
 
-TagLib::ushort S3M::Properties::fileFormatVersion() const
+TagLib::ushort S3M::AudioProperties::fileFormatVersion() const
 {
   return d->fileFormatVersion;
 }
 
-uchar S3M::Properties::globalVolume() const
+uchar S3M::AudioProperties::globalVolume() const
 {
   return d->globalVolume;
 }
 
-uchar S3M::Properties::masterVolume() const
+uchar S3M::AudioProperties::masterVolume() const
 {
   return d->masterVolume;
 }
 
-uchar S3M::Properties::tempo() const
+uchar S3M::AudioProperties::tempo() const
 {
   return d->tempo;
 }
 
-uchar S3M::Properties::bpmSpeed() const
+uchar S3M::AudioProperties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }
 
-void S3M::Properties::setLengthInPatterns(ushort lengthInPatterns)
+void S3M::AudioProperties::setLengthInPatterns(ushort lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }
 
-void S3M::Properties::setChannels(int channels)
+void S3M::AudioProperties::setChannels(int channels)
 {
   d->channels = channels;
 }
 
-void S3M::Properties::setStereo(bool stereo)
+void S3M::AudioProperties::setStereo(bool stereo)
 {
   d->stereo = stereo;
 }
 
-void S3M::Properties::setSampleCount(ushort sampleCount)
+void S3M::AudioProperties::setSampleCount(ushort sampleCount)
 {
   d->sampleCount = sampleCount;
 }
 
-void S3M::Properties::setPatternCount(ushort patternCount)
+void S3M::AudioProperties::setPatternCount(ushort patternCount)
 {
   d->patternCount = patternCount;
 }
 
-void S3M::Properties::setFlags(ushort flags)
+void S3M::AudioProperties::setFlags(ushort flags)
 {
   d->flags = flags;
 }
 
-void S3M::Properties::setTrackerVersion(ushort trackerVersion)
+void S3M::AudioProperties::setTrackerVersion(ushort trackerVersion)
 {
   d->trackerVersion = trackerVersion;
 }
 
-void S3M::Properties::setFileFormatVersion(ushort fileFormatVersion)
+void S3M::AudioProperties::setFileFormatVersion(ushort fileFormatVersion)
 {
   d->fileFormatVersion = fileFormatVersion;
 }
 
-void S3M::Properties::setGlobalVolume(uchar globalVolume)
+void S3M::AudioProperties::setGlobalVolume(uchar globalVolume)
 {
   d->globalVolume = globalVolume;
 }
 
-void S3M::Properties::setMasterVolume(uchar masterVolume)
+void S3M::AudioProperties::setMasterVolume(uchar masterVolume)
 {
   d->masterVolume = masterVolume;
 }
 
-void S3M::Properties::setTempo(uchar tempo)
+void S3M::AudioProperties::setTempo(uchar tempo)
 {
   d->tempo = tempo;
 }
 
-void S3M::Properties::setBpmSpeed(uchar bpmSpeed)
+void S3M::AudioProperties::setBpmSpeed(uchar bpmSpeed)
 {
   d->bpmSpeed = bpmSpeed;
 }

--- a/taglib/s3m/s3mproperties.h
+++ b/taglib/s3m/s3mproperties.h
@@ -27,7 +27,7 @@
 
 namespace TagLib {
   namespace S3M {
-    class TAGLIB_EXPORT Properties : public AudioProperties {
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties {
       friend class File;
     public:
       /*! Flag bits. */
@@ -41,8 +41,8 @@ namespace TagLib {
         CustomData           = 128
       };
 
-      Properties(AudioProperties::ReadStyle propertiesStyle);
-      virtual ~Properties();
+      AudioProperties(AudioProperties::ReadStyle propertiesStyle);
+      virtual ~AudioProperties();
 
       int length()     const;
       int bitrate()    const;
@@ -76,8 +76,8 @@ namespace TagLib {
       void setBpmSpeed         (uchar bpmSpeed);
 
     private:
-      Properties(const Properties&);
-      Properties &operator=(const Properties&);
+      AudioProperties(const AudioProperties&);
+      AudioProperties &operator=(const AudioProperties&);
 
       class PropertiesPrivate;
       PropertiesPrivate *d;

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -71,7 +71,7 @@ public:
 
   TagUnion tag;
 
-  Properties *properties;
+  AudioProperties *properties;
 
   // These indicate whether the file *on disk* has these tags, not if
   // this data structure does.  This is used in computing offsets.
@@ -85,7 +85,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 TrueAudio::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                 AudioProperties::ReadStyle propertiesStyle) : TagLib::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -93,7 +93,7 @@ TrueAudio::File::File(FileName file, bool readProperties,
 }
 
 TrueAudio::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
+                 bool readProperties, AudioProperties::ReadStyle propertiesStyle) :
   TagLib::File(file)
 {
   d = new FilePrivate(frameFactory);
@@ -102,7 +102,7 @@ TrueAudio::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
 }
 
 TrueAudio::File::File(IOStream *stream, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(stream)
+                 AudioProperties::ReadStyle propertiesStyle) : TagLib::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -110,7 +110,7 @@ TrueAudio::File::File(IOStream *stream, bool readProperties,
 }
 
 TrueAudio::File::File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
+                 bool readProperties, AudioProperties::ReadStyle propertiesStyle) :
   TagLib::File(stream)
 {
   d = new FilePrivate(frameFactory);
@@ -135,7 +135,7 @@ PropertyMap TrueAudio::File::setProperties(const PropertyMap &properties)
   return d->tag.access<ID3v2::Tag>(TrueAudioID3v2Index, true)->setProperties(properties);
 }
 
-TrueAudio::Properties *TrueAudio::File::audioProperties() const
+TrueAudio::AudioProperties *TrueAudio::File::audioProperties() const
 {
   return d->properties;
 }
@@ -224,7 +224,7 @@ void TrueAudio::File::strip(int tags)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void TrueAudio::File::read(bool readProperties, Properties::ReadStyle /* propertiesStyle */)
+void TrueAudio::File::read(bool readProperties, AudioProperties::ReadStyle /* propertiesStyle */)
 {
   // Look for an ID3v2 tag
 
@@ -259,12 +259,12 @@ void TrueAudio::File::read(bool readProperties, Properties::ReadStyle /* propert
   if(readProperties) {
     if(d->ID3v2Location >= 0) {
       seek(d->ID3v2Location + d->ID3v2OriginalSize);
-      d->properties = new Properties(readBlock(TrueAudio::HeaderSize),
+      d->properties = new AudioProperties(readBlock(TrueAudio::HeaderSize),
                                      length() - d->ID3v2OriginalSize);
     }
     else {
       seek(0);
-      d->properties = new Properties(readBlock(TrueAudio::HeaderSize),
+      d->properties = new AudioProperties(readBlock(TrueAudio::HeaderSize),
                                      length());
     }
   }

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -84,7 +84,7 @@ namespace TagLib {
        * false, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
@@ -94,7 +94,7 @@ namespace TagLib {
        */
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
@@ -105,7 +105,7 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
@@ -118,7 +118,7 @@ namespace TagLib {
        */
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -141,7 +141,7 @@ namespace TagLib {
        * Returns the TrueAudio::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Set the ID3v2::FrameFactory to something other than the default.
@@ -197,7 +197,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       void scan();
       offset_t findID3v1();
       offset_t findID3v2();

--- a/taglib/trueaudio/trueaudioproperties.cpp
+++ b/taglib/trueaudio/trueaudioproperties.cpp
@@ -36,7 +36,7 @@
 
 using namespace TagLib;
 
-class TrueAudio::Properties::PropertiesPrivate
+class TrueAudio::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(const ByteVector &d, offset_t length, ReadStyle s) :
@@ -67,48 +67,50 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-TrueAudio::Properties::Properties(const ByteVector &data, offset_t streamLength, ReadStyle style) : AudioProperties(style)
+TrueAudio::AudioProperties::AudioProperties(
+    const ByteVector &data, offset_t streamLength, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   d = new PropertiesPrivate(data, streamLength, style);
   read();
 }
 
-TrueAudio::Properties::~Properties()
+TrueAudio::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int TrueAudio::Properties::length() const
+int TrueAudio::AudioProperties::length() const
 {
   return d->length;
 }
 
-int TrueAudio::Properties::bitrate() const
+int TrueAudio::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int TrueAudio::Properties::sampleRate() const
+int TrueAudio::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int TrueAudio::Properties::bitsPerSample() const
+int TrueAudio::AudioProperties::bitsPerSample() const
 {
   return d->bitsPerSample;
 }
 
-int TrueAudio::Properties::channels() const
+int TrueAudio::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-TagLib::uint TrueAudio::Properties::sampleFrames() const
+TagLib::uint TrueAudio::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
 
-int TrueAudio::Properties::ttaVersion() const
+int TrueAudio::AudioProperties::ttaVersion() const
 {
   return d->version;
 }
@@ -117,7 +119,7 @@ int TrueAudio::Properties::ttaVersion() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void TrueAudio::Properties::read()
+void TrueAudio::AudioProperties::read()
 {
   if(!d->data.startsWith("TTA"))
     return;

--- a/taglib/trueaudio/trueaudioproperties.h
+++ b/taglib/trueaudio/trueaudioproperties.h
@@ -47,19 +47,19 @@ namespace TagLib {
      * API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
-       * Create an instance of TrueAudio::Properties with the data read from the
-       * ByteVector \a data.
+       * Create an instance of TrueAudio::AudioProperties with the data read from 
+       * the ByteVector \a data.
        */
-      Properties(const ByteVector &data, offset_t streamLength, ReadStyle style = Average);
+      AudioProperties(const ByteVector &data, offset_t streamLength, ReadStyle style = Average);
 
       /*!
-       * Destroys this TrueAudio::Properties instance.
+       * Destroys this TrueAudio::AudioProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -84,8 +84,8 @@ namespace TagLib {
       int ttaVersion() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void read();
 

--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -69,7 +69,7 @@ public:
 
   TagUnion tag;
 
-  Properties *properties;
+  AudioProperties *properties;
 
   // These indicate whether the file *on disk* has these tags, not if
   // this data structure does.  This is used in computing offsets.
@@ -83,7 +83,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 WavPack::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                AudioProperties::ReadStyle propertiesStyle) : TagLib::File(file)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -91,7 +91,7 @@ WavPack::File::File(FileName file, bool readProperties,
 }
 
 WavPack::File::File(IOStream *stream, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(stream)
+                AudioProperties::ReadStyle propertiesStyle) : TagLib::File(stream)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -115,7 +115,7 @@ PropertyMap WavPack::File::setProperties(const PropertyMap &properties)
   return d->tag.access<APE::Tag>(WavAPEIndex, true)->setProperties(properties);
 }
 
-WavPack::Properties *WavPack::File::audioProperties() const
+WavPack::AudioProperties *WavPack::File::audioProperties() const
 {
   return d->properties;
 }
@@ -218,7 +218,7 @@ void WavPack::File::strip(int tags)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void WavPack::File::read(bool readProperties, Properties::ReadStyle /* propertiesStyle */)
+void WavPack::File::read(bool readProperties, AudioProperties::ReadStyle /* propertiesStyle */)
 {
   // Look for an ID3v1 tag
 
@@ -247,7 +247,7 @@ void WavPack::File::read(bool readProperties, Properties::ReadStyle /* propertie
 
   if(readProperties) {
     seek(0);
-    d->properties = new Properties(this, length() - d->APESize);
+    d->properties = new AudioProperties(this, length() - d->APESize);
   }
 }
 

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -85,7 +85,7 @@ namespace TagLib {
        * false, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Contructs an WavPack file from \a file.  If \a readProperties is true the
@@ -96,7 +96,7 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
       /*!
        * Destroys this instance of the File.
@@ -120,7 +120,7 @@ namespace TagLib {
        * Returns the MPC::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */
-      virtual Properties *audioProperties() const;
+      virtual AudioProperties *audioProperties() const;
 
       /*!
        * Saves the file.
@@ -168,7 +168,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
       void scan();
       offset_t findID3v1();
       offset_t findAPE();

--- a/taglib/wavpack/wavpackproperties.cpp
+++ b/taglib/wavpack/wavpackproperties.cpp
@@ -35,7 +35,7 @@
 
 using namespace TagLib;
 
-class WavPack::Properties::PropertiesPrivate
+class WavPack::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate(const ByteVector &d, offset_t length, ReadStyle s, File *f) :
@@ -68,49 +68,50 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-WavPack::Properties::Properties(File *file, offset_t streamLength, ReadStyle style) : AudioProperties(style)
+WavPack::AudioProperties::AudioProperties(File *file, offset_t streamLength, ReadStyle style) 
+  : TagLib::AudioProperties(style)
 {
   ByteVector data = file->readBlock(32);
   d = new PropertiesPrivate(data, streamLength, style, file);
   read();
 }
 
-WavPack::Properties::~Properties()
+WavPack::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int WavPack::Properties::length() const
+int WavPack::AudioProperties::length() const
 {
   return d->length;
 }
 
-int WavPack::Properties::bitrate() const
+int WavPack::AudioProperties::bitrate() const
 {
   return d->bitrate;
 }
 
-int WavPack::Properties::sampleRate() const
+int WavPack::AudioProperties::sampleRate() const
 {
   return d->sampleRate;
 }
 
-int WavPack::Properties::channels() const
+int WavPack::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-int WavPack::Properties::version() const
+int WavPack::AudioProperties::version() const
 {
   return d->version;
 }
 
-int WavPack::Properties::bitsPerSample() const
+int WavPack::AudioProperties::bitsPerSample() const
 {
   return d->bitsPerSample;
 }
 
-TagLib::uint WavPack::Properties::sampleFrames() const
+TagLib::uint WavPack::AudioProperties::sampleFrames() const
 {
   return d->sampleFrames;
 }
@@ -136,7 +137,7 @@ static const unsigned int sample_rates[] = { 6000, 8000, 9600, 11025, 12000,
 
 #define FINAL_BLOCK     0x1000
 
-void WavPack::Properties::read()
+void WavPack::AudioProperties::read()
 {
   if(!d->data.startsWith("wvpk"))
     return;
@@ -166,7 +167,7 @@ void WavPack::Properties::read()
   d->bitrate = d->length > 0 ? static_cast<int>(d->streamLength * 8L / d->length / 1000) : 0;
 }
 
-unsigned int WavPack::Properties::seekFinalIndex()
+unsigned int WavPack::AudioProperties::seekFinalIndex()
 {
   ByteVector blockID("wvpk", 4);
 

--- a/taglib/wavpack/wavpackproperties.h
+++ b/taglib/wavpack/wavpackproperties.h
@@ -48,18 +48,18 @@ namespace TagLib {
      * API.
      */
 
-    class TAGLIB_EXPORT Properties : public AudioProperties
+    class TAGLIB_EXPORT AudioProperties : public TagLib::AudioProperties
     {
     public:
       /*!
-       * Create an instance of WavPack::Properties.
+       * Create an instance of WavPack::AudioProperties.
        */
-      Properties(File *file, offset_t streamLength, ReadStyle style = Average);
+      AudioProperties(File *file, offset_t streamLength, ReadStyle style = Average);
 
       /*!
-       * Destroys this WavPack::Properties instance.
+       * Destroys this WavPack::AudioProperties instance.
        */
-      virtual ~Properties();
+      virtual ~AudioProperties();
 
       // Reimplementations.
 
@@ -80,8 +80,8 @@ namespace TagLib {
       int version() const;
 
     private:
-      Properties(const Properties &);
-      Properties &operator=(const Properties &);
+      AudioProperties(const AudioProperties &);
+      AudioProperties &operator=(const AudioProperties &);
 
       void read();
       unsigned int seekFinalIndex();

--- a/taglib/xm/xmfile.cpp
+++ b/taglib/xm/xmfile.cpp
@@ -360,7 +360,7 @@ public:
   }
 
   Mod::Tag       tag;
-  XM::Properties properties;
+  XM::AudioProperties properties;
 };
 
 XM::File::File(FileName file, bool readProperties,
@@ -391,7 +391,7 @@ Mod::Tag *XM::File::tag() const
   return &d->tag;
 }
 
-XM::Properties *XM::File::audioProperties() const
+XM::AudioProperties *XM::File::audioProperties() const
 {
   return &d->properties;
 }

--- a/taglib/xm/xmfile.h
+++ b/taglib/xm/xmfile.h
@@ -67,7 +67,7 @@ namespace TagLib {
          * Returns the XM::Properties for this file. If no audio properties
          * were read then this will return a null pointer.
          */
-        XM::Properties *audioProperties() const;
+        XM::AudioProperties *audioProperties() const;
 
         /*!
          * Save the file.

--- a/taglib/xm/xmproperties.cpp
+++ b/taglib/xm/xmproperties.cpp
@@ -24,7 +24,7 @@
 using namespace TagLib;
 using namespace XM;
 
-class XM::Properties::PropertiesPrivate
+class XM::AudioProperties::PropertiesPrivate
 {
 public:
   PropertiesPrivate() :
@@ -53,128 +53,128 @@ public:
   ushort bpmSpeed;
 };
 
-XM::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :
-  AudioProperties(propertiesStyle),
-  d(new PropertiesPrivate)
+XM::AudioProperties::AudioProperties(AudioProperties::ReadStyle propertiesStyle)
+  : TagLib::AudioProperties(propertiesStyle)
+  , d(new PropertiesPrivate)
 {
 }
 
-XM::Properties::~Properties()
+XM::AudioProperties::~AudioProperties()
 {
   delete d;
 }
 
-int XM::Properties::length() const
+int XM::AudioProperties::length() const
 {
   return 0;
 }
 
-int XM::Properties::bitrate() const
+int XM::AudioProperties::bitrate() const
 {
   return 0;
 }
 
-int XM::Properties::sampleRate() const
+int XM::AudioProperties::sampleRate() const
 {
   return 0;
 }
 
-int XM::Properties::channels() const
+int XM::AudioProperties::channels() const
 {
   return d->channels;
 }
 
-TagLib::ushort XM::Properties::lengthInPatterns() const
+TagLib::ushort XM::AudioProperties::lengthInPatterns() const
 {
   return d->lengthInPatterns;
 }
 
-TagLib::ushort XM::Properties::version() const
+TagLib::ushort XM::AudioProperties::version() const
 {
   return d->version;
 }
 
-TagLib::ushort XM::Properties::restartPosition() const
+TagLib::ushort XM::AudioProperties::restartPosition() const
 {
   return d->restartPosition;
 }
 
-TagLib::ushort XM::Properties::patternCount() const
+TagLib::ushort XM::AudioProperties::patternCount() const
 {
   return d->patternCount;
 }
 
-TagLib::ushort XM::Properties::instrumentCount() const
+TagLib::ushort XM::AudioProperties::instrumentCount() const
 {
   return d->instrumentCount;
 }
 
-TagLib::uint XM::Properties::sampleCount() const
+TagLib::uint XM::AudioProperties::sampleCount() const
 {
   return d->sampleCount;
 }
 
-TagLib::ushort XM::Properties::flags() const
+TagLib::ushort XM::AudioProperties::flags() const
 {
   return d->flags;
 }
 
-TagLib::ushort XM::Properties::tempo() const
+TagLib::ushort XM::AudioProperties::tempo() const
 {
   return d->tempo;
 }
 
-TagLib::ushort XM::Properties::bpmSpeed() const
+TagLib::ushort XM::AudioProperties::bpmSpeed() const
 {
   return d->bpmSpeed;
 }
 
-void XM::Properties::setLengthInPatterns(ushort lengthInPatterns)
+void XM::AudioProperties::setLengthInPatterns(ushort lengthInPatterns)
 {
   d->lengthInPatterns = lengthInPatterns;
 }
 
-void XM::Properties::setChannels(int channels)
+void XM::AudioProperties::setChannels(int channels)
 {
   d->channels = channels;
 }
 
-void XM::Properties::setVersion(ushort version)
+void XM::AudioProperties::setVersion(ushort version)
 {
   d->version = version;
 }
 
-void XM::Properties::setRestartPosition(ushort restartPosition)
+void XM::AudioProperties::setRestartPosition(ushort restartPosition)
 {
   d->restartPosition = restartPosition;
 }
 
-void XM::Properties::setPatternCount(ushort patternCount)
+void XM::AudioProperties::setPatternCount(ushort patternCount)
 {
   d->patternCount = patternCount;
 }
 
-void XM::Properties::setInstrumentCount(ushort instrumentCount)
+void XM::AudioProperties::setInstrumentCount(ushort instrumentCount)
 {
   d->instrumentCount = instrumentCount;
 }
 
-void XM::Properties::setSampleCount(uint sampleCount)
+void XM::AudioProperties::setSampleCount(uint sampleCount)
 {
   d->sampleCount = sampleCount;
 }
 
-void XM::Properties::setFlags(ushort flags)
+void XM::AudioProperties::setFlags(ushort flags)
 {
   d->flags = flags;
 }
 
-void XM::Properties::setTempo(ushort tempo)
+void XM::AudioProperties::setTempo(ushort tempo)
 {
   d->tempo = tempo;
 }
 
-void XM::Properties::setBpmSpeed(ushort bpmSpeed)
+void XM::AudioProperties::setBpmSpeed(ushort bpmSpeed)
 {
   d->bpmSpeed = bpmSpeed;
 }

--- a/taglib/xm/xmproperties.h
+++ b/taglib/xm/xmproperties.h
@@ -28,7 +28,7 @@
 
 namespace TagLib {
   namespace XM {
-    class Properties : public AudioProperties {
+    class AudioProperties : public TagLib::AudioProperties {
       friend class File;
     public:
       /*! Flag bits. */
@@ -36,8 +36,8 @@ namespace TagLib {
         LinearFreqTable = 1 // otherwise its the amiga freq. table
       };
 
-      Properties(AudioProperties::ReadStyle propertiesStyle);
-      virtual ~Properties();
+      AudioProperties(AudioProperties::ReadStyle propertiesStyle);
+      virtual ~AudioProperties();
 
       int length()     const;
       int bitrate()    const;
@@ -67,8 +67,8 @@ namespace TagLib {
       void setBpmSpeed(ushort bpmSpeed);
 
     private:
-      Properties(const Properties&);
-      Properties &operator=(const Properties&);
+      AudioProperties(const AudioProperties&);
+      AudioProperties &operator=(const AudioProperties&);
 
       class PropertiesPrivate;
       PropertiesPrivate *d;

--- a/tests/test_it.cpp
+++ b/tests/test_it.cpp
@@ -98,7 +98,7 @@ private:
 
     CPPUNIT_ASSERT(file.isValid());
 
-    IT::Properties *p = file.audioProperties();
+    IT::AudioProperties *p = file.audioProperties();
     Mod::Tag *t = file.tag();
 
     CPPUNIT_ASSERT(0 != p);

--- a/tests/test_mod.cpp
+++ b/tests/test_mod.cpp
@@ -100,7 +100,7 @@ private:
 
     CPPUNIT_ASSERT(file.isValid());
 
-    Mod::Properties *p = file.audioProperties();
+    Mod::AudioProperties *p = file.audioProperties();
     Mod::Tag *t = file.tag();
 
     CPPUNIT_ASSERT(0 != p);

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -38,7 +38,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(3, f.audioProperties()->bitrate());
     CPPUNIT_ASSERT_EQUAL(2, f.audioProperties()->channels());
     CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
-    CPPUNIT_ASSERT_EQUAL(16, ((MP4::Properties *)f.audioProperties())->bitsPerSample());
+    CPPUNIT_ASSERT_EQUAL(16, ((MP4::AudioProperties *)f.audioProperties())->bitsPerSample());
   }
 
   void testPropertiesALAC()
@@ -48,7 +48,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(2, f.audioProperties()->bitrate());
     CPPUNIT_ASSERT_EQUAL(2, f.audioProperties()->channels());
     CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
-    CPPUNIT_ASSERT_EQUAL(16, ((MP4::Properties *)f.audioProperties())->bitsPerSample());
+    CPPUNIT_ASSERT_EQUAL(16, ((MP4::AudioProperties *)f.audioProperties())->bitsPerSample());
   }
 
   void testCheckValid()

--- a/tests/test_opus.cpp
+++ b/tests/test_opus.cpp
@@ -26,7 +26,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->bitrate());
     CPPUNIT_ASSERT_EQUAL(1, f.audioProperties()->channels());
     CPPUNIT_ASSERT_EQUAL(48000, f.audioProperties()->sampleRate());
-    CPPUNIT_ASSERT_EQUAL(48000, ((Ogg::Opus::Properties *)f.audioProperties())->inputSampleRate());
+    CPPUNIT_ASSERT_EQUAL(48000, ((Ogg::Opus::AudioProperties *)f.audioProperties())->inputSampleRate());
   }
 
   void testReadComments()

--- a/tests/test_s3m.cpp
+++ b/tests/test_s3m.cpp
@@ -88,7 +88,7 @@ private:
 
     CPPUNIT_ASSERT(file.isValid());
 
-    S3M::Properties *p = file.audioProperties();
+    S3M::AudioProperties *p = file.audioProperties();
     Mod::Tag *t = file.tag();
 
     CPPUNIT_ASSERT(0 != p);

--- a/tests/test_wavpack.cpp
+++ b/tests/test_wavpack.cpp
@@ -21,7 +21,7 @@ public:
   void testBasic()
   {
     WavPack::File f(TEST_FILE_PATH_C("no_length.wv"));
-    WavPack::Properties *props = f.audioProperties();
+    WavPack::AudioProperties *props = f.audioProperties();
     CPPUNIT_ASSERT_EQUAL(44100, props->sampleRate());
     CPPUNIT_ASSERT_EQUAL(2, props->channels());
     CPPUNIT_ASSERT_EQUAL(1, props->bitrate());
@@ -31,7 +31,7 @@ public:
   void testLengthScan()
   {
     WavPack::File f(TEST_FILE_PATH_C("no_length.wv"));
-    WavPack::Properties *props = f.audioProperties();
+    WavPack::AudioProperties *props = f.audioProperties();
     CPPUNIT_ASSERT_EQUAL(4, props->length());
   }
 

--- a/tests/test_xm.cpp
+++ b/tests/test_xm.cpp
@@ -120,7 +120,7 @@ public:
     XM::File file(TEST_FILE_PATH_C("stripped.xm"));
     CPPUNIT_ASSERT(file.isValid());
 
-    XM::Properties *p = file.audioProperties();
+    XM::AudioProperties *p = file.audioProperties();
     Mod::Tag *t = file.tag();
 
     CPPUNIT_ASSERT(0 != p);
@@ -166,7 +166,7 @@ private:
 
     CPPUNIT_ASSERT(file.isValid());
 
-    XM::Properties *p = file.audioProperties();
+    XM::AudioProperties *p = file.audioProperties();
     Mod::Tag *t = file.tag();
 
     CPPUNIT_ASSERT(0 != p);


### PR DESCRIPTION
Currently, the term "properties" is used for two things in taglib2 branch: tag contents and audio properties. It's a little confusing so I changed the names of the classes derived from AudioProperties from "Properties" to "AudioProperties".
But I think it's better to give a distinctive name to either of them. For example, change `PropertyMap File::properties();` into `TagContentsMap File::tagContents();`
