### PR TITLE
Stop Release Date data loss when reading ID3v2.3

### DIFF
--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -378,12 +378,11 @@ bool FrameFactory::updateFrame(Frame::Header *header) const
 
   case 3: // ID3v2.3
   {
+    // TDAT and TIME are deprecated, but need to be merged with TYER into TDRC.
     if(frameID == "EQUA" ||
        frameID == "RVAD" ||
-       frameID == "TIME" ||
        frameID == "TRDA" ||
-       frameID == "TSIZ" ||
-       frameID == "TDAT")
+       frameID == "TSIZ")
     {
       debug("ID3v2.4 no longer supports the frame type " + String(frameID) +
             ".  It will be discarded from the tag.");
@@ -391,7 +390,6 @@ bool FrameFactory::updateFrame(Frame::Header *header) const
     }
 
     convertFrame("TORY", "TDOR", header);
-    convertFrame("TYER", "TDRC", header);
     convertFrame("IPLS", "TIPL", header);
 
     break;

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -679,6 +679,13 @@ void ID3v2::Tag::parse(const ByteVector &origData)
 
   // parse frames
 
+  // The way that ID3v2.4 maps some data is different compared to ID3v2.3.
+  // FrameFactory assumes that changes are renames, not merges.
+  // Avoid data loss by correctly handling this data outside of FrameFactory.
+  Frame* oldTyer = 0;
+  Frame* oldTdat = 0;
+  Frame* oldTime = 0;
+
   // Make sure that there is at least enough room in the remaining frame data for
   // a frame header.
 
@@ -693,24 +700,77 @@ void ID3v2::Tag::parse(const ByteVector &origData)
       }
 
       d->paddingSize = frameDataLength - frameDataPosition;
-      return;
+      break;
     }
 
     Frame *frame = d->factory->createFrame(data.mid(frameDataPosition),
                                            &d->header);
 
     if(!frame)
-      return;
+      break;
 
     // Checks to make sure that frame parsed correctly.
 
     if(frame->size() <= 0) {
       delete frame;
-      return;
+      break;
     }
 
     frameDataPosition += frame->size() + Frame::headerSize(d->header.majorVersion());
-    addFrame(frame);
+	
+    // If the conversion to ID3v2.4 merges multiple frames into one, the frame is not
+    // ready to be added yet.
+    ByteVector frameID = frame->header()->frameID();
+    if(frameID == "TYER") {
+      // TYER is one of several frames to be merged into TDRC
+      oldTyer = frame;
+    }
+    else if(frameID == "TDAT") {
+      // TDAT is one of several frames to be merged into TDRC
+      oldTdat = frame;
+    }
+    else if(frameID == "TIME") {
+      // TIME is one of several frames to be merged into TDRC
+      oldTime = frame;
+    }
+    else 
+      addFrame(frame);
+  }
+
+  if(oldTyer) {
+    // Merge (2.3) TYER + TDAT + TIME into (2.4) TDRC.
+    // Assume that TIME will only exist if TDAT exists, which will only exist if TYER exists.
+    StringList sl;
+	// Assume that TYER is 4 characters long
+    sl.append(dynamic_cast<ID3v2::TextIdentificationFrame *>(oldTyer)->fieldList().front());
+    delete oldTyer;
+	if(oldTdat) {
+      ID3v2::TextIdentificationFrame *frameTdat = dynamic_cast<ID3v2::TextIdentificationFrame *>(oldTdat);
+      if (frameTdat->fieldList().front().length() == 4) {
+        // TDAT's format is "DDmm".  TDRC's format is "yyyy-MM-dd"
+        sl.append("-");
+        sl.append(frameTdat->fieldList().front().substr(2,4));
+        sl.append("-");
+        sl.append(frameTdat->fieldList().front().substr(0,2));
+        if(oldTime) {
+          ID3v2::TextIdentificationFrame *frameTime = dynamic_cast<ID3v2::TextIdentificationFrame *>(oldTime);
+          if (frameTime->fieldList().front().length() == 4) {
+            // TIME's format is "HHmm".  TDRC's format is "yyyy-MM-ddTHH:mm"
+            sl.append("T");
+            sl.append(frameTime->fieldList().front().substr(0,2));
+            sl.append(":");
+            sl.append(frameTime->fieldList().front().substr(2,4));
+		  }
+          delete oldTime;
+        }
+      }
+      delete oldTdat;
+    }
+    // Add TDRC to the frames list
+    ID3v2::TextIdentificationFrame *newTdrc =
+          new ID3v2::TextIdentificationFrame("TDRC", String::Latin1);
+    newTdrc->setText(sl.toString(""));
+    addFrame(newTdrc);
   }
 }
 

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -559,7 +559,7 @@ public:
     tf = static_cast<ID3v2::TextIdentificationFrame *>(bar.ID3v2Tag()->frameList("TDRC").front());
     CPPUNIT_ASSERT(tf);
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(1), tf->fieldList().size());
-    CPPUNIT_ASSERT_EQUAL(String("2012"), tf->fieldList().front());
+    CPPUNIT_ASSERT_EQUAL(String("2012-04-17T12:01"), tf->fieldList().front());
     tf = dynamic_cast<ID3v2::TextIdentificationFrame *>(bar.ID3v2Tag()->frameList("TIPL").front());
     CPPUNIT_ASSERT(tf);
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(8), tf->fieldList().size());


### PR DESCRIPTION
The ID3v2.4 release date (TDRC) replaced multiple 2.3 frames (TYER,
TDAT, and TIME).  TagLib currently throws away TDAT and TIME.  This data
loss is fixed with the following changes:
- FrameFactory no longer renames TYER to TDRC (this change isn't
actually necessary)
- FrameFactory no longer discards TDAT or TIME
- During Tag::parse(ByteVector), the pointers to TYER, TDAT, and TIME
that FrameFactory::createFrame(...) returns are saved.  After the
createFrame loop, TDRC is manually created from TYER, TDAT, and TIME.
(TIME is only used if TDAT exists, and TDAT is only used if TYER
exists).  TIME is inserted into TDRC with least-necessary precision as
specified in "id3v2.40-structure.txt"

This change should not break any existing apps using an unaltered copy
of TagLib to retrieve the TDRC frame.  (It was never possible to find
TYER, TDAT, or TIME in an unaltered copy of TagLib.)