### PR TITLE
Introduced the runtime byte order detection when config.h is missing

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -203,6 +203,9 @@ T toNumber(const ByteVector &v, size_t offset, size_t length, bool mostSignifica
 template <class T>
 T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
 {
+  static const bool isBigEndian = (Utils::SystemByteOrder == Utils::BigEndian);
+  const bool swap = (mostSignificantByteFirst != isBigEndian);
+
   if(offset + sizeof(T) > v.size()) 
     return toNumber<T>(v, offset, v.size() - offset, mostSignificantByteFirst);
 
@@ -210,13 +213,8 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
   T tmp;
   ::memcpy(&tmp, v.data() + offset, sizeof(T));
 
-#if SYSTEM_BYTEORDER == 1
-  const bool swap = mostSignificantByteFirst;
-#else
-  const bool swap != mostSignificantByteFirst;
-#endif
   if(swap)
-    return byteSwap(tmp);
+    return Utils::byteSwap(tmp);
   else
     return tmp;
 }
@@ -224,17 +222,13 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
 template <class T>
 ByteVector fromNumber(T value, bool mostSignificantByteFirst)
 {
-  const size_t size = sizeof(T);
+  static const bool isBigEndian = (Utils::SystemByteOrder == Utils::BigEndian);
+  const bool swap = (mostSignificantByteFirst != isBigEndian);
 
-#if SYSTEM_BYTEORDER == 1
-  const bool swap = mostSignificantByteFirst;
-#else
-  const bool swap != mostSignificantByteFirst;
-#endif
- if(swap)
-    value = byteSwap(value);
+  if(swap)
+    value = Utils::byteSwap(value);
 
-  return ByteVector(reinterpret_cast<const char *>(&value), size);
+  return ByteVector(reinterpret_cast<const char *>(&value), sizeof(T));
 }
 
 class DataPrivate : public RefCounter

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -800,7 +800,7 @@ void String::copyFromUTF16(const wchar_t *s, size_t length, Type t)
 
   if(swap) {
     for(size_t i = 0; i < length; ++i)
-      d->data[i] = byteSwap(static_cast<ushort>(s[i]));
+      d->data[i] = Utils::byteSwap(static_cast<ushort>(s[i]));
   }
 }
 
@@ -839,15 +839,8 @@ void String::copyFromUTF16(const char *s, size_t length, Type t)
   }
 }
 
-#if SYSTEM_BYTEORDER == 1
-
-const String::Type String::WCharByteOrder = String::UTF16LE;
-
-#else
-
-const String::Type String::WCharByteOrder = String::UTF16BE;
-
-#endif
+const String::Type String::WCharByteOrder 
+  = (Utils::SystemByteOrder == Utils::BigEndian) ? String::UTF16BE : String::UTF16LE;
 
 }
 

