### PR TITLE
Enable read-only file support

### DIFF
--- a/taglib/ape/apefile.cpp
+++ b/taglib/ape/apefile.cpp
@@ -87,7 +87,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 APE::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                Properties::ReadStyle propertiesStyle, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/ape/apefile.h
+++ b/taglib/ape/apefile.h
@@ -90,7 +90,8 @@ namespace TagLib {
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an APE file from \a stream.  If \a readProperties is true the

--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -366,8 +366,8 @@ ByteVector ASF::File::HeaderExtensionObject::render(ASF::File *file)
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-ASF::File::File(FileName file, bool readProperties, Properties::ReadStyle propertiesStyle)
-  : TagLib::File(file)
+ASF::File::File(FileName file, bool readProperties, Properties::ReadStyle propertiesStyle, bool openReadOnly)
+  : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/asf/asffile.h
+++ b/taglib/asf/asffile.h
@@ -55,7 +55,8 @@ namespace TagLib {
        * read.
        */
       File(FileName file, bool readProperties = true, 
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an ASF file from \a stream.

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -78,9 +78,9 @@ FileRef::FileRef()
 }
 
 FileRef::FileRef(FileName fileName, bool readAudioProperties,
-                 AudioProperties::ReadStyle audioPropertiesStyle)
+                 AudioProperties::ReadStyle audioPropertiesStyle, bool openReadOnly)
 {
-  d = new FileRefPrivate(create(fileName, readAudioProperties, audioPropertiesStyle));
+  d = new FileRefPrivate(create(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly));
 }
 
 FileRef::FileRef(File *file)
@@ -202,13 +202,13 @@ bool FileRef::operator!=(const FileRef &ref) const
 }
 
 File *FileRef::create(FileName fileName, bool readAudioProperties,
-                      AudioProperties::ReadStyle audioPropertiesStyle) // static
+                      AudioProperties::ReadStyle audioPropertiesStyle, bool openReadOnly) // static
 {
 
   List<const FileTypeResolver *>::ConstIterator it = FileRefPrivate::fileTypeResolvers.begin();
 
   for(; it != FileRefPrivate::fileTypeResolvers.end(); ++it) {
-    File *file = (*it)->createFile(fileName, readAudioProperties, audioPropertiesStyle);
+    File *file = (*it)->createFile(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(file)
       return file;
   }
@@ -238,48 +238,48 @@ File *FileRef::create(FileName fileName, bool readAudioProperties,
 
   if(!ext.isEmpty()) {
     if(ext == "MP3")
-      return new MPEG::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new MPEG::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "OGG")
-      return new Ogg::Vorbis::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new Ogg::Vorbis::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "OGA") {
       /* .oga can be any audio in the Ogg container. First try FLAC, then Vorbis. */
-      File *file = new Ogg::FLAC::File(fileName, readAudioProperties, audioPropertiesStyle);
+      File *file = new Ogg::FLAC::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
       if (file->isValid())
         return file;
       delete file;
-      return new Ogg::Vorbis::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new Ogg::Vorbis::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     }
     if(ext == "FLAC")
-      return new FLAC::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new FLAC::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "MPC")
-      return new MPC::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new MPC::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "WV")
-      return new WavPack::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new WavPack::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "SPX")
-      return new Ogg::Speex::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new Ogg::Speex::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "OPUS")
-      return new Ogg::Opus::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new Ogg::Opus::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "TTA")
-      return new TrueAudio::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new TrueAudio::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "M4A" || ext == "M4R" || ext == "M4B" || ext == "M4P" || ext == "MP4" || ext == "3G2")
-      return new MP4::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new MP4::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "WMA" || ext == "ASF")
-      return new ASF::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new ASF::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "AIF" || ext == "AIFF")
-      return new RIFF::AIFF::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new RIFF::AIFF::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "WAV")
-      return new RIFF::WAV::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new RIFF::WAV::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "APE")
-      return new APE::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new APE::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     // module, nst and wow are possible but uncommon extensions
     if(ext == "MOD" || ext == "MODULE" || ext == "NST" || ext == "WOW")
-      return new Mod::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new Mod::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "S3M")
-      return new S3M::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new S3M::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "IT")
-      return new IT::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new IT::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
     if(ext == "XM")
