### PR TITLE
Added a missing delete to MPEG::Header

### DIFF
--- a/taglib/mpeg/mpegheader.cpp
+++ b/taglib/mpeg/mpegheader.cpp
@@ -89,6 +89,7 @@ MPEG::Header::Header(const Header &h)
 
 MPEG::Header::~Header()
 {
+  delete d;
 }
 
 bool MPEG::Header::isValid() const


### PR DESCRIPTION
Fixed a memory leak reported on the mailing list:
http://mail.kde.org/pipermail/taglib-devel/2013-July/002514.html
