### PR TITLE
Interface change of List::find() and contains()

### DIFF
--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -204,17 +204,20 @@ namespace TagLib {
     /*!
      * Find the first occurrence of \a value.
      */
-    Iterator find(const T &value);
+    template <class U>
+    Iterator find(const U &value);
 
     /*!
      * Find the first occurrence of \a value.
      */
-    ConstIterator find(const T &value) const;
+    template <class U>
+    ConstIterator find(const U &value) const;
 
     /*!
      * Returns true if the list contains \a value.
      */
-    bool contains(const T &value) const;
+    template <class U>
+    bool contains(const U &value) const;
 
     /*!
      * Erase the item at \a it from the list.

--- a/taglib/toolkit/tlist.tcc
+++ b/taglib/toolkit/tlist.tcc
@@ -281,19 +281,22 @@ bool List<T>::isEmpty() const
 }
 
 template <class T>
-typename List<T>::Iterator List<T>::find(const T &value)
+template <class U>
+typename List<T>::Iterator List<T>::find(const U &value)
 {
   return std::find(d->list.begin(), d->list.end(), value);
 }
 
 template <class T>
-typename List<T>::ConstIterator List<T>::find(const T &value) const
+template <class U>
+typename List<T>::ConstIterator List<T>::find(const U &value) const
 {
   return std::find(d->list.begin(), d->list.end(), value);
 }
 
 template <class T>
-bool List<T>::contains(const T &value) const
+template <class U>
+bool List<T>::contains(const U &value) const
 {
   return std::find(d->list.begin(), d->list.end(), value) != d->list.end();
 }


### PR DESCRIPTION
`List<T>::find()` and `contains()` now take a parameter of any type comparable to T just like `std::find()`.
