### PR TITLE
Removed the risk of new/delete across binary boundaries in FLAC::File

### DIFF
--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -46,7 +46,7 @@ namespace TagLib {
   /*!
    * This is implementation of FLAC metadata for non-Ogg FLAC files.  At some
    * point when Ogg / FLAC is more common there will be a similar implementation
-   * under the Ogg hiearchy.
+   * under the Ogg hierarchy.
    *
    * This supports ID3v1, ID3v2 and Xiph style comments as well as reading stream
    * properties from the file.
@@ -190,23 +190,27 @@ namespace TagLib {
       List<Picture *> pictureList();
 
       /*!
-       * Removes an attached picture. If \a del is true the picture's memory
-       * will be freed; if it is false, it must be deleted by the user.
+       * Adds a new picture based on \a data to the file and returns a pointer 
+       * to the new picture.
+       *
+       * \note The picture is owned by the FLAC::File and should not be deleted 
+       * by the user.  It will be deleted when the file (object) is destroyed.
+       *
+       * \note The file will be saved only after calling save().
+       *
+       * \see FLAC::Picture::Picture()
        */
-      void removePicture(Picture *picture, bool del = true);
+      Picture *addPicture(const ByteVector &data = ByteVector::null);
+
+      /*!
+       * Removes an attached picture. The picture's memory will be freed.
+       */
+      void removePicture(Picture *picture);
 
       /*!
        * Remove all attached images.
        */
       void removePictures();
-
-      /*!
-       * Add a new picture to the file. The file takes ownership of the
-       * picture and will handle freeing its memory.
-       *
-       * \note The file will be saved only after calling save().
-       */
-      void addPicture(Picture *picture);
 
     private:
       File(const File &);

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -80,7 +80,7 @@ public:
     List<FLAC::Picture *> lst = f->pictureList();
     CPPUNIT_ASSERT_EQUAL(size_t(1), lst.size());
 
-    FLAC::Picture *newpic = new FLAC::Picture();
+    FLAC::Picture *newpic = f->addPicture();
     newpic->setType(FLAC::Picture::BackCover);
     newpic->setWidth(5);
     newpic->setHeight(6);
@@ -89,7 +89,6 @@ public:
     newpic->setMimeType("image/jpeg");
     newpic->setDescription("new image");
     newpic->setData("JPEG data");
-    f->addPicture(newpic);
     f->save();
 
     f = new FLAC::File(newname.c_str());
@@ -126,7 +125,8 @@ public:
     List<FLAC::Picture *> lst = f->pictureList();
     CPPUNIT_ASSERT_EQUAL(size_t(1), lst.size());
 
-    FLAC::Picture *newpic = new FLAC::Picture();
+    f->removePictures();
+    FLAC::Picture *newpic = f->addPicture();
     newpic->setType(FLAC::Picture::BackCover);
     newpic->setWidth(5);
     newpic->setHeight(6);
@@ -135,8 +135,6 @@ public:
     newpic->setMimeType("image/jpeg");
     newpic->setDescription("new image");
     newpic->setData("JPEG data");
-    f->removePictures();
-    f->addPicture(newpic);
     f->save();
 
     f = new FLAC::File(newname.c_str());


### PR DESCRIPTION
Currently, `FLAC::File::addPicture()` accepts a `FLAC::Picture` object created outside TagLib and delete it unless it is removed before the `File` object is destructed. It can lead programs to crash. It is similar to the issue #253.
In order to remove the risk, I have modified `FLAC::File` class always to perform new/delete operations of `FLAC::Picture` internally.

The API is changed a little. Current usage of `FLAC::File::addPicture()` is like this:

```
FLAC::File f(...);
...
FLAC::Picture *newpic = new FLAC::Picture(...);
newpic->setType(FLAC::Picture::BackCover);
...
f.addPicture(newpic);
```

I have changed it like this:

```
FLAC::File f(...);
...
FLAC::Picture *newpic = f.addPicture(...);  // Creates and returns a Picture object.
newpic->setType(FLAC::Picture::BackCover);
```

The concrete examples are shown in `tests/test_flac.cpp`.
