### PR TITLE
Fixed a wrong default parameter of String

### DIFF
--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -153,7 +153,7 @@ namespace TagLib {
     /*!
      * Makes a deep copy of the data in \a c.
      */
-    String(wchar_t c, Type t = Latin1);
+    String(wchar_t c, Type t = WCharByteOrder);
 
 
     /*!


### PR DESCRIPTION
It's not logical that the default parameter causes an error.
