### PR TITLE
Fixed a bug in creating String from ByteVector

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -268,6 +268,9 @@ String::String(const ByteVector &v, Type t)
     copyFromUTF8(v.data(), v.size());
   else 
     copyFromUTF16(v.data(), v.size(), t);
+
+  // If we hit a null in the ByteVector, shrink the string again.
+  d->data.resize(::wcslen(d->data.c_str()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/test_id3v1.cpp
+++ b/tests/test_id3v1.cpp
@@ -1,7 +1,10 @@
 #include <string>
 #include <stdio.h>
+#include <tstring.h>
+#include <mpegfile.h>
 #include <id3v1tag.h>
 #include <cppunit/extensions/HelperMacros.h>
+#include "utils.h"
 
 using namespace std;
 using namespace TagLib;
@@ -16,8 +19,20 @@ public:
 
   void testStripWhiteSpace()
   {
-    ID3v1::StringHandler h;
-    CPPUNIT_ASSERT_EQUAL(String("Foo"), h.parse(ByteVector("Foo                ")));
+    ScopedFileCopy copy("xing", ".mp3");
+    string newname = copy.fileName();
+
+    {
+      MPEG::File f(newname.c_str());
+      f.ID3v1Tag(true)->setArtist("Artist     ");
+      f.save();
+    }
+    
+    {
+      MPEG::File f(newname.c_str());
+      CPPUNIT_ASSERT(f.ID3v1Tag(false));
+      CPPUNIT_ASSERT_EQUAL(String("Artist"), f.ID3v1Tag(false)->artist());
+    }
   }
 
 };


### PR DESCRIPTION
The behavior of `String` in being created from `ByteVector` has been changed a little from TagLib1.8.
