### PR TITLE
Fixed comments for File constructors

### DIFF
--- a/taglib/ape/apefile.h
+++ b/taglib/ape/apefile.h
@@ -59,7 +59,7 @@ namespace TagLib {
     //! An implementation of TagLib::File with APE specific methods
 
     /*!
-     * This implements and provides an interface APE WavPack files to the
+     * This implements and provides an interface for APE files to the
      * TagLib::Tag and TagLib::AudioProperties interfaces by way of implementing
      * the abstract TagLib::File API as well as providing some additional
      * information specific to APE files.
@@ -84,20 +84,22 @@ namespace TagLib {
       };
 
       /*!
-       * Contructs an WavPack file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an APE file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an WavPack file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an APE file from \a stream.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/asf/asffile.h
+++ b/taglib/asf/asffile.h
@@ -48,22 +48,16 @@ namespace TagLib {
     public:
 
       /*!
-       * Contructs an ASF file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an ASF file from \a file.
        *
        * \note In the current implementation, both \a readProperties and
        * \a propertiesStyle are ignored.
-       *
-       * \note TagLib will *not* take ownership of the stream, the caller is
-       * responsible for deleting it after the File object.
        */
-      File(FileName file, bool readProperties = true, Properties::ReadStyle propertiesStyle = Properties::Average);
+      File(FileName file, bool readProperties = true, 
+           Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an ASF file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an ASF file from \a stream.
        *
        * \note In the current implementation, both \a readProperties and
        * \a propertiesStyle are ignored.
@@ -71,7 +65,8 @@ namespace TagLib {
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        */
-      File(IOStream *stream, bool readProperties = true, Properties::ReadStyle propertiesStyle = Properties::Average);
+      File(IOStream *stream, bool readProperties = true, 
+           Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
        * Destroys this instance of the File.

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -67,9 +67,10 @@ namespace TagLib {
     {
     public:
       /*!
-       * Contructs a FLAC file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs a FLAC file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        *
        * \deprecated This constructor will be dropped in favor of the one below
        * in a future version.
@@ -78,12 +79,13 @@ namespace TagLib {
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs a FLAC file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an APE file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
        * If this file contains and ID3v2 tag the frames will be created using
        * \a frameFactory.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       // BIC: merge with the above constructor
       File(FileName file, ID3v2::FrameFactory *frameFactory,
@@ -91,15 +93,16 @@ namespace TagLib {
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs a FLAC file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs a FLAC file from \a stream.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * \note TagLib will *not* take ownership of the stream, the caller is
+       * responsible for deleting it after the File object.
        *
        * If this file contains and ID3v2 tag the frames will be created using
        * \a frameFactory.
        *
-       * \note TagLib will *not* take ownership of the stream, the caller is
-       * responsible for deleting it after the File object.
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       // BIC: merge with the above constructor
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,

--- a/taglib/it/itfile.h
+++ b/taglib/it/itfile.h
@@ -36,23 +36,25 @@ namespace TagLib {
     class TAGLIB_EXPORT File : public Mod::FileBase {
       public:
         /*!
-         * Contructs a Impulse Tracker file from \a file. If \a readProperties
-         * is true the file's audio properties will also be read using
-         * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+         * Constructs a Impulse Tracker file from \a file.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.
          */
         File(FileName file, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
              AudioProperties::Average);
 
         /*!
-         * Contructs a Impulse Tracker file from \a stream. If \a readProperties
-         * is true the file's audio properties will also be read using
-         * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+         * Constructs a Impulse Tracker file from \a stream.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.
          */
-        File(IOStream *stram, bool readProperties = true,
+        File(IOStream *stream, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
              AudioProperties::Average);
 

--- a/taglib/mod/modfile.h
+++ b/taglib/mod/modfile.h
@@ -37,18 +37,20 @@ namespace TagLib {
     {
     public:
       /*!
-       * Contructs a Protracker file from \a file. If \a readProperties
-       * is true the file's audio properties will also be read using
-       * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+       * Constructs a Protracker file from \a file.
+       *
+       * \note In the current implementation, both \a readProperties and
+       * \a propertiesStyle are ignored.
        */
       File(FileName file, bool readProperties = true,
            AudioProperties::ReadStyle propertiesStyle =
            AudioProperties::Average);
 
       /*!
-       * Contructs a Protracker file from \a stream. If \a readProperties
-       * is true the file's audio properties will also be read using
-       * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+       * Constructs a Protracker file from \a stream.
+       *
+       * \note In the current implementation, both \a readProperties and
+       * \a propertiesStyle are ignored.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -49,27 +49,25 @@ namespace TagLib {
     {
     public:
       /*!
-       * Contructs a MP4 file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an MP4 file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
-       * \note In the current implementation, both \a readProperties and
-       * \a propertiesStyle are ignored.
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true, Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+      File(FileName file, bool readProperties = true, 
+           Properties::ReadStyle audioPropertiesStyle = Properties::Average);
 
       /*!
-       * Contructs a MP4 file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
-       *
-       * \note In the current implementation, both \a readProperties and
-       * \a propertiesStyle are ignored.
+       * Constructs an MP4 file from \a stream.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      File(IOStream *stream, bool readProperties = true, Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+      File(IOStream *stream, bool readProperties = true, 
+           Properties::ReadStyle audioPropertiesStyle = Properties::Average);
 
       /*!
        * Destroys this instance of the File.

--- a/taglib/mpc/mpcfile.h
+++ b/taglib/mpc/mpcfile.h
@@ -84,20 +84,22 @@ namespace TagLib {
       };
 
       /*!
-       * Contructs an MPC file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an MPC file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an MPC file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an MPC file from \a stream.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -71,9 +71,10 @@ namespace TagLib {
       };
 
       /*!
-       * Contructs an MPEG file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs an MPEG file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        *
        * \deprecated This constructor will be dropped in favor of the one below
        * in a future version.
@@ -82,28 +83,31 @@ namespace TagLib {
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an MPEG file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.  The frames will be created using
+       * Constructs an MPEG file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * If this file contains and ID3v2 tag the frames will be created using
        * \a frameFactory.
        *
-       * \deprecated This constructor will be dropped in favor of the one below
-       * in a future version.
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
+      // BIC: merge with the above constructor
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an MPEG file from \a stream.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.  The frames will be created using
-       * \a frameFactory.
+       * Constructs an MPEG file from \a stream.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * If this file contains and ID3v2 tag the frames will be created using
+       * \a frameFactory.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      // BIC: merge with the above constructor
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/ogg/flac/oggflacfile.h
+++ b/taglib/ogg/flac/oggflacfile.h
@@ -64,20 +64,22 @@ namespace TagLib {
     {
     public:
       /*!
-       * Contructs an Ogg/FLAC file from \a file.  If \a readProperties is true
-       * the file's audio properties will also be read using \a propertiesStyle.
-       * If false, \a propertiesStyle is ignored.
+       * Constructs an Ogg/FLAC file from \a file.  If \a readProperties is true 
+       * the file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an Ogg/FLAC file from \a file.  If \a readProperties is true
-       * the file's audio properties will also be read using \a propertiesStyle.
-       * If false, \a propertiesStyle is ignored.
+       * Constructs an Ogg/FLAC file from \a stream.  If \a readProperties is true 
+       * the file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/ogg/opus/opusfile.h
+++ b/taglib/ogg/opus/opusfile.h
@@ -56,20 +56,22 @@ namespace TagLib {
       {
       public:
         /*!
-         * Contructs a Opus file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs an Opus file from \a file.  If \a readProperties is true the
+         * file's audio properties will also be read.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!
-         * Contructs a Opus file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs an Opus file from \a stream.  If \a readProperties is true the
+         * file's audio properties will also be read.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(IOStream *stream, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/ogg/speex/speexfile.h
+++ b/taglib/ogg/speex/speexfile.h
@@ -56,20 +56,22 @@ namespace TagLib {
       {
       public:
         /*!
-         * Contructs a Speex file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs a Speex file from \a file.  If \a readProperties is true the
+         * file's audio properties will also be read.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!
-         * Contructs a Speex file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs a Speex file from \a stream.  If \a readProperties is true the
+         * file's audio properties will also be read.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(IOStream *stream, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/ogg/vorbis/vorbisfile.h
+++ b/taglib/ogg/vorbis/vorbisfile.h
@@ -63,20 +63,22 @@ namespace TagLib {
     {
     public:
       /*!
-       * Contructs a Vorbis file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs a Vorbis file from \a file.  If \a readProperties is true the
+       * file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs a Vorbis file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs a Vorbis file from \a stream.  If \a readProperties is true the
+       * file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -58,20 +58,22 @@ namespace TagLib {
       {
       public:
         /*!
-         * Contructs an AIFF file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs an AIFF file from \a file.  If \a readProperties is true the
+         * file's audio properties will also be read.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!
-         * Contructs an AIFF file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs an AIFF file from \a stream.  If \a readProperties is true the
+         * file's audio properties will also be read.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(IOStream *stream, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -70,20 +70,22 @@ namespace TagLib {
         };
 
         /*!
-         * Contructs an WAV file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs a WAV file from \a file.  If \a readProperties is true the
+         * file's audio properties will also be read.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);
 
         /*!
-         * Contructs an WAV file from \a file.  If \a readProperties is true the
-         * file's audio properties will also be read using \a propertiesStyle.  If
-         * false, \a propertiesStyle is ignored.
+         * Constructs a WAV file from \a stream.  If \a readProperties is true the
+         * file's audio properties will also be read.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.
+         *
+         * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(IOStream *stream, bool readProperties = true,
              Properties::ReadStyle propertiesStyle = Properties::Average);

--- a/taglib/s3m/s3mfile.h
+++ b/taglib/s3m/s3mfile.h
@@ -36,18 +36,20 @@ namespace TagLib {
     class TAGLIB_EXPORT File : public Mod::FileBase {
       public:
         /*!
-         * Contructs a ScreamTracker III file from \a file. If \a readProperties
-         * is true the file's audio properties will also be read using
-         * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+         * Constructs a ScreamTracker III from \a file.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.
          */
         File(FileName file, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
              AudioProperties::Average);
 
         /*!
-         * Contructs a ScreamTracker III file from \a stream. If \a readProperties
-         * is true the file's audio properties will also be read using
-         * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+         * Constructs a ScreamTracker III file from \a stream.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -79,42 +79,50 @@ namespace TagLib {
       };
 
       /*!
-       * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
+       * the file's audio properties will also be read.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored. The frames will be created using
+       * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
+       * the file's audio properties will also be read.
+       *
+       * If this file contains and ID3v2 tag the frames will be created using
        * \a frameFactory.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * Constructs a TrueAudio file from \a stream.  If \a readProperties is true
+       * the file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an TrueAudio file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored. The frames will be created using
-       * \a frameFactory.
+       * Constructs a TrueAudio file from \a stream.  If \a readProperties is true 
+       * the file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
+       *
+       * If this file contains and ID3v2 tag the frames will be created using
+       * \a frameFactory.
+       *
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -80,15 +80,16 @@ namespace TagLib {
       };
 
       /*!
-       * Contructs an WavPack file from \a file.  If \a readProperties is true the
+       * Constructs a WavPack file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read using \a propertiesStyle.  If
-       * false, \a propertiesStyle is ignored.
+       * false, \a propertiesStyle is ignored
        */
+
       File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Contructs an WavPack file from \a file.  If \a readProperties is true the
+       * Constructs an WavPack file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read using \a propertiesStyle.  If
        * false, \a propertiesStyle is ignored.
        *

--- a/taglib/xm/xmfile.h
+++ b/taglib/xm/xmfile.h
@@ -36,18 +36,20 @@ namespace TagLib {
     class TAGLIB_EXPORT File : public Mod::FileBase {
       public:
         /*!
-         * Contructs a Extended Module file from \a file. If \a readProperties
-         * is true the file's audio properties will also be read using
-         * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+         * Constructs an Extended Module file from \a file.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.
          */
         File(FileName file, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
              AudioProperties::Average);
 
         /*!
-         * Contructs a Extended Module file from \a stream. If \a readProperties
-         * is true the file's audio properties will also be read using
-         * \a propertiesStyle. If false, \a propertiesStyle is ignored.
+         * Constructs an Extended Module file from \a stream.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.
          *
          * \note TagLib will *not* take ownership of the stream, the caller is
          * responsible for deleting it after the File object.


### PR DESCRIPTION
Fixed parameter names, spellings and confusing descriptions. 
