### PR TITLE
Removed some redundant code from String::operator==()

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -155,11 +155,6 @@ public:
   {
   }
 
-  StringPrivate(const std::wstring &s) 
-    : data(new std::wstring(s)) 
-  {
-  }
-
   StringPrivate(size_t n, wchar_t c) 
     : data(new std::wstring(n, c)) 
   {
@@ -651,54 +646,43 @@ String &String::operator=(const String &s)
 
 String &String::operator=(const std::string &s)
 {
-  d->data.reset(new std::wstring());
-  copyFromLatin1(s.c_str(), s.length());
-
+  *this = String(s);
   return *this;
 }
 
 String &String::operator=(const std::wstring &s)
 {
-  d->data.reset(new std::wstring(s));
+  *this = String(s);
   return *this;
 }
 
 String &String::operator=(const wchar_t *s)
 {
-  d->data.reset(new std::wstring());
-  copyFromUTF16(s, ::wcslen(s), WCharByteOrder);
-
+  *this = String(s);
   return *this;
 }
 
 String &String::operator=(char c)
 {
-  d->data.reset(new std::wstring(1, c));
+  *this = String(c);
   return *this;
 }
 
 String &String::operator=(wchar_t c)
 {
-  d->data.reset(new std::wstring(1, c));
+  *this = String(c);
   return *this;
 }
 
 String &String::operator=(const char *s)
 {
-  d->data.reset(new std::wstring());
-  copyFromLatin1(s, ::strlen(s));
-
+  *this = String(s);
   return *this;
 }
 
 String &String::operator=(const ByteVector &v)
 {
-  d->data.reset(new std::wstring());
-  copyFromLatin1(v.data(), v.size());
-
-  // If we hit a null in the ByteVector, shrink the string again.
-  d->data->resize(::wcslen(d->data->c_str()));
-
+  *this = String(v);
   return *this;
 }
 


### PR DESCRIPTION
Some versions of `String::operator==()` had redundant code with their corresponding constructors. 
