### PR TITLE
Fixed compilation error with GCC4.2

### DIFF
--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -69,9 +69,9 @@ using namespace TagLib;
 namespace
 {
 #ifdef _WIN32
-  const uint BufferSize = 8192;
+  const TagLib::uint BufferSize = 8192;
 #else
-  const uint BufferSize = 1024;
+  const TagLib::uint BufferSize = 1024;
 #endif
 }
 


### PR DESCRIPTION
Fixed an ambiguity between `TagLib::uint` and `uint`.
