### PR TITLE
Fixed the test for ID3V2's compressed frame

### DIFF
--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <stdio.h>
+#include <config.h>
 // so evil :(
 #define protected public
 #include <id3v2tag.h>
@@ -15,6 +16,7 @@
 #include <popularimeterframe.h>
 #include <urllinkframe.h>
 #include <ownershipframe.h>
+#include <unknownframe.h>
 #include <tdebug.h>
 #include <tpropertymap.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -580,13 +582,27 @@ public:
   {
     MPEG::File f(TEST_FILE_PATH_C("compressed_id3_frame.mp3"), false);
     CPPUNIT_ASSERT(f.ID3v2Tag()->frameListMap().contains("APIC"));
-    ID3v2::AttachedPictureFrame *frame =
-        static_cast<TagLib::ID3v2::AttachedPictureFrame*>(f.ID3v2Tag()->frameListMap()["APIC"].front());
+
+#ifdef HAVE_ZLIB
+
+    ID3v2::AttachedPictureFrame *frame 
+      = dynamic_cast<TagLib::ID3v2::AttachedPictureFrame*>(f.ID3v2Tag()->frameListMap()["APIC"].front());
     CPPUNIT_ASSERT(frame);
     CPPUNIT_ASSERT_EQUAL(String("image/bmp"), frame->mimeType());
     CPPUNIT_ASSERT_EQUAL(ID3v2::AttachedPictureFrame::Other, frame->type());
     CPPUNIT_ASSERT_EQUAL(String(""), frame->description());
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(86414), frame->picture().size());
+
+#else
+
+    // Skip the test if ZLIB is not installed.
+    // The message "Compressed frames are currently not supported." will be displayed.
+
+    ID3v2::UnknownFrame *frame 
+      = dynamic_cast<TagLib::ID3v2::UnknownFrame*>(f.ID3v2Tag()->frameListMap()["APIC"].front());
+    CPPUNIT_ASSERT(frame);
+
+#endif
   }
   
   void testW000()


### PR DESCRIPTION
Fixed the test for ID3V2's compressed frame which fails if ZLIB is missing.
