### PR TITLE
Fixed some MSVC warnings in DSF related classes

### DIFF
--- a/taglib/dsf/dsffile.cpp
+++ b/taglib/dsf/dsffile.cpp
@@ -154,7 +154,7 @@ bool DSF::File::save()
     }
 
     // Delete the old tag and write the new one
-    insert(tagData, newMetadataOffset, oldTagSize);
+    insert(tagData, static_cast<offset_t>(newMetadataOffset), static_cast<size_t>(oldTagSize));
   }
 
   return true;
@@ -214,7 +214,8 @@ void DSF::File::read(bool readProperties, AudioProperties::ReadStyle propertiesS
 
   chunkSize = readBlock(8).toInt64LE(0);
   
-  d->properties = new AudioProperties(readBlock(chunkSize), propertiesStyle);
+  d->properties 
+    = new AudioProperties(readBlock(static_cast<size_t>(chunkSize)), propertiesStyle);
   
   // Skip the data chunk
 

--- a/taglib/dsf/dsfproperties.cpp
+++ b/taglib/dsf/dsfproperties.cpp
@@ -144,6 +144,8 @@ void DSF::AudioProperties::read(const ByteVector &data)
   d->sampleCount           = data.toInt64LE(24);
   d->blockSizePerChannel   = data.toUInt32LE(32);
 
-  d->bitrate               = (d->samplingFrequency * d->bitsPerSample * d->channelNum) / 1000.0;
-  d->length                = d->samplingFrequency > 0 ? d->sampleCount / d->samplingFrequency : 0;
+  d->bitrate               
+    = static_cast<uint>((d->samplingFrequency * d->bitsPerSample * d->channelNum) / 1000.0);
+  d->length                
+    = d->samplingFrequency > 0 ? static_cast<uint>(d->sampleCount / d->samplingFrequency) : 0;
 }


### PR DESCRIPTION
They have some implicit narrowing conversions that generate warnings in MSVC.
