### PR TITLE
Changed String::toInt() to use a standard function

### DIFF
--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -94,7 +94,7 @@ namespace TagLib {
        */
       UTF16 = 1,
       /*!
-       * UTF16 <i>big endian</i>.  16 bit characters.  
+       * UTF16 <i>big endian</i>.  16 bit characters.
        */
       UTF16BE = 2,
       /*!
@@ -130,20 +130,20 @@ namespace TagLib {
     /*!
      * Makes a deep copy of the data in \a s.
      *
-     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or 
-     * UTF16LE, when used with other codecs it will simply print a warning and 
-     * exit.  UTF16BE or UTF16LE is automatically chosen as default according 
-     * to the CPU byte order    
+     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or
+     * UTF16LE, when used with other codecs it will simply print a warning and
+     * exit.  UTF16BE or UTF16LE is automatically chosen as default according
+     * to the CPU byte order
      */
     String(const std::wstring &s, Type t = WCharByteOrder);
 
     /*!
      * Makes a deep copy of the data in \a s.
      *
-     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or 
-     * UTF16LE, when used with other codecs it will simply print a warning and 
-     * exit.  UTF16BE or UTF16LE is automatically chosen as default according 
-     * to the CPU byte order    
+     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or
+     * UTF16LE, when used with other codecs it will simply print a warning and
+     * exit.  UTF16BE or UTF16LE is automatically chosen as default according
+     * to the CPU byte order
      */
     String(const wchar_t *s, Type t = WCharByteOrder);
 
@@ -158,10 +158,10 @@ namespace TagLib {
     /*!
      * Makes a deep copy of the data in \a c.
      *
-     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or 
-     * UTF16LE, when used with other codecs it will simply print a warning and 
-     * exit.  UTF16BE or UTF16LE is automatically chosen as default according 
-     * to the CPU byte order    
+     * \note This should only be used with the 16-bit codecs UTF16, UTF16BE or
+     * UTF16LE, when used with other codecs it will simply print a warning and
+     * exit.  UTF16BE or UTF16LE is automatically chosen as default according
+     * to the CPU byte order
      */
     String(wchar_t c, Type t = WCharByteOrder);
 
@@ -185,7 +185,7 @@ namespace TagLib {
     virtual ~String();
 
     /*!
-     * Returns a deep copy of this String as an std::string.  The returned string 
+     * Returns a deep copy of this String as an std::string.  The returned string
      * is encoded in UTF8 if \a unicode is true, otherwise Latin1.
      *
      * \see toCString()
@@ -193,7 +193,7 @@ namespace TagLib {
     std::string to8Bit(bool unicode = false) const;
 
     /*!
-     * Returns a deep copy of this String as a wstring.  The returned string is 
+     * Returns a deep copy of this String as a wstring.  The returned string is
      * encoded in UTF-16 (without BOM/CPU byte order).
      *
      * \see toCWString()
@@ -201,43 +201,43 @@ namespace TagLib {
     const std::wstring &toWString() const;
 
     /*!
-     * Creates and returns a standard C-style (null-terminated) version of this 
-     * String.  The returned string is encoded in UTF8 if \a unicode is true, 
+     * Creates and returns a standard C-style (null-terminated) version of this
+     * String.  The returned string is encoded in UTF8 if \a unicode is true,
      * otherwise Latin1.
-     * 
-     * The returned string is still owned by this String and should not be deleted 
+     *
+     * The returned string is still owned by this String and should not be deleted
      * by the user.
      *
-     * The returned pointer remains valid until this String instance is destroyed 
+     * The returned pointer remains valid until this String instance is destroyed
      * or toCString() is called again.
      *
      * \warning This however has the side effect that the returned string will remain
-     * in memory <b>in addition to</b> other memory that is consumed by this 
+     * in memory <b>in addition to</b> other memory that is consumed by this
      * String instance.  So, this method should not be used on large strings or
      * where memory is critical.  Consider using to8Bit() instead to avoid it.
      *
      * \see to8Bit()
      */
     const char *toCString(bool unicode = false) const;
-    
+
     /*!
-     * Returns a standard C-style (null-terminated) wide character version of 
-     * this String.  The returned string is encoded in UTF-16 (without BOM/CPU byte 
+     * Returns a standard C-style (null-terminated) wide character version of
+     * this String.  The returned string is encoded in UTF-16 (without BOM/CPU byte
      * order).
-     * 
-     * The returned string is still owned by this String and should not be deleted 
+     *
+     * The returned string is still owned by this String and should not be deleted
      * by the user.
      *
-     * The returned pointer remains valid until this String instance is destroyed 
+     * The returned pointer remains valid until this String instance is destroyed
      * or any other method of this String is called.
      *
-     * \note This returns a pointer to the String's internal data without any 
+     * \note This returns a pointer to the String's internal data without any
      * conversions.
      *
      * \see toWString()
      */
     const wchar_t *toCWString() const;
-    
+
     /*!
      * Returns an iterator pointing to the beginning of the string.
      */
@@ -338,7 +338,7 @@ namespace TagLib {
     /*!
      * Convert the string to an integer.
      *
-     * If the conversion was successfull, it sets the value of \a *ok to
+     * If the conversion was successful, it sets the value of \a *ok to
      * true and returns the integer. Otherwise it sets \a *ok to false
      * and the result is undefined.
      */
@@ -477,7 +477,7 @@ namespace TagLib {
     static const String null;
 
     /*!
-    * When used as the value for a \a length parameter in String's member 
+    * When used as the value for a \a length parameter in String's member
     * functions, means "until the end of the string".
     * As a return value, it is usually used to indicate no matches.
     */
@@ -493,31 +493,31 @@ namespace TagLib {
 
   private:
     /*!
-     * Converts a \e Latin-1 string into \e UTF-16(without BOM/CPU byte order) 
+     * Converts a \e Latin-1 string into \e UTF-16(without BOM/CPU byte order)
      * and copies it to the internal buffer.
      */
     void copyFromLatin1(const char *s, size_t length);
 
     /*!
-     * Converts a \e UTF-8 string into \e UTF-16(without BOM/CPU byte order) 
+     * Converts a \e UTF-8 string into \e UTF-16(without BOM/CPU byte order)
      * and copies it to the internal buffer.
      */
     void copyFromUTF8(const char *s, size_t length);
 
     /*!
-     * Converts a \e UTF-16 (with BOM), UTF-16LE or UTF16-BE string into 
+     * Converts a \e UTF-16 (with BOM), UTF-16LE or UTF16-BE string into
      * \e UTF-16(without BOM/CPU byte order) and copies it to the internal buffer.
      */
     void copyFromUTF16(const wchar_t *s, size_t length, Type t);
 
     /*!
-     * Converts a \e UTF-16 (with BOM), UTF-16LE or UTF16-BE string into 
+     * Converts a \e UTF-16 (with BOM), UTF-16LE or UTF16-BE string into
      * \e UTF-16(without BOM/CPU byte order) and copies it to the internal buffer.
      */
     void copyFromUTF16(const char *s, size_t length, Type t);
 
     /*!
-     * Indicates which byte order of UTF-16 is used to store strings internally. 
+     * Indicates which byte order of UTF-16 is used to store strings internally.
      *
      * \note \e String::UTF16BE or \e String::UTF16LE
      */


### PR DESCRIPTION
Changed `String::toInt()` function to use `wcstol()` which is compliant with POSIX rather than the self-implemented one.
