### PR TITLE
Fixed detecting RIFF files with invalid chunk sizes

### DIFF
--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -273,7 +273,7 @@ void RIFF::File::read()
       break;
     }
 
-    if(tell() + chunkSize > uint(length())) {
+    if(static_cast<ulonglong>(tell()) + chunkSize > static_cast<ulonglong>(length())) {
       debug("RIFF::File::read() -- Chunk '" + chunkName + "' has invalid size (larger than the file size)");
       setValid(false);
       break;


### PR DESCRIPTION
Fix for the issue @wifanlith pointed out at #291.

The check may fail because `tell() + chunkSize` can overflow when `chunkSize` is close to `UINT_MAX`.
This patch will work correctly in `taglib2` branch as well.
