### PR TITLE
Enabled some File classes to take an ID3v2::FrameFactory parameter

### DIFF
--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -70,32 +70,32 @@ namespace TagLib {
        * Constructs a FLAC file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
-       * If this file contains and ID3v2 tag the frames will be created using
-       * \a frameFactory.
+       * If this file contains an ID3v2 tag the frames will be created using
+       * \a frameFactory.  \a frameFactory needs to be valid until the File 
+       * object is destructed.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      File(FileName file,
-           bool readProperties = true,
+      File(FileName file, bool readProperties = true,
            AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
-           ID3v2::FrameFactory *frameFactory = 0);
+           const ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
        * Constructs a FLAC file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
-       * If this file contains and ID3v2 tag the frames will be created using
-       * \a frameFactory.
+       * If this file contains an ID3v2 tag the frames will be created using
+       * \a frameFactory.  \a frameFactory needs to be valid until the File 
+       * object is destructed.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        */
-      File(IOStream *stream,
-           bool readProperties = true,
+      File(IOStream *stream, bool readProperties = true,
            AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
-           ID3v2::FrameFactory *frameFactory = 0);
+           const ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
        * Destroys this instance of the File.
@@ -194,15 +194,6 @@ namespace TagLib {
       Ogg::XiphComment *xiphComment(bool create = false);
 
       /*!
-       * Set the ID3v2::FrameFactory to something other than the default.  This
-       * can be used to specify the way that ID3v2 frames will be interpreted
-       * when
-       *
-       * \see ID3v2FrameFactory
-       */
-      void setID3v2FrameFactory(const ID3v2::FrameFactory *factory);
-
-      /*!
        * Returns a list of pictures attached to the FLAC file.
        */
       List<Picture *> pictureList();
@@ -251,7 +242,8 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle,
+                const ID3v2::FrameFactory *frameFactory);
       void scan();
       offset_t findID3v2();
       offset_t findID3v1();

--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -77,18 +77,6 @@ FrameFactory *FrameFactory::instance()
   return &factory;
 }
 
-Frame *FrameFactory::createFrame(const ByteVector &data, bool synchSafeInts) const
-{
-  return createFrame(data, uint(synchSafeInts ? 4 : 3));
-}
-
-Frame *FrameFactory::createFrame(const ByteVector &data, uint version) const
-{
-  Header tagHeader;
-  tagHeader.setMajorVersion(version);
-  return createFrame(data, &tagHeader);
-}
-
 Frame *FrameFactory::createFrame(const ByteVector &origData, Header *tagHeader) const
 {
   ByteVector data = origData;
@@ -156,7 +144,7 @@ Frame *FrameFactory::createFrame(const ByteVector &origData, Header *tagHeader) 
 
   frameID = header->frameID();
 
-  // This is where things get necissarily nasty.  Here we determine which
+  // This is where things get necessarily nasty.  Here we determine which
   // Frame subclass (or if none is found simply an Frame) based
   // on the frame ID.  Since there are a lot of possibilities, that means
   // a lot of if blocks.
@@ -277,9 +265,9 @@ void FrameFactory::setDefaultTextEncoding(String::Type encoding)
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
 
-FrameFactory::FrameFactory()
+FrameFactory::FrameFactory() : 
+  d(new FrameFactoryPrivate())
 {
-  d = new FrameFactoryPrivate;
 }
 
 FrameFactory::~FrameFactory()

--- a/taglib/mpeg/id3v2/id3v2framefactory.h
+++ b/taglib/mpeg/id3v2/id3v2framefactory.h
@@ -47,9 +47,9 @@ namespace TagLib {
      * Reimplementing this factory is the key to adding support for frame types
      * not directly supported by TagLib to your application.  To do so you would
      * subclass this factory reimplement createFrame().  Then by setting your
-     * factory to be the default factory in ID3v2::Tag constructor or with
-     * MPEG::File::setID3v2FrameFactory() you can implement behavior that will
-     * allow for new ID3v2::Frame subclasses (also provided by you) to be used.
+     * factory to be the default factory in ID3v2::Tag constructor you can 
+     * implement behavior that will allow for new ID3v2::Frame subclasses (also 
+     * provided by you) to be used.
      *
      * This implements both <i>abstract factory</i> and <i>singleton</i> patterns
      * of which more information is available on the web and in software design
@@ -66,38 +66,18 @@ namespace TagLib {
     {
     public:
       static FrameFactory *instance();
-      /*!
-       * Create a frame based on \a data.  \a synchSafeInts should only be set
-       * false if we are parsing an old tag (v2.3 or older) that does not support
-       * synchsafe ints.
-       *
-       * \deprecated Please use the method below that accepts a ID3v2::Header
-       * instance in new code.
-       */
-      Frame *createFrame(const ByteVector &data, bool synchSafeInts) const;
-
-      /*!
-       * Create a frame based on \a data.  \a version should indicate the ID3v2
-       * version of the tag.  As ID3v2.4 is the most current version of the
-       * standard 4 is the default.
-       *
-       * \deprecated Please use the method below that accepts a ID3v2::Header
-       * instance in new code.
-       */
-      Frame *createFrame(const ByteVector &data, uint version = 4) const;
 
       /*!
        * Create a frame based on \a data.  \a tagHeader should be a valid
        * ID3v2::Header instance.
        */
-      // BIC: make virtual
-      Frame *createFrame(const ByteVector &data, Header *tagHeader) const;
+      virtual Frame *createFrame(const ByteVector &data, Header *tagHeader) const;
 
       /*!
        * Returns the default text encoding for text frames.  If setTextEncoding()
        * has not been explicitly called this will only be used for new text
        * frames.  However, if this value has been set explicitly all frames will be
-       * converted to this type (unless it's explitly set differently for the
+       * converted to this type (unless it's explicitly set differently for the
        * individual frame) when being rendered.
        *
        * \see setDefaultTextEncoding()
@@ -149,8 +129,7 @@ namespace TagLib {
        * \a to.  If the frame matches the \a from pattern and converts the frame
        * ID in the \a header or simply does nothing if the frame ID does not match.
        */
-      void convertFrame(const char *from, const char *to,
-                        Frame::Header *header) const;
+      void convertFrame(const char *from, const char *to, Frame::Header *header) const;
 
       void updateGenre(TextIdentificationFrame *frame) const;
 

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -707,9 +707,7 @@ void ID3v2::Tag::parse(const ByteVector &origData)
       return;
     }
 
-    Frame *frame = d->factory->createFrame(data.mid(frameDataPosition),
-                                           &d->header);
-
+    Frame *frame = d->factory->createFrame(data.mid(frameDataPosition), &d->header);
     if(!frame)
       return;
 

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -74,43 +74,32 @@ namespace TagLib {
        * Constructs an MPEG file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
-       * \note In the current implementation, \a propertiesStyle is ignored.
+       * If this file contains an ID3v2 tag the frames will be created using
+       * \a frameFactory.  \a frameFactory needs to be valid until the File 
+       * object is destructed.
        *
-       * \deprecated This constructor will be dropped in favor of the one below
-       * in a future version.
+       * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
-
-      /*!
-       * Constructs an MPEG file from \a file.  If \a readProperties is true the
-       * file's audio properties will also be read.
-       *
-       * If this file contains and ID3v2 tag the frames will be created using
-       * \a frameFactory.
-       *
-       * \note In the current implementation, \a propertiesStyle is ignored.
-       */
-      // BIC: merge with the above constructor
-      File(FileName file, ID3v2::FrameFactory *frameFactory,
-           bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average, 
+           const ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
        * Constructs an MPEG file from \a stream.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
+       * If this file contains an ID3v2 tag the frames will be created using
+       * \a frameFactory.  \a frameFactory needs to be valid until the File 
+       * object is destructed.
+       *
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        *
-       * If this file contains and ID3v2 tag the frames will be created using
-       * \a frameFactory.
-       *
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
-           bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+      File(IOStream *stream, bool readProperties = true,
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average, 
+           const ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
        * Destroys this instance of the File.
@@ -282,13 +271,6 @@ namespace TagLib {
       bool strip(int tags, bool freeMemory);
 
       /*!
-       * Set the ID3v2::FrameFactory to something other than the default.
-       *
-       * \see ID3v2FrameFactory
-       */
-      void setID3v2FrameFactory(const ID3v2::FrameFactory *factory);
-
-      /*!
        * Returns the position in the file of the first MPEG frame.
        */
       offset_t firstFrameOffset();
@@ -335,7 +317,8 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle,
+                const ID3v2::FrameFactory *frameFactory);
       offset_t findID3v2();
       offset_t findID3v1();
       void findAPE();

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -61,22 +61,32 @@ namespace TagLib {
          * Constructs an AIFF file from \a file.  If \a readProperties is true the
          * file's audio properties will also be read.
          *
+         * If this file contains an ID3v2 tag the frames will be created using
+         * \a frameFactory.  \a frameFactory needs to be valid until the File 
+         * object is destructed.
+         *
          * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
+             const ID3v2::FrameFactory *frameFactory = 0);
 
         /*!
          * Constructs an AIFF file from \a stream.  If \a readProperties is true the
          * file's audio properties will also be read.
          *
-         * \note TagLib will *not* take ownership of the stream, the caller is
-         * responsible for deleting it after the File object.
+         * If this file contains an ID3v2 tag the frames will be created using
+         * \a frameFactory.  \a frameFactory needs to be valid until the File 
+         * object is destructed.
          *
          * \note In the current implementation, \a propertiesStyle is ignored.
+         *
+         * \note TagLib will *not* take ownership of the stream, the caller is
+         * responsible for deleting it after the File object.
          */
         File(IOStream *stream, bool readProperties = true,
-             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
+             const ID3v2::FrameFactory *frameFactory = 0);
 
         /*!
          * Destroys this instance of the File.
@@ -130,7 +140,8 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
+        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle,
+                  const ID3v2::FrameFactory *frameFactory);
 
         class FilePrivate;
         FilePrivate *d;

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -73,22 +73,32 @@ namespace TagLib {
          * Constructs a WAV file from \a file.  If \a readProperties is true the
          * file's audio properties will also be read.
          *
+         * If this file contains an ID3v2 tag the frames will be created using
+         * \a frameFactory.  \a frameFactory needs to be valid until the File 
+         * object is destructed.
+         *
          * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
+             const ID3v2::FrameFactory *frameFactory = 0);
 
         /*!
          * Constructs a WAV file from \a stream.  If \a readProperties is true the
          * file's audio properties will also be read.
          *
-         * \note TagLib will *not* take ownership of the stream, the caller is
-         * responsible for deleting it after the File object.
+         * If this file contains an ID3v2 tag the frames will be created using
+         * \a frameFactory.  \a frameFactory needs to be valid until the File 
+         * object is destructed.
          *
          * \note In the current implementation, \a propertiesStyle is ignored.
+         *
+         * \note TagLib will *not* take ownership of the stream, the caller is
+         * responsible for deleting it after the File object.
          */
         File(IOStream *stream, bool readProperties = true,
-             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
+             const ID3v2::FrameFactory *frameFactory = 0);
 
         /*!
          * Destroys this instance of the File.
@@ -168,7 +178,8 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
+        void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle,
+                  const ID3v2::FrameFactory *frameFactory);
 
         void strip(TagTypes tags);
 

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -82,51 +82,32 @@ namespace TagLib {
        * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
        * the file's audio properties will also be read.
        *
+       * If this file contains an ID3v2 tag the frames will be created using
+       * \a frameFactory.  \a frameFactory needs to be valid until the File 
+       * object is destructed.
+       *
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
-
-      /*!
-       * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
-       * the file's audio properties will also be read.
-       *
-       * If this file contains and ID3v2 tag the frames will be created using
-       * \a frameFactory.
-       *
-       * \note In the current implementation, \a propertiesStyle is ignored.
-       */
-      File(FileName file, ID3v2::FrameFactory *frameFactory,
-           bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
-
-      /*!
-       * Constructs a TrueAudio file from \a stream.  If \a readProperties is true
-       * the file's audio properties will also be read.
-       *
-       * \note TagLib will *not* take ownership of the stream, the caller is
-       * responsible for deleting it after the File object.
-       *
-       * \note In the current implementation, \a propertiesStyle is ignored.
-       */
-      File(IOStream *stream, bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average, 
+           const ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
        * Constructs a TrueAudio file from \a stream.  If \a readProperties is true 
        * the file's audio properties will also be read.
        *
-       * \note TagLib will *not* take ownership of the stream, the caller is
-       * responsible for deleting it after the File object.
-       *
-       * If this file contains and ID3v2 tag the frames will be created using
-       * \a frameFactory.
+       * If this file contains an ID3v2 tag the frames will be created using
+       * \a frameFactory.  \a frameFactory needs to be valid until the File 
+       * object is destructed.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
+       *
+       * \note TagLib will *not* take ownership of the stream, the caller is
+       * responsible for deleting it after the File object.
        */
-      File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
-           bool readProperties = true,
-           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
+      File(IOStream *stream, bool readProperties = true,
+           AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average,
+           const ID3v2::FrameFactory *frameFactory = 0);
 
       /*!
        * Destroys this instance of the File.
@@ -150,13 +131,6 @@ namespace TagLib {
        * were read then this will return a null pointer.
        */
       virtual AudioProperties *audioProperties() const;
-
-      /*!
-       * Set the ID3v2::FrameFactory to something other than the default.
-       *
-       * \see ID3v2FrameFactory
-       */
-      void setID3v2FrameFactory(const ID3v2::FrameFactory *factory);
 
       /*!
        * Saves the file.
@@ -229,7 +203,8 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle);
+      void read(bool readProperties, AudioProperties::ReadStyle propertiesStyle,
+                const ID3v2::FrameFactory *frameFactory);
       void scan();
       offset_t findID3v1();
       offset_t findID3v2();

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -10,6 +10,7 @@
 #include <mpegfile.h>
 #include <id3v2frame.h>
 #undef protected
+#include <id3v2header.h>
 #include <uniquefileidentifierframe.h>
 #include <textidentificationframe.h>
 #include <attachedpictureframe.h>
@@ -183,8 +184,10 @@ public:
                                  "\x01"
                                  "d\x00"
                                  "\x00", 18);
+    ID3v2::Header header;
+    header.setMajorVersion(2);
     ID3v2::AttachedPictureFrame *frame =
-        static_cast<TagLib::ID3v2::AttachedPictureFrame*>(factory->createFrame(data, TagLib::uint(2)));
+        static_cast<TagLib::ID3v2::AttachedPictureFrame*>(factory->createFrame(data, &header));
 
     CPPUNIT_ASSERT(frame);
     CPPUNIT_ASSERT_EQUAL(String("image/jpeg"), frame->mimeType());
@@ -202,8 +205,10 @@ public:
                                  "\x01"
                                  "d\x00"
                                  "\x00", 18);
+    ID3v2::Header header;
+    header.setMajorVersion(2);
     ID3v2::AttachedPictureFrame *frame =
-        static_cast<TagLib::ID3v2::AttachedPictureFrame*>(factory->createFrame(data, TagLib::uint(2)));
+        static_cast<TagLib::ID3v2::AttachedPictureFrame*>(factory->createFrame(data, &header));
 
     CPPUNIT_ASSERT(frame);
 
@@ -461,8 +466,10 @@ public:
                                  "\x00\x00"             // Frame flags
                                  "\x00"                 // Encoding
                                  "(22)Death Metal", 26);     // Text
+    ID3v2::Header header;
+    header.setMajorVersion(3);
     ID3v2::TextIdentificationFrame *frame =
-        static_cast<TagLib::ID3v2::TextIdentificationFrame*>(factory->createFrame(data, TagLib::uint(3)));
+        static_cast<TagLib::ID3v2::TextIdentificationFrame*>(factory->createFrame(data, &header));
     CPPUNIT_ASSERT_EQUAL(size_t(1), frame->fieldList().size());
     CPPUNIT_ASSERT_EQUAL(String("Death Metal"), frame->fieldList()[0]);
 
@@ -480,8 +487,10 @@ public:
                                  "\x00\x00"             // Frame flags
                                  "\x00"                 // Encoding
                                  "(4)Eurodisco", 23);   // Text
+    ID3v2::Header header;
+    header.setMajorVersion(3);
     ID3v2::TextIdentificationFrame *frame =
-        static_cast<TagLib::ID3v2::TextIdentificationFrame*>(factory->createFrame(data, TagLib::uint(3)));
+        static_cast<TagLib::ID3v2::TextIdentificationFrame*>(factory->createFrame(data, &header));
     CPPUNIT_ASSERT_EQUAL(size_t(2), frame->fieldList().size());
     CPPUNIT_ASSERT_EQUAL(String("4"), frame->fieldList()[0]);
     CPPUNIT_ASSERT_EQUAL(String("Eurodisco"), frame->fieldList()[1]);
@@ -499,8 +508,10 @@ public:
                                  "\x00\x00"               // Frame flags
                                  "\0"                   // Encoding
                                  "14\0Eurodisco", 23);     // Text
+    ID3v2::Header header;
+    header.setMajorVersion(4);
     ID3v2::TextIdentificationFrame *frame =
-        static_cast<TagLib::ID3v2::TextIdentificationFrame*>(factory->createFrame(data, TagLib::uint(4)));
+        static_cast<TagLib::ID3v2::TextIdentificationFrame*>(factory->createFrame(data, &header));
     CPPUNIT_ASSERT_EQUAL(size_t(2), frame->fieldList().size());
     CPPUNIT_ASSERT_EQUAL(String("14"), frame->fieldList()[0]);
     CPPUNIT_ASSERT_EQUAL(String("Eurodisco"), frame->fieldList()[1]);


### PR DESCRIPTION
Enabled all the `File` classes which support ID3v2 tags to take an `ID3v2::FrameFactory` in their constructors.

Additionally, it's accompanied by some changes:
- Removed the deprecated overloads of `FrameFactory` constructor.
- Rearranged the parameters of the relevant `File` constructors in the same order.
- Stopped storing `FrameFactory` in `File` classes because `ID3v2::Tag` class has it.
- Removed `MPEG::File::setID3v2FrameFactory()` method because it doesn't take effect. `FrameFactory` is only used when a `File` is being constructed.
