### PR TITLE
Fixed a possible out-of-bound access when reading WavPack files

### DIFF
--- a/taglib/wavpack/wavpackproperties.cpp
+++ b/taglib/wavpack/wavpackproperties.cpp
@@ -126,8 +126,9 @@ TagLib::uint WavPack::Properties::sampleFrames() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-static const unsigned int sample_rates[] = { 6000, 8000, 9600, 11025, 12000,
-    16000, 22050, 24000, 32000, 44100, 48000, 64000, 88200, 96000, 192000 };
+static const unsigned int sample_rates[] = { 
+   6000,  8000,  9600, 11025, 12000, 16000,  22050, 24000, 
+  32000, 44100, 48000, 64000, 88200, 96000, 192000,     0 };
 
 #define BYTES_STORED    3
 #define MONO_FLAG       4

--- a/taglib/wavpack/wavpackproperties.h
+++ b/taglib/wavpack/wavpackproperties.h
@@ -75,7 +75,12 @@ namespace TagLib {
 
       virtual int length() const;
       virtual int bitrate() const;
+
+      /*!
+       * Returns the sample rate in Hz. 0 means unknown or custom.
+       */
       virtual int sampleRate() const;
+      
       virtual int channels() const;
 
       /*!


### PR DESCRIPTION
Accoding to the WavPack documentation at http://www.wavpack.com/file_format.txt, the sampling rate index can be up to 15.
