### PR TITLE
Removed an unnecessary method returns StringHandler*.

### DIFF
--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -32,6 +32,12 @@
 using namespace TagLib;
 using namespace ID3v1;
 
+namespace
+{
+  const ID3v1::StringHandler defaultStringHandler;
+  const TagLib::StringHandler *stringHandler = &defaultStringHandler;
+}
+
 class ID3v1::Tag::TagPrivate
 {
 public:
@@ -47,16 +53,7 @@ public:
   String comment;
   uchar track;
   uchar genre;
-
-  static const TagLib::StringHandler *stringHandler;
 };
-
-namespace
-{
-  const ID3v1::StringHandler defaultStringHandler;
-}
-
-const TagLib::StringHandler *ID3v1::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 ////////////////////////////////////////////////////////////////////////////////
 // StringHandler implementation
@@ -107,11 +104,11 @@ ByteVector ID3v1::Tag::render() const
   ByteVector data;
 
   data.append(fileIdentifier());
-  data.append(TagPrivate::stringHandler->render(d->title).resize(30));
-  data.append(TagPrivate::stringHandler->render(d->artist).resize(30));
-  data.append(TagPrivate::stringHandler->render(d->album).resize(30));
-  data.append(TagPrivate::stringHandler->render(d->year).resize(4));
-  data.append(TagPrivate::stringHandler->render(d->comment).resize(28));
+  data.append(stringHandler->render(d->title).resize(30));
+  data.append(stringHandler->render(d->artist).resize(30));
+  data.append(stringHandler->render(d->album).resize(30));
+  data.append(stringHandler->render(d->year).resize(4));
+  data.append(stringHandler->render(d->comment).resize(28));
   data.append(char(0));
   data.append(char(d->track));
   data.append(char(d->genre));
