### PR TITLE
Removed some redundant code relevant to RefCounter.

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -18,14 +18,9 @@
 #cmakedefine   HAVE_MAC_BYTESWAP 1
 #cmakedefine   HAVE_OPENBSD_BYTESWAP 1
 
-/* Defined if your compiler supports shared_ptr */
-#cmakedefine   HAVE_STD_SHARED_PTR 1    // #include <memory> / std::shared_ptr<T>
-#cmakedefine   HAVE_TR1_SHARED_PTR 1    // #include <tr1/memory> / std::tr1::shared_ptr<T>
-#cmakedefine   HAVE_BOOST_SHARED_PTR 1  // #include <boost/shared_ptr.hpp> / boost::shared_ptr<T>
-
-/* Defined if your compiler supports unique_ptr or scoped_ptr */
-#cmakedefine   HAVE_STD_UNIQUE_PTR 1    // #include <memory> / std::unique_ptr<T>
-#cmakedefine   HAVE_BOOST_SCOPED_PTR 1  // #include <boost/scoped_ptr.hpp> / boost::scoped_ptr<T>
+/* Defined if your compiler supports smart pointers */
+#cmakedefine   HAVE_STD_SMART_PTR 1
+#cmakedefine   HAVE_BOOST_SMART_PTR 1
 
 /* Defined if your compiler supports some atomic operations */
 #cmakedefine   HAVE_STD_ATOMIC 1
@@ -52,4 +47,3 @@
 #cmakedefine   TRACE_IN_RELEASE 1
 
 #cmakedefine TESTS_DIR "@TESTS_DIR@"
-

--- a/taglib/toolkit/trefcounter.cpp
+++ b/taglib/toolkit/trefcounter.cpp
@@ -27,7 +27,7 @@
 #include <config.h>
 #endif
 
-#include "trefcounter.h"
+#include <trefcounter.h>
 
 #if defined(HAVE_STD_ATOMIC)
 # include <atomic>
@@ -48,7 +48,7 @@
 #   define NOMINMAX
 # endif
 # include <windows.h>
-# define ATOMIC_INT long
+# define ATOMIC_INT LONG volatile
 # define ATOMIC_INC(x) InterlockedIncrement(&x)
 # define ATOMIC_DEC(x) InterlockedDecrement(&x)
 #elif defined(HAVE_MAC_ATOMIC)
@@ -72,16 +72,14 @@ namespace TagLib
   class RefCounter::RefCounterPrivate
   {
   public:
-    RefCounterPrivate() 
-      : refCount(1) 
-    {
-    }
+    RefCounterPrivate() :
+      refCount(1) {}
 
-    volatile ATOMIC_INT refCount;
+    ATOMIC_INT refCount;
   };
 
-  RefCounter::RefCounter()
-    : d(new RefCounterPrivate())
+  RefCounter::RefCounter() : 
+    d(new RefCounterPrivate()) 
   {
   }
 
@@ -98,6 +96,11 @@ namespace TagLib
   bool RefCounter::deref()
   { 
     return (ATOMIC_DEC(d->refCount) == 0); 
+  }
+
+  long RefCounter::count() const
+  {
+    return static_cast<long>(d->refCount);
   }
 
   bool RefCounter::unique() const 

--- a/taglib/toolkit/trefcounter.h
+++ b/taglib/toolkit/trefcounter.h
@@ -44,6 +44,7 @@ namespace TagLib
 
     void ref();
     bool deref();
+    long count() const;
     bool unique() const;
 
   private:


### PR DESCRIPTION
Removed some redundant code and useless CMake checks relevant to `RefCounter` class.
And added a CMake check automatically enables C++11 option if possible.
