### PR TITLE
Fixed some MSVC specific warnings

### DIFF
--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -36,23 +36,31 @@
 namespace TagLib {
 
 #ifdef _WIN32
+
   class TAGLIB_EXPORT FileName
   {
   public:
+    FileName();
     FileName(const wchar_t *name);
     FileName(const char *name);
-
     FileName(const FileName &name);
+
+    ~FileName();
+
+    FileName &operator=(const FileName &name);
 
     const std::wstring &wstr() const;
     const std::string  &str() const; 
-
+    
   private:
-    const std::string  m_name;
-    const std::wstring m_wname;
+    class FileNamePrivate;
+    FileNamePrivate *d;
   };
+
 #else
+
   typedef const char *FileName;
+
 #endif
 
   //! An abstract class that provides operations on a sequence of bytes


### PR DESCRIPTION
Stopped exporting `std::string` and `std::wstring` directly.
Equivalent to the pull request #222.
