### PR TITLE
Enabled debug() to display non-Latin1 characters in Windows

### DIFF
--- a/taglib/toolkit/tdebug.cpp
+++ b/taglib/toolkit/tdebug.cpp
@@ -42,12 +42,13 @@ namespace
 {
   std::string unicodeToAnsi(const String &s) 
   {
-    const int len = WideCharToMultiByte(CP_ACP, 0, s.toWString().c_str(), -1, NULL, 0, NULL, NULL);
+    const wstring wstr = s.toWString();
+    const int len = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, NULL, 0, NULL, NULL);
     if(len == 0)
       return std::string();
 
     std::string str(len, '\0');
-    WideCharToMultiByte(CP_ACP, 0, s.toWString().c_str(), -1, &str[0], len, NULL, NULL);
+    WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &str[0], len, NULL, NULL);
 
     return str;
   }


### PR DESCRIPTION
I made another workaround for #233.

Unlike #233, `debug()` still uses `stderr`. It converts a Unicode string into the Windows' local code page before outputting to `stderr`.

Strictly saying, it cannot cover all Unicode strings. For example, if there is a string like this: `日本語 & 한국어.mp3` (it consists of Japanese, Korean and Latin-1 characters), it won't be displayed correctly in any environment.
However, perhaps it's enough for debugging for most users.
