### PR TITLE
Fixed compilation error with GCC4.2

### DIFF
--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -45,7 +45,7 @@ namespace
   typedef FileName FileNameHandle;
   typedef HANDLE FileHandle;
 
-  const uint BufferSize = 8192;
+  const TagLib::uint BufferSize = 8192;
   const FileHandle InvalidFileHandle = INVALID_HANDLE_VALUE;
 
   inline FileHandle openFile(const FileName &path, bool readOnly)
@@ -122,7 +122,7 @@ namespace
 
   typedef FILE* FileHandle;
 
-  const uint BufferSize = 8192;
+  const TagLib::uint BufferSize = 8192;
   const FileHandle InvalidFileHandle = 0;
 
   inline FileHandle openFile(const FileName &path, bool readOnly)


### PR DESCRIPTION
Fixed an ambiguity between `TagLib::uint` and `uint`.
