### PR TITLE
Introduced runtime byte order detection when SYSTEM_BYTEORDER macro is missing

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -203,16 +203,8 @@ T toNumber(const ByteVector &v, size_t offset, size_t length, bool mostSignifica
 template <class T>
 T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
 {
-#ifdef SYSTEM_BYTEORDER
-# if SYSTEM_BYTEORDER == 1
-  const bool swap = mostSignificantByteFirst;
-# else
-  const bool swap = !mostSignificantByteFirst;
-# endif
-#else
-  static const bool IsBigEndian = isSystemBigEndian();
+  static const bool IsBigEndian = (systemByteOrder() == BigEndian);
   const bool swap = (mostSignificantByteFirst != IsBigEndian);
-#endif
 
   if(offset + sizeof(T) > v.size()) 
     return toNumber<T>(v, offset, v.size() - offset, mostSignificantByteFirst);
@@ -230,16 +222,8 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
 template <class T>
 ByteVector fromNumber(T value, bool mostSignificantByteFirst)
 {
-#ifdef SYSTEM_BYTEORDER
-# if SYSTEM_BYTEORDER == 1
-  const bool swap = mostSignificantByteFirst;
-# else
-  const bool swap = !mostSignificantByteFirst;
-# endif
-#else
-  static const bool IsBigEndian = isSystemBigEndian();
+  static const bool IsBigEndian = (systemByteOrder() == BigEndian);
   const bool swap = (mostSignificantByteFirst != IsBigEndian);
-#endif
  
   const size_t size = sizeof(T);
 

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -839,24 +839,8 @@ void String::copyFromUTF16(const char *s, size_t length, Type t)
   }
 }
 
-#ifdef SYSTEM_BYTEORDER
-
-# if SYSTEM_BYTEORDER == 1
-
-const String::Type String::WCharByteOrder = String::UTF16LE;
-
-# else
-
-const String::Type String::WCharByteOrder = String::UTF16BE;
-
-# endif
-
-#else
-
 const String::Type String::WCharByteOrder 
-  = isSystemBigEndian() ? String::UTF16BE : String::UTF16LE;
-
-#endif
+  = (systemByteOrder() == BigEndian) ? String::UTF16BE : String::UTF16LE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -46,7 +46,6 @@
 
 namespace TagLib
 {
-
   inline ushort byteSwap(ushort x)
   {
 #if defined(HAVE_GCC_BYTESWAP_16)
@@ -144,20 +143,42 @@ namespace TagLib
 #endif
   }
 
-#ifndef SYSTEM_BYTEORDER
 
-  inline bool isSystemBigEndian()
+  enum SystemByteOrder
   {
+    LittleEndian,
+    BigEndian
+  };
+
+  inline SystemByteOrder systemByteOrder()
+  {
+#ifdef SYSTEM_BYTEORDER
+
+# if SYSTEM_BYTEORDER == 1
+
+    return LittleEndian;
+
+# else
+
+    return BigEndian;
+
+# endif
+
+#else
+
     union {
       int  i;
       char c;
     } u;
 
     u.i = 1;
-    return (u.c == 0);
-  }
+    if(u.c == 1)
+      return LittleEndian;
+    else
+      return BigEndian;
 
 #endif
+  }
 };
 
 #endif


### PR DESCRIPTION
Fixed the bug reported in the issue #263.
