### PR TITLE
Removed #include "tdebug.h" from a public header

### DIFF
--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -28,14 +28,11 @@
 
 #include "tbytevector.h"
 
-#ifdef _WIN32
-# include "tstring.h"
-# include "tdebug.h"
-#endif
-
 namespace TagLib {
 
 #ifdef _WIN32
+
+  class String;
 
   class TAGLIB_EXPORT FileName
   {


### PR DESCRIPTION
Fixes an issue @scotchi pointed out in #276.
