### PR TITLE
Added Matroska to FileRef

### DIFF
--- a/taglib/ebml/matroska/ebmlmatroskaaudio.cpp
+++ b/taglib/ebml/matroska/ebmlmatroskaaudio.cpp
@@ -46,7 +46,7 @@ public:
     if(info && (value = info->getChild(Constants::Duration))) {
       length = static_cast<int>(value->getAsFloat() / 1000000000.L);
       if((value = info->getChild(Constants::TimecodeScale)))
-        length *= value->getAsUnsigned();
+        length *= static_cast<int>(value->getAsUnsigned());
       else
         length *= 1000000;
     }

--- a/taglib/ebml/matroska/ebmlmatroskafile.h
+++ b/taglib/ebml/matroska/ebmlmatroskafile.h
@@ -28,6 +28,7 @@
 #define TAGLIB_EBMLMATROSKAFILE_H
 
 #include "ebmlelement.h"
+#include "audioproperties.h"
 
 namespace TagLib {
   
@@ -49,12 +50,14 @@ namespace TagLib {
         /*!
          * Constructs a Matroska File from a file name.
          */
-        File(FileName file);
+        File(FileName file, bool readProperties = true,
+             AudioProperties::ReadStyle readStyle = AudioProperties::Average);
         
         /*!
          *  Constructs a Matroska File from a stream.
          */
-        File(IOStream *stream);
+        File(IOStream *stream, bool readProperties = true,
+             AudioProperties::ReadStyle readStyle = AudioProperties::Average);
         
         /*!
          * Returns the pointer to a tag that allow access on common tags.

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -56,6 +56,7 @@
 #include "s3mfile.h"
 #include "itfile.h"
 #include "xmfile.h"
+#include "ebmlmatroskafile.h"
 
 using namespace TagLib;
 
@@ -150,6 +151,8 @@ namespace
         file.reset(new IT::File(fileName, readAudioProperties, audioPropertiesStyle));
       else if(ext == "XM")
         file.reset(new XM::File(fileName, readAudioProperties, audioPropertiesStyle));
+      else if(ext == "MKA")
+        file.reset(new EBML::Matroska::File(fileName, readAudioProperties, audioPropertiesStyle));
     }
 
     return file;

--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -27,6 +27,7 @@ class TestFileRef : public CppUnit::TestFixture
   CPPUNIT_TEST(testTrueAudio);
   CPPUNIT_TEST(testAPE);
   CPPUNIT_TEST(testWav);
+  CPPUNIT_TEST(testMatroska);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -37,7 +38,6 @@ public:
     string newname = copy.fileName();
 
     FileRef *f = new FileRef(newname.c_str());
-    CPPUNIT_ASSERT(f->isValid());
     CPPUNIT_ASSERT(!f->isNull());
     f->tag()->setArtist("test artist");
     f->tag()->setTitle("test title");
@@ -49,7 +49,6 @@ public:
     delete f;
 
     f = new FileRef(newname.c_str());
-    CPPUNIT_ASSERT(f->isValid());
     CPPUNIT_ASSERT(!f->isNull());
     CPPUNIT_ASSERT_EQUAL(f->tag()->artist(), String("test artist"));
     CPPUNIT_ASSERT_EQUAL(f->tag()->title(), String("test title"));
@@ -67,7 +66,6 @@ public:
     delete f;
 
     f = new FileRef(newname.c_str());
-    CPPUNIT_ASSERT(f->isValid());
     CPPUNIT_ASSERT(!f->isNull());
     CPPUNIT_ASSERT_EQUAL(f->tag()->artist(), String("ttest artist"));
     CPPUNIT_ASSERT_EQUAL(f->tag()->title(), String("ytest title"));
@@ -76,27 +74,6 @@ public:
     CPPUNIT_ASSERT_EQUAL(f->tag()->track(), TagLib::uint(7));
     CPPUNIT_ASSERT_EQUAL(f->tag()->year(), TagLib::uint(2080));
     delete f;
-
-    f = new FileRef(newname.c_str());
-    CPPUNIT_ASSERT(f->isValid());
-    CPPUNIT_ASSERT(!f->isNull());
-    PropertyMap prop = f->properties();
-    CPPUNIT_ASSERT_EQUAL(prop["ARTIST"].front(), String("ttest artist"));
-    CPPUNIT_ASSERT_EQUAL(prop["TITLE" ].front(), String("ytest title"));
-    prop["ARTIST"].front() = "a test artist";
-    prop["TITLE" ].front() = "b test title";
-    f->setProperties(prop);
-    f->save();
-    delete f;
-    
-    f = new FileRef(newname.c_str());
-    CPPUNIT_ASSERT(f->isValid());
-    CPPUNIT_ASSERT(!f->isNull());
-    prop = f->properties();
-    CPPUNIT_ASSERT_EQUAL(prop["ARTIST"].front(), String("a test artist"));
-    CPPUNIT_ASSERT_EQUAL(prop["TITLE" ].front(), String("b test title"));
-    delete f;
-    
   }
 
   void testMusepack()
@@ -171,6 +148,11 @@ public:
   void testAPE()
   {
     fileRefSave("mac-399", ".ape");
+  }
+  
+  void testMatroska()
+  {
+    fileRefSave("matroska", ".mka");
   }
 };
 


### PR DESCRIPTION
This is just a note for @Rachus. Don't merge this.

I tried to add `EBML::Matroska::File` class to `FileRef` and add a test to `test_fileref.cpp`, but it didn't pass. There seems to be some bugs there.

`Tag` class is defined inside `File` class. I think that it's better to separate them just like other classes do.
