### PR TITLE
Fixed a wrong default parameter of String::ctor()

### DIFF
--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -129,11 +129,21 @@ namespace TagLib {
 
     /*!
      * Makes a deep copy of the data in \a s.
+     *
+     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or 
+     * UTF16LE, when used with other codecs it will simply print a warning and 
+     * exit.  UTF16BE or UTF16LE is automatically chosen as default according 
+     * to the CPU byte order    
      */
     String(const std::wstring &s, Type t = WCharByteOrder);
 
     /*!
      * Makes a deep copy of the data in \a s.
+     *
+     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or 
+     * UTF16LE, when used with other codecs it will simply print a warning and 
+     * exit.  UTF16BE or UTF16LE is automatically chosen as default according 
+     * to the CPU byte order    
      */
     String(const wchar_t *s, Type t = WCharByteOrder);
 
@@ -147,6 +157,11 @@ namespace TagLib {
 
     /*!
      * Makes a deep copy of the data in \a c.
+     *
+     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or 
+     * UTF16LE, when used with other codecs it will simply print a warning and 
+     * exit.  UTF16BE or UTF16LE is automatically chosen as default according 
+     * to the CPU byte order    
      */
     String(wchar_t c, Type t = WCharByteOrder);
 
@@ -161,9 +176,6 @@ namespace TagLib {
 
     /*!
      * Makes a deep copy of the data in \a s.
-     *
-     * \note This should only be used with the 8-bit codecs Latin1 and UTF8, when
-     * used with other codecs it will simply print a warning and exit.
      */
     String(const ByteVector &v, Type t = Latin1);
 


### PR DESCRIPTION
Fixed a default parameter of this which actually doesn't accept `Latin1`:

```
String(wchar_t c, Type t = Latin1);
```

And added some complementary comments about `Type` parameters and removed wrong one.
Is it better to update the comments in `master` branch as well?