-      return new XM::File(fileName, readAudioProperties, audioPropertiesStyle);
+      return new XM::File(fileName, readAudioProperties, audioPropertiesStyle, openReadOnly);
   }
 
   return 0;

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -105,7 +105,8 @@ namespace TagLib {
       virtual File *createFile(FileName fileName,
                                bool readAudioProperties = true,
                                AudioProperties::ReadStyle
-                               audioPropertiesStyle = AudioProperties::Average) const = 0;
+                               audioPropertiesStyle = AudioProperties::Average,
+                               bool openReadOnly = false) const = 0;
     };
 
     /*!
@@ -125,7 +126,8 @@ namespace TagLib {
     explicit FileRef(FileName fileName,
                      bool readAudioProperties = true,
                      AudioProperties::ReadStyle
-                     audioPropertiesStyle = AudioProperties::Average);
+                     audioPropertiesStyle = AudioProperties::Average,
+                     bool openReadOnly = false);
 
     /*!
      * Contruct a FileRef using \a file.  The FileRef now takes ownership of the
@@ -250,7 +252,8 @@ namespace TagLib {
      */
     static File *create(FileName fileName,
                         bool readAudioProperties = true,
-                        AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
+                        AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average,
+                        bool openReadOnly = false);
 
 
   private:

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -105,8 +105,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 FLAC::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+                 Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -114,8 +114,8 @@ FLAC::File::File(FileName file, bool readProperties,
 }
 
 FLAC::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+                 bool readProperties, Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   d->ID3v2FrameFactory = frameFactory;

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -76,7 +76,8 @@ namespace TagLib {
        * in a future version.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an APE file from \a file.  If \a readProperties is true the
@@ -90,7 +91,8 @@ namespace TagLib {
       // BIC: merge with the above constructor
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs a FLAC file from \a stream.  If \a readProperties is true the

--- a/taglib/it/itfile.cpp
+++ b/taglib/it/itfile.cpp
@@ -41,8 +41,8 @@ public:
 };
 
 IT::File::File(FileName file, bool readProperties,
-               AudioProperties::ReadStyle propertiesStyle) :
-  Mod::FileBase(file),
+               AudioProperties::ReadStyle propertiesStyle, bool openReadOnly) :
+  Mod::FileBase(file, openReadOnly),
   d(new FilePrivate(propertiesStyle))
 {
   if(isOpen())

--- a/taglib/it/itfile.h
+++ b/taglib/it/itfile.h
@@ -44,7 +44,7 @@ namespace TagLib {
          */
         File(FileName file, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
-             AudioProperties::Average);
+             AudioProperties::Average, bool openReadOnly = false);
 
         /*!
          * Constructs a Impulse Tracker file from \a stream.

--- a/taglib/mod/modfile.cpp
+++ b/taglib/mod/modfile.cpp
@@ -41,8 +41,8 @@ public:
 };
 
 Mod::File::File(FileName file, bool readProperties,
-                AudioProperties::ReadStyle propertiesStyle) :
-  Mod::FileBase(file),
+                AudioProperties::ReadStyle propertiesStyle, bool openReadOnly) :
+  Mod::FileBase(file, openReadOnly),
   d(new FilePrivate(propertiesStyle))
 {
   if(isOpen())

--- a/taglib/mod/modfile.h
+++ b/taglib/mod/modfile.h
@@ -45,7 +45,7 @@ namespace TagLib {
        */
       File(FileName file, bool readProperties = true,
            AudioProperties::ReadStyle propertiesStyle =
-           AudioProperties::Average);
+           AudioProperties::Average, bool openReadOnly = false);
 
       /*!
        * Constructs a Protracker file from \a stream.

--- a/taglib/mod/modfilebase.cpp
+++ b/taglib/mod/modfilebase.cpp
@@ -25,7 +25,8 @@
 using namespace TagLib;
 using namespace Mod;
 
-Mod::FileBase::FileBase(FileName file) : TagLib::File(file)
+Mod::FileBase::FileBase(FileName file, bool openReadOnly) :
+  TagLib::File(file, openReadOnly)
 {
 }
 

--- a/taglib/mod/modfilebase.h
+++ b/taglib/mod/modfilebase.h
@@ -37,7 +37,7 @@ namespace TagLib {
     class TAGLIB_EXPORT FileBase : public TagLib::File
     {
     protected:
-      FileBase(FileName file);
+      FileBase(FileName file, bool openReadOnly = false);
       FileBase(IOStream *stream);
 
       void writeString(const String &s, ulong size, char padding = 0);

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -60,8 +60,8 @@ public:
   MP4::Properties *properties;
 };
 
-MP4::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
-    : TagLib::File(file)
+MP4::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle, bool openReadOnly)
+    : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -55,7 +55,8 @@ namespace TagLib {
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true, 
-           Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+           Properties::ReadStyle audioPropertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an MP4 file from \a stream.  If \a readProperties is true the

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -91,7 +91,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 MPC::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                Properties::ReadStyle propertiesStyle, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/mpc/mpcfile.h
+++ b/taglib/mpc/mpcfile.h
@@ -90,7 +90,8 @@ namespace TagLib {
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an MPC file from \a stream.  If \a readProperties is true the

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -96,7 +96,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 MPEG::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                 Properties::ReadStyle propertiesStyle, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
 
@@ -105,8 +105,8 @@ MPEG::File::File(FileName file, bool readProperties,
 }
 
 MPEG::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+                 bool readProperties, Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate(frameFactory);
 

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -80,7 +80,8 @@ namespace TagLib {
        * in a future version.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an MPEG file from \a file.  If \a readProperties is true the
@@ -94,7 +95,8 @@ namespace TagLib {
       // BIC: merge with the above constructor
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an MPEG file from \a stream.  If \a readProperties is true the

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -70,7 +70,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 Ogg::FLAC::File::File(FileName file, bool readProperties,
-                      Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                      Properties::ReadStyle propertiesStyle, bool openReadOnly) : Ogg::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/ogg/flac/oggflacfile.h
+++ b/taglib/ogg/flac/oggflacfile.h
@@ -70,7 +70,8 @@ namespace TagLib {
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an Ogg/FLAC file from \a stream.  If \a readProperties is true 

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -208,7 +208,7 @@ bool Ogg::File::save()
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
 
-Ogg::File::File(FileName file) : TagLib::File(file)
+Ogg::File::File(FileName file, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
 }

--- a/taglib/ogg/oggfile.h
+++ b/taglib/ogg/oggfile.h
@@ -88,7 +88,7 @@ namespace TagLib {
        * instantiated directly but rather should be used through the codec
        * specific subclasses.
        */
