### PR TITLE
Replaced wrongly used slashes with backslashes in some comments

### DIFF
--- a/taglib/mpeg/id3v1/id3v1tag.h
+++ b/taglib/mpeg/id3v1/id3v1tag.h
@@ -154,14 +154,14 @@ namespace TagLib {
       /*!
        * Returns the genre in number.
        *
-       * /note Normally 255 indicates that this tag contains no genre.
+       * \note Normally 255 indicates that this tag contains no genre.
        */
       TagLib::uint genreNumber() const;
 
       /*!
        * Sets the genre in number to \a i.
        *
-       * /note Valid value is from 0 up to 255. Normally 255 indicates that
+       * \note Valid value is from 0 up to 255. Normally 255 indicates that
        * this tag contains no genre.
        */
       void setGenreNumber(TagLib::uint i);

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -224,7 +224,7 @@ namespace TagLib {
      * The returned pointer remains valid until this String instance is destroyed 
      * or any other method of this String is called.
      *
-     * /note This returns a pointer to the String's internal data without any 
+     * \note This returns a pointer to the String's internal data without any 
      * conversions.
      *
      * \see toWString()


### PR DESCRIPTION
It will fix the online API documentation.
