### PR TITLE
Unified the string formatting functions

### DIFF
--- a/taglib/mp4/mp4item.cpp
+++ b/taglib/mp4/mp4item.cpp
@@ -25,45 +25,16 @@
 
 #include "config.h"
 
-#include <cstdio>
-#include <cstdarg>
-
 #include "taglib.h"
 #include "tdebug.h"
 #include "tsmartptr.h"
 #include "mp4item.h"
+#include "tutils.h"
 
 using namespace TagLib;
 
 namespace
 {
-  String format(const char *fmt, ...)
-  {
-    va_list args;
-    va_start(args, fmt);
-
-    char buf[256];
-
-#if defined(HAVE_SNPRINTF)
-
-    vsnprintf(buf, sizeof(buf), fmt, args);
-
-#elif defined(HAVE_SPRINTF_S)
-
-    vsprintf_s(buf, fmt, args);
-
-#else
-
-    // Be careful. May cause a buffer overflow.  
-    vsprintf(buf, fmt, args);
-
-#endif
-
-    va_end(args);
-
-    return String(buf);
-  }
-
   struct ItemData
   {
     bool valid;
@@ -263,26 +234,26 @@ MP4::Item::toString() const
     case TypeBool:
       return d->data->m_bool ? "true" : "false";
     case TypeInt:
-      return format("%d", d->data->m_int);
+      return Utils::formatString("%d", d->data->m_int);
     case TypeIntPair:
-      return format("%d/%d", d->data->m_intPair.first, d->data->m_intPair.second);
+      return Utils::formatString("%d/%d", d->data->m_intPair.first, d->data->m_intPair.second);
     case TypeByte:
-      return format("%d", d->data->m_byte);
+      return Utils::formatString("%d", d->data->m_byte);
     case TypeUInt:
-      return format("%u", d->data->m_uint);
+      return Utils::formatString("%u", d->data->m_uint);
     case TypeLongLong:
-      return format("%lld", d->data->m_longlong);
+      return Utils::formatString("%lld", d->data->m_longlong);
     case TypeStringList:
       return d->data->m_stringList.toString(" / ");
     case TypeByteVectorList:
       for(TagLib::uint i = 0; i < d->data->m_byteVectorList.size(); i++) {
-        desc.append(format(
+        desc.append(Utils::formatString(
           "[%d bytes of data]", static_cast<int>(d->data->m_byteVectorList[i].size())));
       }
       return desc.toString(", ");
     case TypeCoverArtList:
       for(TagLib::uint i = 0; i < d->data->m_coverArtList.size(); i++) {
-        desc.append(format(
+        desc.append(Utils::formatString(
           "[%d bytes of data]", static_cast<int>(d->data->m_coverArtList[i].data().size())));
       }
       return desc.toString(", ");

--- a/taglib/toolkit/tdebug.cpp
+++ b/taglib/toolkit/tdebug.cpp
@@ -29,43 +29,12 @@
 
 #include "tdebug.h"
 #include "tstring.h"
+#include "tutils.h"
 #include "tdebuglistener.h"
 
 #include <bitset>
-#include <cstdio>
-#include <cstdarg>
 
 using namespace TagLib;
-
-namespace
-{
-  String format(const char *fmt, ...)
-  {
-    va_list args;
-    va_start(args, fmt);
-
-    char buf[256];
-
-#if defined(HAVE_SNPRINTF)
-
-    vsnprintf(buf, sizeof(buf), fmt, args);
-
-#elif defined(HAVE_SPRINTF_S)
-
-    vsprintf_s(buf, fmt, args);
-
-#else
-
-    // Be careful. May cause a buffer overflow.  
-    vsprintf(buf, fmt, args);
-
-#endif
-
-    va_end(args);
-
-    return String(buf);
-  }
-}
 
 namespace TagLib
 {
@@ -88,7 +57,8 @@ namespace TagLib
     for(size_t i = 0; i < v.size(); ++i) 
     {
       std::string bits = std::bitset<8>(v[i]).to_string();
-      String msg = format("*** [%d] - char '%c' - int %d, 0x%02x, 0b%s\n", 
+      String msg = Utils::formatString(
+        "*** [%d] - char '%c' - int %d, 0x%02x, 0b%s\n", 
         i, v[i], v[i], v[i], bits.c_str());
 
       debugListener->printMessage(msg);

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -36,7 +36,6 @@
 #include "tutils.h"
 
 #include <iostream>
-#include <cstdio>
 #include <cstring>
 
 #ifdef HAVE_STD_CODECVT
@@ -559,30 +558,7 @@ bool String::isAscii() const
 
 String String::number(int n) // static
 {
-  static const size_t BufferSize = 11; // Sufficient to store "-214748364".
-  static const char *Format = "%d";
-
-  char buffer[BufferSize];
-  int length;
-
-#if defined(HAVE_SNPRINTF)
-
-  length = snprintf(buffer, BufferSize, Format, n);
-
-#elif defined(HAVE_SPRINTF_S)
-
-  length = sprintf_s(buffer, Format, n);
-
-#else
-
-  length = sprintf(buffer, Format, n);
-
-#endif
-
-  if(length > 0)
-    return String(buffer);
-  else
-    return String::null;
+  return Utils::formatString("%d", n);
 }
 
 TagLib::wchar &String::operator[](size_t i)

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -41,6 +41,7 @@ class TestString : public CppUnit::TestFixture
   CPPUNIT_TEST(testAppendCharDetach);
   CPPUNIT_TEST(testAppendStringDetach);
   CPPUNIT_TEST(testToInt);
+  CPPUNIT_TEST(testFromInt);
   CPPUNIT_TEST(testSubstr);
   CPPUNIT_TEST(testNewline);
   CPPUNIT_TEST_SUITE_END();
@@ -213,6 +214,12 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("-123").toInt(), -123);
     CPPUNIT_ASSERT_EQUAL(String("123aa").toInt(), 123);
     CPPUNIT_ASSERT_EQUAL(String("-123aa").toInt(), -123);
+  }
+
+  void testFromInt()
+  {
+    CPPUNIT_ASSERT_EQUAL(String("123"), String::number(123));
+    CPPUNIT_ASSERT_EQUAL(String("-123"), String::number(-123));
   }
 
   void testSubstr()


### PR DESCRIPTION
This patch unifies some similar `sprintf()` like functions into a single function `Utils::formatString()`.
This also adds a test for `String::number()` and underlying `Utils::formatString()`.