--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -46,105 +46,144 @@
 
 namespace TagLib
 {
-
-  inline ushort byteSwap(ushort x)
+  namespace Utils
   {
+    inline ushort byteSwap(ushort x)
+    {
 #if defined(HAVE_GCC_BYTESWAP_16)
 
-    return __builtin_bswap16(x);
+      return __builtin_bswap16(x);
 
 #elif defined(HAVE_MSC_BYTESWAP)
 
-    return _byteswap_ushort(x);
+      return _byteswap_ushort(x);
 
 #elif defined(HAVE_GLIBC_BYTESWAP)
 
-    return __bswap_16(x);
+      return __bswap_16(x);
 
 #elif defined(HAVE_MAC_BYTESWAP)
 
-    return OSSwapInt16(x);
+      return OSSwapInt16(x);
 
 #elif defined(HAVE_OPENBSD_BYTESWAP)
 
-    return swap16(x);
+      return swap16(x);
 
 #else
 
-    return ((x >> 8) & 0xff) | ((x & 0xff) << 8);
+      return ((x >> 8) & 0xff) | ((x & 0xff) << 8);
 
 #endif
-  }
+    }
 
-  inline uint byteSwap(uint x)
-  {
+    inline uint byteSwap(uint x)
+    {
 #if defined(HAVE_GCC_BYTESWAP_32)
 
-    return __builtin_bswap32(x);
+      return __builtin_bswap32(x);
 
 #elif defined(HAVE_MSC_BYTESWAP)
 
-    return _byteswap_ulong(x);
+      return _byteswap_ulong(x);
 
 #elif defined(HAVE_GLIBC_BYTESWAP)
 
-    return __bswap_32(x);
+      return __bswap_32(x);
 
 #elif defined(HAVE_MAC_BYTESWAP)
 
-    return OSSwapInt32(x);
+      return OSSwapInt32(x);
 
 #elif defined(HAVE_OPENBSD_BYTESWAP)
 
-    return swap32(x);
+      return swap32(x);
 
 #else
 
-    return ((x & 0xff000000u) >> 24)
-      | ((x & 0x00ff0000u) >>  8)
-      | ((x & 0x0000ff00u) <<  8)
-      | ((x & 0x000000ffu) << 24);
+      return ((x & 0xff000000u) >> 24)
+        | ((x & 0x00ff0000u) >>  8)
+        | ((x & 0x0000ff00u) <<  8)
+        | ((x & 0x000000ffu) << 24);
 
 #endif
-  }
+    }
 
-  inline ulonglong byteSwap(ulonglong x)
-  {
+    inline ulonglong byteSwap(ulonglong x)
+    {
 #if defined(HAVE_GCC_BYTESWAP_64)
 
-    return __builtin_bswap64(x);
+      return __builtin_bswap64(x);
 
 #elif defined(HAVE_MSC_BYTESWAP)
 
-    return _byteswap_uint64(x);
+      return _byteswap_uint64(x);
 
 #elif defined(HAVE_GLIBC_BYTESWAP)
 
-    return __bswap_64(x);
+      return __bswap_64(x);
 
 #elif defined(HAVE_MAC_BYTESWAP)
 
-    return OSSwapInt64(x);
+      return OSSwapInt64(x);
 
 #elif defined(HAVE_OPENBSD_BYTESWAP)
 
-    return swap64(x);
+      return swap64(x);
 
 #else
 
-    return ((x & 0xff00000000000000ull) >> 56)
-      | ((x & 0x00ff000000000000ull) >> 40)
-      | ((x & 0x0000ff0000000000ull) >> 24)
-      | ((x & 0x000000ff00000000ull) >> 8)
-      | ((x & 0x00000000ff000000ull) << 8)
-      | ((x & 0x0000000000ff0000ull) << 24)
-      | ((x & 0x000000000000ff00ull) << 40)
-      | ((x & 0x00000000000000ffull) << 56);
+      return ((x & 0xff00000000000000ull) >> 56)
+        | ((x & 0x00ff000000000000ull) >> 40)
+        | ((x & 0x0000ff0000000000ull) >> 24)
+        | ((x & 0x000000ff00000000ull) >> 8)
+        | ((x & 0x00000000ff000000ull) << 8)
+        | ((x & 0x0000000000ff0000ull) << 24)
+        | ((x & 0x000000000000ff00ull) << 40)
+        | ((x & 0x00000000000000ffull) << 56);
+
+#endif
+    }
+
+    enum ByteOrder
+    {
+      LittleEndian,
+      BigEndian
+    };
+
+#ifdef SYSTEM_BYTEORDER
+
+# if SYSTEM_BYTEORDER == 1
+
+    const ByteOrder SystemByteOrder = LittleEndian; 
+
+# else
+
+    const ByteOrder SystemByteOrder = BigEndian; 
+
+# endif
+
+#else
+
+    inline ByteOrder systemByteOrder()
+    {
+      union {
+        int  i;
+        char c;
+      } u;
+
+      u.i = 1;
+      if(u.c == 1)
+        return LittleEndian;
+      else
+        return BigEndian;
+    }
+    
+    const ByteOrder SystemByteOrder = systemByteOrder(); 
 
 #endif
   }
-
-};
+}
 
 #endif
 


### PR DESCRIPTION
Fixed the bug reported in the issue #263.
TagLib assumed that the system is big-endian when `config.h` is missing.

It would take some labor to merge this into the `taglib2` branch, so I'll do it if you adopt this.
