### PR TITLE
refcounter.h is not needed to be installed

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -50,7 +50,6 @@ set(tag_HDRS
   toolkit/tmap.h
   toolkit/tmap.tcc
   toolkit/tpropertymap.h
-  toolkit/trefcounter.h
   toolkit/tdebuglistener.h
   mpeg/mpegfile.h
   mpeg/mpegproperties.h


### PR DESCRIPTION
Maybe it's too late, but I fixed it anyway.
