### PR TITLE
Moved StringHandler implementations which are not needed to be public to...

### DIFF
--- a/taglib/mpeg/id3v1/id3v1tag.h
+++ b/taglib/mpeg/id3v1/id3v1tag.h
@@ -39,52 +39,10 @@ namespace TagLib {
 
   namespace ID3v1 {
 
-    //! A abstraction for the string to data encoding in ID3v1 tags.
-
-    /*!
-     * ID3v1 should in theory always contain ISO-8859-1 (Latin1) data.  In
-     * practice it does not.  TagLib by default only supports ISO-8859-1 data
-     * in ID3v1 tags.
-     *
-     * However by subclassing TagLib::StringHandler class and reimplementing 
-     * parse() and render() and setting your reimplementation as the default 
-     * with ID3v1::Tag::setStringHandler() you can define how you would like 
-     * these transformations to be done.
-     *
-     * \warning It is advisable <b>not</b> to write non-ISO-8859-1 data to ID3v1
-     * tags.  Please consider disabling the writing of ID3v1 tags in the case
-     * that the data is not ISO-8859-1.
-     *
-     * \see ID3v1::Tag::setStringHandler()
-     */
-
-    class TAGLIB_EXPORT StringHandler : public TagLib::StringHandler
-    {
-    public:
-      StringHandler();
-
-      /*!
-       * Decode a string from \a data.  The default implementation assumes that
-       * \a data is an ISO-8859-1 (Latin1) character array.
-       */
-      virtual String parse(const ByteVector &data) const;
-
-      /*!
-       * Encode a ByteVector with the data from \a s.  The default implementation
-       * assumes that \a s is an ISO-8859-1 (Latin1) string.  If the string is
-       * does not conform to ISO-8859-1, no value is written.
-       *
-       * \warning It is recommended that you <b>not</b> override this method, but
-       * instead do not write an ID3v1 tag in the case that the data is not
-       * ISO-8859-1.
-       */
-      virtual ByteVector render(const String &s) const;
-    };
-
     //! The main class in the ID3v1 implementation
 
     /*!
-     * This is an implementation of the ID3v1 format.  ID3v1 is both the simplist
+     * This is an implementation of the ID3v1 format.  ID3v1 is both the simplest
      * and most common of tag formats but is rather limited.  Because of its
      * pervasiveness and the way that applications have been written around the
      * fields that it provides, the generic TagLib::Tag API is a mirror of what is
@@ -166,6 +124,15 @@ namespace TagLib {
       void setGenreNumber(TagLib::uint i);
 
       /*!
+       * Gets the current string handler that decides how the ID3v1 data will be
+       * converted to and from binary data.
+       *
+       * \see StringHandler
+       * \see setStringHandler()
+       */
+      static StringHandler *stringHandler();
+
+      /*!
        * Sets the string handler that decides how the ID3v1 data will be
        * converted to and from binary data.
        * If the parameter \a handler is null, the previous handler is
@@ -175,8 +142,9 @@ namespace TagLib {
        * as needed after it is released.
        *
        * \see StringHandler
+       * \see stringHandler()
        */
-      static void setStringHandler(const TagLib::StringHandler *handler);
+      static void setStringHandler(StringHandler *handler);
 
     protected:
       /*!

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -49,10 +49,30 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace
+{
+  class DefaultStringHandler : public StringHandler
+  {
+    virtual String parse(const ByteVector &data) const
+    {
+      return String(data, String::Latin1);
+    }
+
+    virtual ByteVector render(const String &s) const
+    {
+      // Not implemented intentionally.
+      return ByteVector::null;
+    }
+  };
+
+  DefaultStringHandler defaultStringHandler;
+  StringHandler *strHandler = &defaultStringHandler;
+}
+
 class ID3v2::Tag::TagPrivate
 {
 public:
-  TagPrivate() 
+  TagPrivate()
     : file(0)
     , tagOffset(-1)
     , extendedHeader(0)
@@ -80,34 +100,7 @@ public:
 
   FrameListMap frameListMap;
   FrameList frameList;
-
-  static const TagLib::StringHandler *stringHandler;
 };
-
-namespace
-{
-  const ID3v2::Latin1StringHandler defaultStringHandler;
-}
-
-const TagLib::StringHandler *ID3v2::Tag::TagPrivate::stringHandler = &defaultStringHandler;
-
-////////////////////////////////////////////////////////////////////////////////
-// Latin1StringHandler implementation
-////////////////////////////////////////////////////////////////////////////////
-
-ID3v2::Latin1StringHandler::Latin1StringHandler()
-{
-}
-
-String ID3v2::Latin1StringHandler::parse(const ByteVector &data) const
-{
-  return String(data, String::Latin1);
-}
-
-ByteVector ID3v2::Latin1StringHandler::render(const String &s) const
-{
-  return ByteVector();
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // public members
@@ -625,17 +618,17 @@ ByteVector ID3v2::Tag::render(int version) const
   return d->header.render() + tagData;
 }
 
-TagLib::StringHandler const *ID3v2::Tag::latin1StringHandler()
+StringHandler *ID3v2::Tag::latin1StringHandler()  // static
 {
-  return TagPrivate::stringHandler;
+  return strHandler;
 }
 
-void ID3v2::Tag::setLatin1StringHandler(const TagLib::StringHandler *handler)
+void ID3v2::Tag::setLatin1StringHandler(StringHandler *handler) // static
 {
   if(handler)
-    TagPrivate::stringHandler = handler;
+    strHandler = handler;
   else
-    TagPrivate::stringHandler = &defaultStringHandler;
+    strHandler = &defaultStringHandler;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -58,42 +58,6 @@ namespace TagLib {
     typedef List<Frame *> FrameList;
     typedef Map<ByteVector, FrameList> FrameListMap;
 
-    //! An abstraction for the ISO-8859-1 string to data encoding in ID3v2 tags.
-
-    /*!
-     * ID3v2 tag can store strings in ISO-8859-1 (Latin1), and TagLib only 
-     * supports genuine ISO-8859-1 by default.  However, in practice, non 
-     * ISO-8859-1 encodings are often used instead of ISO-8859-1, such as 
-     * Windows-1252 for western languages, Shift_JIS for Japanese and so on.
-     *
-     * Here is an option to read such tags by subclassing this class,
-     * reimplementing parse() and setting your reimplementation as the default 
-     * with ID3v2::Tag::setStringHandler().
-     *
-     * \note Writing non-ISO-8859-1 tags is not implemented intentionally.
-     * Use UTF-16 or UTF-8 instead.
-     *
-     * \see ID3v2::Tag::setStringHandler()
-     */
-    class TAGLIB_EXPORT Latin1StringHandler : public TagLib::StringHandler
-    {
-    public:
-      Latin1StringHandler();
-
-      /*!
-       * Decode a string from \a data.  The default implementation assumes that
-       * \a data is an ISO-8859-1 (Latin1) character array.
-       */
-      virtual String parse(const ByteVector &data) const;
-
-      /*!
-       * Encode a ByteVector with the data from \a s.
-       *
-       * \note Not implemented intentionally.  Always returns empty \s ByteVector.
-       */
-      virtual ByteVector render(const String &s) const;
-    };
-
     //! The main class in the ID3v2 implementation
 
     /*!
@@ -360,14 +324,15 @@ namespace TagLib {
        */
       // BIC: combine with the above method
       ByteVector render(int version) const;
-      
+
       /*!
-       * Gets the current string handler that decides how the "Latin-1" data 
+       * Gets the current string handler that decides how the "Latin-1" data
        * will be converted to and from binary data.
        *
        * \see Latin1StringHandler
+       * \see setLatin1StringHandler()
        */
-      static TagLib::StringHandler const *latin1StringHandler();
+      static StringHandler *latin1StringHandler();
 
       /*!
        * Sets the string handler that decides how the "Latin-1" data will be
@@ -376,11 +341,12 @@ namespace TagLib {
        * released and default ISO-8859-1 handler is restored.
        *
        * \note The caller is responsible for deleting the previous handler
-       * as needed after it is released. 
+       * as needed after it is released.
        *
        * \see Latin1StringHandler
+       * \see latin1StringHandler()
        */
-      static void setLatin1StringHandler(const TagLib::StringHandler *handler);
+      static void setLatin1StringHandler(StringHandler *handler);
 
     protected:
       /*!

--- a/taglib/riff/wav/infotag.h
+++ b/taglib/riff/wav/infotag.h
@@ -38,53 +38,21 @@ namespace TagLib {
 
   class File;
 
-  //! A RIFF INFO tag implementation. 
+  //! A RIFF INFO tag implementation.
 
   namespace RIFF {
   namespace Info {
 
     typedef Map<ByteVector, String> FieldListMap;
 
-    //! A abstraction for the string to data encoding in Info tags.
-
-    /*!
-     * RIFF Info tag has no clear definitions about character encodings.
-     * In practice, local encoding of each system is largely used and UTF-8 is
-     * popular too.
-     *
-     * Here is an option to read and write tags in your preferrd encoding 
-     * by subclassing this class, reimplementing parse() and render() and setting 
-     * your reimplementation as the default with Info::Tag::setStringHandler().
-     *
-     * \see ID3v1::Tag::setStringHandler()
-     */
-
-    class TAGLIB_EXPORT StringHandler : public TagLib::StringHandler
-    {
-    public:
-      StringHandler();
-
-      /*!
-       * Decode a string from \a data.  The default implementation assumes that
-       * \a data is an UTF-8 character array.
-       */
-      virtual String parse(const ByteVector &data) const;
-
-      /*!
-       * Encode a ByteVector with the data from \a s.  The default implementation
-       * assumes that \a s is an UTF-8 string. 
-       */
-      virtual ByteVector render(const String &s) const;
-    };
-
     //! The main class in the RIFF INFO tag implementation
 
     /*!
-     * This is the main class in the INFO tag implementation.  RIFF INFO tag is 
-     * a metadata format found in WAV audio and AVI video files.  Though it is a 
-     * part of Microsoft/IBM's RIFF specification, the author could not find the 
-     * official documents about it.  So, this implementation is referring to 
-     * unofficial documents on the web and some applications' behaviors especially 
+     * This is the main class in the INFO tag implementation.  RIFF INFO tag is
+     * a metadata format found in WAV audio and AVI video files.  Though it is a
+     * part of Microsoft/IBM's RIFF specification, the author could not find the
+     * official documents about it.  So, this implementation is referring to
+     * unofficial documents on the web and some applications' behaviors especially
      * Windows Explorer.
      */
     class TAGLIB_EXPORT Tag : public TagLib::Tag
@@ -123,7 +91,7 @@ namespace TagLib {
       virtual bool isEmpty() const;
 
       /*!
-       * Returns a copy of the internal fields of the tag.  The returned map directly 
+       * Returns a copy of the internal fields of the tag.  The returned map directly
        * reflects the contents of the "INFO" chunk.
        *
        * \note Modifying this map does not affect the tag's internal data.
@@ -138,13 +106,13 @@ namespace TagLib {
        * Gets the value of the field with the ID \a id.
        */
       String fieldText(const ByteVector &id) const;
-        
+
       /*
         * Sets the value of the field with the ID \a id to \a s.
         * If the field does not exist, it is created.
         * If \s is empty, the field is removed.
         *
-        * \note fieldId must be four-byte long pure ASCII string.  This function 
+        * \note fieldId must be four-byte long pure ASCII string.  This function
         * performs nothing if fieldId is invalid.
         */
       void setFieldText(const ByteVector &id, const String &s);
@@ -157,9 +125,18 @@ namespace TagLib {
       /*!
        * Render the tag back to binary data, suitable to be written to disk.
        *
-       * \note Returns empty ByteVector is the tag contains no fields. 
+       * \note Returns empty ByteVector is the tag contains no fields.
        */
       ByteVector render() const;
+
+      /*!
+       * Gets the current string handler that decides how the text data will be
+       * converted to and from binary data.
+       *
+       * \see StringHandler
+       * \see setStringHandler()
+       */
+      static StringHandler *stringHandler();
 
       /*!
        * Sets the string handler that decides how the text data will be
@@ -171,9 +148,10 @@ namespace TagLib {
        * as needed after it is released.
        *
        * \see StringHandler
+       * \see stringHandler()
        */
-      static void setStringHandler(const TagLib::StringHandler *handler);
-    
+      static void setStringHandler(StringHandler *handler);
+
     protected:
       /*!
        * Pareses the body of the tag in \a data.

--- a/taglib/toolkit/tstringhandler.h
+++ b/taglib/toolkit/tstringhandler.h
@@ -35,18 +35,21 @@ namespace TagLib
   //! A abstraction for the string to data encoding.
 
   /*!
-   * ID3v1, ID3v2 and RIFF Info tag sometimes store strings in local encodings
-   * encodings instead of ISO-8859-1 (Latin1), such as Windows-1252 for western 
-   * languages, Shift_JIS for Japanese and so on. However, TagLib only supports 
-   * genuine ISO-8859-1 by default.
+   * ID3v1, ID3v2 and RIFF INFO tag sometimes store strings in local encodings
+   * instead of ISO-8859-1 (Latin1) or UTF-8, such as Windows-1252 for western 
+   * languages,Shift_JIS for Japanese and so on.  However, TagLib only supports 
+   * genuine ISO-8859-1 or UTF-8 by default.
    *
-   * Here is an option to read and write tags in your preferrd encoding 
+   * Here is an option to read and write tags in your preferred encoding 
    * by subclassing this class, reimplementing parse() and render() and setting 
    * your reimplementation as the default with ID3v1::Tag::setStringHandler(),
    * ID3v2::Tag::setStringHandler() or Info::Tag::setStringHandler().
    *
+   * \note ID3v2::Tag class won't use render() method.  TagLib doesn't support
+   * writing non-standard tags.
+   *
    * \see ID3v1::Tag::setStringHandler()
-   * \see ID3v2::Tag::setStringHandler()
+   * \see ID3v2::Tag::setLatin1StringHandler()
    * \see Info::Tag::setStringHandler()
    */
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ SET(test_runner_SRCS
   test_bytevectorlist.cpp
   test_bytevectorstream.cpp
   test_string.cpp
+  test_strhandler.cpp
   test_propertymap.cpp
   test_fileref.cpp
   test_id3v1.cpp

--- a/tests/test_strhandler.cpp
+++ b/tests/test_strhandler.cpp
@@ -1,0 +1,139 @@
+#include <string.h>
+#include <tstring.h>
+#include <tstringhandler.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
+#include <infotag.h>
+#include <mpegfile.h>
+#include <wavfile.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include "utils.h"
+
+using namespace std;
+using namespace TagLib;
+
+namespace
+{
+  class CeasarStringHandler : public StringHandler
+  {
+  public:
+    CeasarStringHandler() : key(0) {}
+
+    virtual String parse(const ByteVector &data) const
+    {
+      ByteVector tmp = data;
+      tmp.resize(::strlen(data.data()));
+
+      for(ByteVector::Iterator it = tmp.begin(); it != tmp.end(); ++it)
+        *it = static_cast<char>(*it - key);
+
+      return String(tmp).stripWhiteSpace();
+    }
+
+    virtual ByteVector render(const String &s) const
+    {
+      ByteVector tmp = s.stripWhiteSpace().data(String::Latin1);
+      for(ByteVector::Iterator it = tmp.begin(); it != tmp.end(); ++it)
+        *it = static_cast<char>(*it + key);
+
+      return tmp;
+    }
+
+    void setKey(int k) { key = k; }
+
+  private:
+    int key;
+  };
+}
+
+class TestStringHandler : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestStringHandler);
+  CPPUNIT_TEST(testID3v1Tag);
+  CPPUNIT_TEST(testID3v2Tag);
+  CPPUNIT_TEST(testInfoTag);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void testID3v1Tag()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+    string newname = copy.fileName();
+
+    CeasarStringHandler sh;
+    ID3v1::Tag::setStringHandler(&sh);
+
+    dynamic_cast<CeasarStringHandler*>(ID3v1::Tag::stringHandler())->setKey(2);
+
+    {
+      MPEG::File f(newname.c_str());
+      f.ID3v1Tag(true)->setTitle("ABC");
+      f.save();
+    }
+
+    dynamic_cast<CeasarStringHandler*>(ID3v1::Tag::stringHandler())->setKey(1);
+
+    {
+      MPEG::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(String("BCD"), f.ID3v1Tag(false)->title());
+    }
+
+    ID3v1::Tag::setStringHandler(0);
+  }
+
+  void testID3v2Tag()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+    string newname = copy.fileName();
+
+    CeasarStringHandler sh;
+    ID3v2::Tag::setLatin1StringHandler(&sh);
+
+    dynamic_cast<CeasarStringHandler*>(ID3v2::Tag::latin1StringHandler())->setKey(2);
+
+    // StringHandler is not used for rendering.
+    {
+      MPEG::File f(newname.c_str());
+      f.ID3v2Tag(true)->setTitle("ABC");
+      f.save();
+    }
+
+    dynamic_cast<CeasarStringHandler*>(ID3v2::Tag::latin1StringHandler())->setKey(1);
+
+    {
+      MPEG::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(String("@AB"), f.ID3v2Tag(false)->title());
+    }
+
+    ID3v2::Tag::setLatin1StringHandler(0);
+  }
+
+  void testInfoTag()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+    string newname = copy.fileName();
+
+    CeasarStringHandler sh;
+    RIFF::Info::Tag::setStringHandler(&sh);
+
+    dynamic_cast<CeasarStringHandler*>(RIFF::Info::Tag::stringHandler())->setKey(2);
+
+    {
+      RIFF::WAV::File f(newname.c_str());
+      f.InfoTag()->setTitle("ABC");
+      f.save();
+    }
+
+    dynamic_cast<CeasarStringHandler*>(RIFF::Info::Tag::stringHandler())->setKey(1);
+
+    {
+      RIFF::WAV::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(String("BCD"), f.InfoTag()->title());
+    }
+
+    RIFF::Info::Tag::setStringHandler(0);
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestStringHandler);


### PR DESCRIPTION
... .cpp files

The `StringHandler` implementations are not needed to be public because they have a common public interface class.
This also allows users to access and manipulate the current `StringHandler` like shown in `test_strhandler.cpp`.
