### PR TITLE
Fixed shlwapi.h and shlwapi.lib detection for MSVC

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -219,7 +219,7 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-if(WIN32)
+if(WIN32 AND NOT MSVC)
   find_package(SHLWAPI)
   if(SHLWAPI_FOUND)
     set(HAVE_SHLWAPI 1)

--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -30,7 +30,7 @@ if(ZLIB_FOUND)
   include_directories(${ZLIB_INCLUDE_DIR})
 endif()
 
-if(SHLWAPI_FOUND)
+if(NOT MSVC AND SHLWAPI_FOUND)
   include_directories(${SHLWAPI_INCLUDE_DIR})
 endif()
 
@@ -315,8 +315,12 @@ if(ZLIB_FOUND)
 	target_link_libraries(tag ${ZLIB_LIBRARIES})
 endif()
 
-if(SHLWAPI_FOUND)
-  target_link_libraries(tag ${SHLWAPI_LIBRARIES})
+if(MSVC)
+  target_link_libraries(tag shlwapi.lib)
+else()
+  if(SHLWAPI_FOUND)
+    target_link_libraries(tag ${SHLWAPI_LIBRARIES})
+  endif()
 endif()
 
 set_target_properties(tag PROPERTIES


### PR DESCRIPTION
Fixed shlwapi.h and shlwapi.lib detection for MSVC. See #220.
