### PR TITLE
Silence non-virtual destructor warning.

### DIFF
--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -106,6 +106,7 @@ namespace TagLib {
                                bool readAudioProperties = true,
                                AudioProperties::ReadStyle
                                audioPropertiesStyle = AudioProperties::Average) const = 0;
+      virtual ~FileTypeResolver();
     };
 
     /*!


### PR DESCRIPTION
After staring at the warning and a bit of reading I realized it didn't have a destructor at all, I added one and it silenced the warning ...

I have no clue as to the repercussions ... I leave that to those of greater skills then I.

-Enjoy
fh : )_~