-      File(FileName file);
+      File(FileName file, bool openReadOnly = false);
 
       /*!
        * Constructs an Ogg file from \a stream.

--- a/taglib/ogg/opus/opusfile.cpp
+++ b/taglib/ogg/opus/opusfile.cpp
@@ -59,8 +59,8 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-Opus::File::File(FileName file, bool readProperties, Properties::ReadStyle propertiesStyle) :
-  Ogg::File(file),
+Opus::File::File(FileName file, bool readProperties, Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  Ogg::File(file, openReadOnly),
   d(new FilePrivate())
 {
   if(isOpen())

--- a/taglib/ogg/opus/opusfile.h
+++ b/taglib/ogg/opus/opusfile.h
@@ -62,7 +62,8 @@ namespace TagLib {
          * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             Properties::ReadStyle propertiesStyle = Properties::Average,
+             bool openReadOnly = false);
 
         /*!
          * Constructs an Opus file from \a stream.  If \a readProperties is true the

--- a/taglib/ogg/speex/speexfile.cpp
+++ b/taglib/ogg/speex/speexfile.cpp
@@ -60,7 +60,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 Speex::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                   Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  Ogg::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/ogg/speex/speexfile.h
+++ b/taglib/ogg/speex/speexfile.h
@@ -62,7 +62,8 @@ namespace TagLib {
          * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             Properties::ReadStyle propertiesStyle = Properties::Average,
+             bool openReadOnly = false);
 
         /*!
          * Constructs a Speex file from \a stream.  If \a readProperties is true the

--- a/taglib/ogg/vorbis/vorbisfile.cpp
+++ b/taglib/ogg/vorbis/vorbisfile.cpp
@@ -64,7 +64,7 @@ namespace TagLib {
 ////////////////////////////////////////////////////////////////////////////////
 
 Vorbis::File::File(FileName file, bool readProperties,
-                   Properties::ReadStyle propertiesStyle) : Ogg::File(file)
+                   Properties::ReadStyle propertiesStyle, bool openReadOnly) : Ogg::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/ogg/vorbis/vorbisfile.h
+++ b/taglib/ogg/vorbis/vorbisfile.h
@@ -69,7 +69,8 @@ namespace TagLib {
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs a Vorbis file from \a stream.  If \a readProperties is true the

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -60,7 +60,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 RIFF::AIFF::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, BigEndian)
+                       Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  RIFF::File(file, BigEndian, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -64,7 +64,8 @@ namespace TagLib {
          * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             Properties::ReadStyle propertiesStyle = Properties::Average,
+             bool openReadOnly = false);
 
         /*!
          * Constructs an AIFF file from \a stream.  If \a readProperties is true the

--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -71,7 +71,7 @@ RIFF::File::~File()
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::File::File(FileName file, Endianness endianness) : TagLib::File(file)
+RIFF::File::File(FileName file, Endianness endianness, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   d->endianness = endianness;

--- a/taglib/riff/rifffile.h
+++ b/taglib/riff/rifffile.h
@@ -55,7 +55,7 @@ namespace TagLib {
 
       enum Endianness { BigEndian, LittleEndian };
 
-      File(FileName file, Endianness endianness);
+      File(FileName file, Endianness endianness, bool openReadOnly = false);
       File(IOStream *stream, Endianness endianness);
 
       /*!

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -71,7 +71,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 RIFF::WAV::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, LittleEndian)
+                       Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  RIFF::File(file, LittleEndian, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -76,7 +76,8 @@ namespace TagLib {
          * \note In the current implementation, \a propertiesStyle is ignored.
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             Properties::ReadStyle propertiesStyle = Properties::Average,
+             bool openReadOnly = false);
 
         /*!
          * Constructs a WAV file from \a stream.  If \a readProperties is true the

--- a/taglib/s3m/s3mfile.cpp
+++ b/taglib/s3m/s3mfile.cpp
@@ -43,8 +43,8 @@ public:
 };
 
 S3M::File::File(FileName file, bool readProperties,
-                AudioProperties::ReadStyle propertiesStyle) :
-  Mod::FileBase(file),
+                AudioProperties::ReadStyle propertiesStyle, bool openReadOnly) :
+  Mod::FileBase(file, openReadOnly),
   d(new FilePrivate(propertiesStyle))
 {
   if(isOpen())

--- a/taglib/s3m/s3mfile.h
+++ b/taglib/s3m/s3mfile.h
@@ -44,7 +44,7 @@ namespace TagLib {
          */
         File(FileName file, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
-             AudioProperties::Average);
+             AudioProperties::Average, bool openReadOnly = false);
 
         /*!
          * Constructs a ScreamTracker III file from \a stream.

--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -96,9 +96,9 @@ File::FilePrivate::FilePrivate(IOStream *stream, bool owner) :
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-File::File(FileName fileName)
+File::File(FileName fileName, bool openReadOnly)
 {
-  IOStream *stream = new FileStream(fileName);
+  IOStream *stream = new FileStream(fileName, openReadOnly);
   d = new FilePrivate(stream, true);
 }
 

--- a/taglib/toolkit/tfile.h
+++ b/taglib/toolkit/tfile.h
@@ -263,7 +263,8 @@ namespace TagLib {
      * \note Constructor is protected since this class should only be
      * instantiated through subclasses.
      */
