### PR TITLE
fixed the unit test builds failure

### DIFF
--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -239,8 +239,8 @@ public:
     map["HÄÖ"] = String("bla");
     FLAC::File f(copy.fileName().c_str());
     PropertyMap invalid = f.setProperties(map);
-    CPPUNIT_ASSERT_EQUAL(uint(1), invalid.size());
-    CPPUNIT_ASSERT_EQUAL(uint(0), f.properties().size());
+    CPPUNIT_ASSERT_EQUAL(TagLib::uint(1), invalid.size());
+    CPPUNIT_ASSERT_EQUAL(TagLib::uint(0), f.properties().size());
   }
 
 };


### PR DESCRIPTION
fixed the following build error

/home/uchida/src/taglib/tests/test_flac.cpp: In member function ‘void TestFLAC::testInvalid()’:
/home/uchida/src/taglib/tests/test_flac.cpp:242: error: reference to ‘uint’ is ambiguous
/usr/include/sys/types.h:153: error: candidates are: typedef unsigned int uint
/home/uchida/src/taglib/tests/../taglib/toolkit/taglib.h:66: error:                 typedef unsigned int TagLib::uint
/home/uchida/src/taglib/tests/test_flac.cpp:242: error: reference to ‘uint’ is ambiguous
/usr/include/sys/types.h:153: error: candidates are: typedef unsigned int uint
/home/uchida/src/taglib/tests/../taglib/toolkit/taglib.h:66: error:                 typedef unsigned int TagLib::uint
/home/uchida/src/taglib/tests/test_flac.cpp:243: error: reference to ‘uint’ is ambiguous
/usr/include/sys/types.h:153: error: candidates are: typedef unsigned int uint
/home/uchida/src/taglib/tests/../taglib/toolkit/taglib.h:66: error:                 typedef unsigned int TagLib::uint
/home/uchida/src/taglib/tests/test_flac.cpp:243: error: reference to ‘uint’ is ambiguous
/usr/include/sys/types.h:153: error: candidates are: typedef unsigned int uint
/home/uchida/src/taglib/tests/../taglib/toolkit/taglib.h:66: error:                 typedef unsigned int TagLib::uint
