### PR TITLE
Probable fix for http://mail.kde.org/pipermail/taglib-devel/2013-July/00...

### DIFF
--- a/taglib/ebml/matroska/ebmlmatroskafile.cpp
+++ b/taglib/ebml/matroska/ebmlmatroskafile.cpp
@@ -405,7 +405,7 @@ public:
     pm.insert(tagname, StringList(s));
     document->d->tags.append(
       std::pair<PropertyMap, std::pair<Element *, ulli> >(pm,
-        std::pair<Element *, ulli>(0, ttv)
+        std::pair<Element *, ulli>(static_cast<Element *>(0), ttv)
       )
     );
   }


### PR DESCRIPTION
...2516.html

As stated in the mail (http://mail.kde.org/pipermail/taglib-devel/2013-July/002516.html) MSVS doesn't seem to compile ebmlmatroskafile.cpp. Unfortunately I do not have MSVS, therefore I'm unable to check, whether this patch fixed the issue.

A note to the matroska/ebml implementation. As stated in https://github.com/taglib/taglib/pull/217, I wasn't able to debug the code but I could confirm the issue. But since TsudaKageyu suggested to separate the `Tag` from the `File` implementation, I'm thinking about rewriting the whole implementation. Unfortunately I currently do not have much time.
