### PR TITLE
Fixed an MSVC specific runtime error only in debug mode

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -156,9 +156,8 @@ int findVector(
   for(size_t i = 0; i < patternSize - 1; ++i)
     lastOccurrence[static_cast<uchar>(*(patternBegin + i))] = patternSize - i - 1;
 
-  for(TIterator it = dataBegin + patternSize - 1 + offset;
-    it < dataEnd;
-    it += lastOccurrence[static_cast<uchar>(*it)])
+  TIterator it = dataBegin + patternSize - 1 + offset;
+  while(true)
   {
     TIterator itBuffer = it;
     TIterator itPattern = patternBegin + patternSize - 1;
@@ -176,6 +175,12 @@ int findVector(
       --itBuffer;
       --itPattern;
     }
+
+    const size_t step = lastOccurrence[static_cast<uchar>(*it)];
+    if(dataEnd - step <= it)
+      break;
+
+    it += step;
   }
 
   return -1;


### PR DESCRIPTION
MSVC does strict bounds checking for iterators in debug mode. TagLib1.8 and current master are sometimes caught by the checks.
I modified `bytevector.cpp` a little in order to pass the checks. 