@@ -207,9 +204,9 @@ void ID3v1::Tag::setGenreNumber(TagLib::uint i)
 void ID3v1::Tag::setStringHandler(const TagLib::StringHandler *handler)
 {
   if(handler)
-    TagPrivate::stringHandler = handler;
+    stringHandler = handler;
   else
-    TagPrivate::stringHandler = &defaultStringHandler;
+    stringHandler = &defaultStringHandler;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -235,16 +232,16 @@ void ID3v1::Tag::parse(const ByteVector &data)
 {
   int offset = 3;
 
-  d->title = TagPrivate::stringHandler->parse(data.mid(offset, 30));
+  d->title = stringHandler->parse(data.mid(offset, 30));
   offset += 30;
 
-  d->artist = TagPrivate::stringHandler->parse(data.mid(offset, 30));
+  d->artist = stringHandler->parse(data.mid(offset, 30));
   offset += 30;
 
-  d->album = TagPrivate::stringHandler->parse(data.mid(offset, 30));
+  d->album = stringHandler->parse(data.mid(offset, 30));
   offset += 30;
 
-  d->year = TagPrivate::stringHandler->parse(data.mid(offset, 4));
+  d->year = stringHandler->parse(data.mid(offset, 4));
   offset += 4;
 
   // Check for ID3v1.1 -- Note that ID3v1 *does not* support "track zero" -- this
@@ -255,7 +252,7 @@ void ID3v1::Tag::parse(const ByteVector &data)
   if(data[offset + 28] == 0 && data[offset + 29] != 0) {
     // ID3v1.1 detected
 
-    d->comment = TagPrivate::stringHandler->parse(data.mid(offset, 28));
+    d->comment = stringHandler->parse(data.mid(offset, 28));
     d->track = uchar(data[offset + 29]);
   }
   else

--- a/taglib/mpeg/id3v2/frames/commentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/commentsframe.cpp
@@ -34,6 +34,12 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace TagLib { namespace ID3v2
+{
+  // The instance is defined in id3v2tag.cpp
+  extern const TagLib::StringHandler *latin1StringHandler;
+}}
+
 class CommentsFrame::CommentsFramePrivate
 {
 public:
@@ -159,11 +165,11 @@ void CommentsFrame::parseFields(const ByteVector &data)
 
   if(l.size() == 2) {
     if(d->textEncoding == String::Latin1) {
-      d->description = Tag::latin1StringHandler()->parse(l.front());
-      d->text = Tag::latin1StringHandler()->parse(l.back());
+      d->description = latin1StringHandler->parse(l.front());
+      d->text        = latin1StringHandler->parse(l.back());
     } else {
       d->description = String(l.front(), d->textEncoding);
-      d->text = String(l.back(), d->textEncoding);
+      d->text        = String(l.back(), d->textEncoding);
     }  
   }
 }

--- a/taglib/mpeg/id3v2/frames/ownershipframe.cpp
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.cpp
@@ -31,6 +31,12 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace TagLib { namespace ID3v2
+{
+  // The instance is defined in id3v2tag.cpp
+  extern const TagLib::StringHandler *latin1StringHandler;
+}}
+
 class OwnershipFrame::OwnershipFramePrivate
 {
 public:
@@ -133,7 +139,7 @@ void OwnershipFrame::parseFields(const ByteVector &data)
   
   // Read the seller
   if(d->textEncoding == String::Latin1)
-    d->seller = Tag::latin1StringHandler()->parse(data.mid(pos));
+    d->seller = latin1StringHandler->parse(data.mid(pos));
   else
     d->seller = String(data.mid(pos), d->textEncoding);
 }

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -32,6 +32,12 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace TagLib { namespace ID3v2
+{
+  // The instance is defined in id3v2tag.cpp
+  extern const TagLib::StringHandler *latin1StringHandler;
+}}
+
 class TextIdentificationFrame::TextIdentificationFramePrivate
 {
 public:
@@ -217,7 +223,7 @@ void TextIdentificationFrame::parseFields(const ByteVector &data)
   for(ByteVectorList::Iterator it = l.begin(); it != l.end(); it++) {
     if(!(*it).isEmpty()) {
       if(d->textEncoding == String::Latin1)
-        d->fieldList.append(Tag::latin1StringHandler()->parse(*it));
+        d->fieldList.append(latin1StringHandler->parse(*it));
       else
         d->fieldList.append(String(*it, d->textEncoding));    
     }

--- a/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
@@ -34,6 +34,12 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace TagLib { namespace ID3v2
+{
+  // The instance is defined in id3v2tag.cpp
+  extern const TagLib::StringHandler *latin1StringHandler;
+}}
+
 class UnsynchronizedLyricsFrame::UnsynchronizedLyricsFramePrivate
 {
 public:
@@ -159,11 +165,11 @@ void UnsynchronizedLyricsFrame::parseFields(const ByteVector &data)
 
   if(l.size() == 2) {
     if(d->textEncoding == String::Latin1) {
-      d->description = Tag::latin1StringHandler()->parse(l.front());
-      d->text = Tag::latin1StringHandler()->parse(l.back());
+      d->description = latin1StringHandler->parse(l.front());
+      d->text        = latin1StringHandler->parse(l.back());
     } else {
       d->description = String(l.front(), d->textEncoding);
-      d->text = String(l.back(), d->textEncoding);
+      d->text        = String(l.back(), d->textEncoding);
     }  
   }
 }

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -50,20 +50,11 @@
 using namespace TagLib;
 using namespace ID3v2;
 
-class Frame::FramePrivate
+namespace TagLib { namespace ID3v2
 {
-public:
-  FramePrivate() :
-    header(0)
-    {}
-
-  ~FramePrivate()
-  {
-    delete header;
-  }
-
-  Frame::Header *header;
-};
+  // The instance is defined in id3v2tag.cpp
+  extern const TagLib::StringHandler *latin1StringHandler;
+}}
 
 namespace
 {
@@ -80,6 +71,21 @@ namespace
     return true;
   }
 }
+
+class Frame::FramePrivate
+{
+public:
+  FramePrivate() :
+    header(0)
+    {}
+
+  ~FramePrivate()
+  {
+    delete header;
+  }
+
+  Frame::Header *header;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // static methods
@@ -277,7 +283,7 @@ String Frame::readStringField(const ByteVector &data, String::Type encoding, siz
 
   String str;
   if(encoding == String::Latin1)
-    str = Tag::latin1StringHandler()->parse(data.mid(position, end - position));
+    str = latin1StringHandler->parse(data.mid(position, end - position));
   else
     str = String(data.mid(position, end - position), encoding);
 

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -49,6 +49,16 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace
+{
+  const ID3v2::Latin1StringHandler defaultStringHandler;
+}
+
+namespace TagLib { namespace ID3v2
+{
+  const TagLib::StringHandler *latin1StringHandler = &defaultStringHandler;
+}}
+
 class ID3v2::Tag::TagPrivate
 {
 public:
@@ -80,16 +90,7 @@ public:
 
   FrameListMap frameListMap;
   FrameList frameList;
-
-  static const TagLib::StringHandler *stringHandler;
 };
-
-namespace
-{
-  const ID3v2::Latin1StringHandler defaultStringHandler;
-}
-
-const TagLib::StringHandler *ID3v2::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Latin1StringHandler implementation
@@ -625,17 +626,12 @@ ByteVector ID3v2::Tag::render(int version) const
   return d->header.render() + tagData;
 }
 
-TagLib::StringHandler const *ID3v2::Tag::latin1StringHandler()
-{
-  return TagPrivate::stringHandler;
-}
-
 void ID3v2::Tag::setLatin1StringHandler(const TagLib::StringHandler *handler)
 {
   if(handler)
-    TagPrivate::stringHandler = handler;
+    latin1StringHandler = handler;
   else
-    TagPrivate::stringHandler = &defaultStringHandler;
+    latin1StringHandler = &defaultStringHandler;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -362,14 +362,6 @@ namespace TagLib {
       ByteVector render(int version) const;
       
       /*!
-       * Gets the current string handler that decides how the "Latin-1" data 
-       * will be converted to and from binary data.
-       *
-       * \see Latin1StringHandler
-       */
-      static TagLib::StringHandler const *latin1StringHandler();
-
-      /*!
        * Sets the string handler that decides how the "Latin-1" data will be
        * converted to and from binary data.
        * If the parameter \a handler is null, the previous handler is

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -33,6 +33,12 @@ using namespace RIFF::Info;
 
 namespace 
 {
+  namespace
+  {
+    const RIFF::Info::StringHandler defaultStringHandler;
+    const TagLib::StringHandler *stringHandler = &defaultStringHandler;
+  }
+
   bool isValidChunkID(const ByteVector &name)
   {
     if(name.size() != 4)
@@ -57,13 +63,6 @@ public:
 
   static const TagLib::StringHandler *stringHandler;
 };
-
-namespace
-{
-  const RIFF::Info::StringHandler defaultStringHandler;
-}
-
-const TagLib::StringHandler *RIFF::Info::Tag::TagPrivate::stringHandler = &defaultStringHandler;
 
 ////////////////////////////////////////////////////////////////////////////////
 // StringHandler implementation
@@ -218,7 +217,7 @@ ByteVector RIFF::Info::Tag::render() const
 
   FieldListMap::ConstIterator it = d->fieldListMap.begin();
   for(; it != d->fieldListMap.end(); ++it) {
-    ByteVector text = TagPrivate::stringHandler->render(it->second);
+    ByteVector text = stringHandler->render(it->second);
     if(text.isEmpty())
       continue;
 
@@ -240,9 +239,9 @@ ByteVector RIFF::Info::Tag::render() const
 void RIFF::Info::Tag::setStringHandler(const TagLib::StringHandler *handler)
 {
   if(handler)
-    TagPrivate::stringHandler = handler;
+    stringHandler = handler;
   else
-    TagPrivate::stringHandler = &defaultStringHandler;
+    stringHandler = &defaultStringHandler;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -254,7 +253,7 @@ void RIFF::Info::Tag::parse(const ByteVector &data)
   size_t p = 4;
   while(p < data.size()) {
     const uint size = data.toUInt32LE(p + 4);
-    d->fieldListMap[data.mid(p, 4)] = TagPrivate::stringHandler->parse(data.mid(p + 8, size));
+    d->fieldListMap[data.mid(p, 4)] = stringHandler->parse(data.mid(p + 8, size));
 
     p += ((size + 1) & ~1) + 8;
   }


### PR DESCRIPTION
`ID3V2::Tag` class has the method `latin1StringHandler()` which returns the current `StringHandler`, but it doesn't need to be accessed from outside.
So I removed it and made some refactoring concerning StringHandler.
