### PR TITLE
Windows build fails on master (due to RefCounter not being exported)

### DIFF
--- a/taglib/toolkit/trefcounter.h
+++ b/taglib/toolkit/trefcounter.h
@@ -26,6 +26,7 @@
 #ifndef TAGLIB_REFCOUNTER_H
 #define TAGLIB_REFCOUNTER_H
 
+#include "taglib_export.h"
 #include "taglib.h"
 
 #ifndef DO_NOT_DOCUMENT // Tell Doxygen to skip this class.
@@ -37,7 +38,7 @@
   */
 namespace TagLib
 {
-  class RefCounter
+  class TAGLIB_EXPORT RefCounter
   {
   public:
     RefCounter();


### PR DESCRIPTION
The recent addition (taglib/taglib@7c64b1966a764ef) of `RefCounter` has broken Windows builds, because the symbols are not being exported.

I just added the `TAGLIB_EXPORT` macro and build started working.

```
Linking CXX shared library tag_c.dll
   Creating library tag_c.lib and object tag_c.exp
tag_c.cpp.obj : error LNK2019: unresolved external symbol "public: __thiscall TagLib::RefCounter::RefCounter(void)" (??0RefCounter@TagLib@@QAE@XZ) referenced in function "public: __thiscall TagLib::ListPrivateBase::ListPrivateBase(void)" (??0ListPrivateBase@TagLib@@QAE@XZ)
tag_c.cpp.obj : error LNK2019: unresolved external symbol "public: virtual __thiscall TagLib::RefCounter::~RefCounter(void)" (??1RefCounter@TagLib@@UAE@XZ) referenced in function "public: virtual __thiscall TagLib::ListPrivateBase::~ListPrivateBase(void)" (??1ListPrivateBase@TagLib@@UAE@XZ)
tag_c.cpp.obj : error LNK2019: unresolved external symbol "public: bool __thiscall TagLib::RefCounter::deref(void)" (?deref@RefCounter@TagLib@@QAE_NXZ) referenced in function "public: virtual __thiscall TagLib::List<char *>::~List<char *>(void)" (??1?$List@PAD@TagLib@@UAE@XZ)
tag_c.cpp.obj : error LNK2019: unresolved external symbol "public: int __thiscall TagLib::RefCounter::count(void)const " (?count@RefCounter@TagLib@@QBEHXZ) referenced in function "protected: void __thiscall TagLib::List<char *>::detach(void)" (?detach@?$List@PAD@TagLib@@IAEXXZ)
tag_c.dll : fatal error LNK1120: 4 unresolved externals
LINK Pass 1 failed. with 1120
jom: C:\Code\Qt\taglib-debug\bindings\c\CMakeFiles\tag_c.dir\build.make [bindings\c\tag_c.dll] Error 2
jom: C:\Code\Qt\taglib-debug\CMakeFiles\Makefile2 [bindings\c\CMakeFiles\tag_c.dir\all] Error 2
jom: C:\Code\Qt\taglib-debug\Makefile [all] Error 2
14:01:09: The process "C:\Qt\qtcreator-2.7.1\bin\jom.exe" exited with code 2.
Error while building/deploying project taglib (kit: Desktop)
When executing step 'Make'
```