-    File(FileName file);
+    //File(FileName file, bool openReadOnly = false); //XXX for testing:
+    File(FileName file, bool openReadOnly);
 
     /*!
      * Construct a File object and use the \a stream instance.

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -85,7 +85,7 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 TrueAudio::File::File(FileName file, bool readProperties,
-                 Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                 Properties::ReadStyle propertiesStyle, bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())
@@ -93,8 +93,8 @@ TrueAudio::File::File(FileName file, bool readProperties,
 }
 
 TrueAudio::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle propertiesStyle) :
-  TagLib::File(file)
+                 bool readProperties, Properties::ReadStyle propertiesStyle, bool openReadOnly) :
+  TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate(frameFactory);
   if(isOpen())

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -85,7 +85,8 @@ namespace TagLib {
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
@@ -98,7 +99,8 @@ namespace TagLib {
        */
       File(FileName file, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs a TrueAudio file from \a stream.  If \a readProperties is true

--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -83,7 +83,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 
 WavPack::File::File(FileName file, bool readProperties,
-                Properties::ReadStyle propertiesStyle) : TagLib::File(file)
+                Properties::ReadStyle propertiesStyle,
+                bool openReadOnly) : TagLib::File(file, openReadOnly)
 {
   d = new FilePrivate;
   if(isOpen())

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -85,7 +85,8 @@ namespace TagLib {
        * false, \a propertiesStyle is ignored
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           bool openReadOnly = false);
 
       /*!
        * Constructs an WavPack file from \a file.  If \a readProperties is true the

--- a/taglib/xm/xmfile.cpp
+++ b/taglib/xm/xmfile.cpp
@@ -355,8 +355,8 @@ public:
 };
 
 XM::File::File(FileName file, bool readProperties,
-               AudioProperties::ReadStyle propertiesStyle) :
-  Mod::FileBase(file),
+               AudioProperties::ReadStyle propertiesStyle, bool openReadOnly) :
+  Mod::FileBase(file, openReadOnly),
   d(new FilePrivate(propertiesStyle))
 {
   if(isOpen())

--- a/taglib/xm/xmfile.h
+++ b/taglib/xm/xmfile.h
@@ -44,7 +44,7 @@ namespace TagLib {
          */
         File(FileName file, bool readProperties = true,
              AudioProperties::ReadStyle propertiesStyle =
-             AudioProperties::Average);
+             AudioProperties::Average, bool openReadOnly = false);
 
         /*!
          * Constructs an Extended Module file from \a stream.


### PR DESCRIPTION
This enables taglib to open files in read-only mode. Not sure if it's is even desired, I needed it though. So why not share it?
