### PR TITLE
Added a missing fieldListmap() method to RIFF::Info::Tag

### DIFF
--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -185,6 +185,11 @@ bool RIFF::Info::Tag::isEmpty() const
   return d->fieldListMap.isEmpty();
 }
 
+FieldListMap RIFF::Info::Tag::fieldListMap() const
+{
+  return d->fieldListMap;
+}
+
 String RIFF::Info::Tag::fieldText(const ByteVector &id) const
 {
   if(d->fieldListMap.contains(id))

--- a/taglib/riff/wav/infotag.h
+++ b/taglib/riff/wav/infotag.h
@@ -120,6 +120,18 @@ namespace TagLib {
 
       virtual bool isEmpty() const;
 
+      /*!
+       * Returns a copy of the internal fields of the tag.  The returned map directly 
+       * reflects the contents of the "INFO" chunk.
+       *
+       * \note Modifying this map does not affect the tag's internal data.
+       * Use setFieldText() and removeField() instead.
+       *
+       * \see setFieldText()
+       * \see removeField()
+       */
+      FieldListMap fieldListMap() const;
+
       /*
        * Gets the value of the field with the ID \a id.
        */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ SET(test_runner_SRCS
   test_ape.cpp
   test_apetag.cpp
   test_wav.cpp
+  test_info.cpp
   test_wavpack.cpp
   test_mp4.cpp
   test_mp4item.cpp

--- a/tests/test_info.cpp
+++ b/tests/test_info.cpp
@@ -1,9 +1,7 @@
-#include <cppunit/extensions/HelperMacros.h>
 #include <string>
 #include <stdio.h>
 #include <infotag.h>
-#include <tpropertymap.h>
-#include <tdebug.h>
+#include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
 using namespace std;
@@ -23,7 +21,13 @@ public:
 
     CPPUNIT_ASSERT_EQUAL(String(""), tag.title());
     tag.setTitle("Test title 1");
+    tag.setFieldText("TEST", "Dummy Text");
+
     CPPUNIT_ASSERT_EQUAL(String("Test title 1"), tag.title());
+    
+    RIFF::Info::FieldListMap map = tag.fieldListMap();
+    CPPUNIT_ASSERT_EQUAL(String("Test title 1"), map["INAM"]);
+    CPPUNIT_ASSERT_EQUAL(String("Dummy Text"), map["TEST"]);
   }
 
   void testNumericFields()


### PR DESCRIPTION
This patch fixes some silly mistakes of mine:
- Added a missing method to `RIFF::Info::Tag` class to peek the internal fields of a tag.
- Added `test_info.cpp` to `tests/CMakeList.txt`. It's silly indeed.
