### PR TITLE
Handle iTunes ID3v2.3 hacks

### DIFF
--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -461,10 +461,18 @@ ByteVector ID3v2::Tag::render() const
 
 void ID3v2::Tag::downgradeFrames(FrameList *frames, FrameList *newFrames) const
 {
+#ifdef NO_ITUNES_HACKS 
   const char *unsupportedFrames[] = {
     "ASPI", "EQU2", "RVA2", "SEEK", "SIGN", "TDRL", "TDTG",
     "TMOO", "TPRO", "TSOA", "TSOT", "TSST", "TSOP", 0
   };
+#else
+  // iTunes writes and reads TSOA, TSOT, TSOP to ID3v2.3.
+  const char *unsupportedFrames[] = {
+    "ASPI", "EQU2", "RVA2", "SEEK", "SIGN", "TDRL", "TDTG",
+    "TMOO", "TPRO", "TSST", 0
+  };
+#endif
   ID3v2::TextIdentificationFrame *frameTDOR = 0;
   ID3v2::TextIdentificationFrame *frameTDRC = 0;
   ID3v2::TextIdentificationFrame *frameTIPL = 0;

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -575,10 +575,12 @@ public:
     CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TDTG"));
     CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TMOO"));
     CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TPRO"));
+#ifdef NO_ITUNES_HACKS 
     CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TSOA"));
     CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TSOT"));
-    CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TSST"));
     CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TSOP"));
+#endif
+    CPPUNIT_ASSERT(!bar.ID3v2Tag()->frameListMap().contains("TSST"));
   }
 
   void testCompressedFrameWithBrokenLength()


### PR DESCRIPTION
iTunes writes the 2.4 frames TSOA, TSOT, TSOP to 2.3 files.  (It
additionally defines TSO2 and TSOC for both 2.3 and 2.4.)  TagLib should
not delete these frames.