### PR TITLE
Output debug messages to the debugger rather than stderr in Win32

### DIFF
--- a/taglib/toolkit/tdebug.h
+++ b/taglib/toolkit/tdebug.h
@@ -29,14 +29,14 @@
 namespace TagLib {
 
   class String;
-  class ByteVector;
 
 #ifndef DO_NOT_DOCUMENT
 #ifndef NDEBUG
 
   /*!
-   * A simple function that prints debugging output to cerr if debugging is
-   * not disabled.
+   * A simple function that prints debugging output if debugging is enabled.
+   *
+   * \note In Win32, the message is sent to the debugger. Otherwise, stderr. 
    *
    * \warning Do not use this outside of TagLib, it could lead to undefined
    * symbols in your build if TagLib is built with NDEBUG defined and your
@@ -46,23 +46,11 @@ namespace TagLib {
    */
   void debug(const String &s);
 
-  /*!
-   * For debugging binary data.
-   *
-   * \warning Do not use this outside of TagLib, it could lead to undefined
-   * symbols in your build if TagLib is built with NDEBUG defined and your
-   * application is not.
-   *
-   * \internal
-   */
-  void debugData(const ByteVector &v);
-
 #else
 
   // Define these to an empty statement if debugging is disabled.
 
 #define debug(x)
-#define debugData(x)
 
 #endif
 #endif


### PR DESCRIPTION
This patch changes the behavior of `debug()` function in Win32 environment. It outputs the messages through the Windows' built-in debugging environments rather than `stderr`.
In Windows, `stderr` is having trouble handling unicode strings. This patch mainly aims to print Unicode paths correctly.

This patch doesn't affect non-Windows environment.

This alters the behavior of TagLib in Win32, so I want to ask Windows users whether it is acceptable.
