### PR TITLE
Fixed warnings in MinGW

### DIFF
--- a/taglib/toolkit/trefcounter.h
+++ b/taglib/toolkit/trefcounter.h
@@ -33,7 +33,9 @@
 #  include <libkern/OSAtomic.h>
 #  define TAGLIB_ATOMIC_MAC
 #elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
-#  define NOMINMAX
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
 #  include <windows.h>
 #  define TAGLIB_ATOMIC_WIN
 #elif defined (__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 401)    \


### PR DESCRIPTION
I remember @FestusHagen reported #298 over a month ago. I didn't fix it because I was not clear whether or not it was useful to make changes to `master` branch at that time. But we have made some changes from that time on.
