### PR TITLE
Added missing #include <algorithm> for std::min() and std::max()

### DIFF
--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -28,6 +28,7 @@
 #include <tstring.h>
 
 #include "rifffile.h"
+#include <algorithm>
 #include <vector>
 
 using namespace TagLib;

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -27,6 +27,7 @@
 #include <config.h>
 #endif
 
+#include <algorithm>
 #include <iostream>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
Some compilers might fail.
