### PR TITLE
Reduced a useless memory copy in tstring.cpp.

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -805,11 +805,12 @@ void String::copyFromUTF16(const wchar_t *s, size_t length, Type t)
 
   d->data.resize(length);
   if(length > 0) {
-    memcpy(&d->data[0], s, length * sizeof(wchar_t));
-
     if(swap) {
       for(size_t i = 0; i < length; ++i)
         d->data[i] = Utils::byteSwap(static_cast<ushort>(s[i]));
+    }
+    else {
+      ::memcpy(&d->data[0], s, length * sizeof(wchar_t));
     }
   }
 }


### PR DESCRIPTION
I found and fixed a `memcpy` that is conditionally useless.
