### PR TITLE
Changed the CMake check to enable C++11 automatically if GCC > 4.3 or Clang > 3.0

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -7,6 +7,13 @@ include(CheckTypeSize)
 include(CheckCXXSourceCompiles)
 include(TestBigEndian)
 
+# Enable C++11 if possible.
+
+if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 3.0)
+    OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.3))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+endif()
+
 # Check if the size of integral types are suitable.
 
 check_type_size("short" SIZEOF_SHORT)


### PR DESCRIPTION
This patch aims to prefer standard smart pointers to self-implemented ones. It doesn't mean TagLib requires C++11.

Currently, TagLib2 tries to use `std::shared_ptr` first, `boost::shared_ptr` second, and then self-implemented one. Enabling C++11 means to make the first try successful.
