### PR TITLE
Removed an unnecessary dependency on shlwapi.lib.

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -341,10 +341,6 @@ if(ZLIB_FOUND)
 	target_link_libraries(tag ${ZLIB_LIBRARIES})
 endif()
 
-if(WIN32 AND NOT TAGLIB_STATIC)
-	target_link_libraries(tag shlwapi.lib)
-endif()
-
 set_target_properties(tag PROPERTIES
   VERSION ${TAGLIB_SOVERSION_MAJOR}.${TAGLIB_SOVERSION_MINOR}.${TAGLIB_SOVERSION_PATCH}
   SOVERSION ${TAGLIB_SOVERSION_MAJOR}


### PR DESCRIPTION
`shlwapi.lib` is required to use `PathFindExtension()` Win32 function which is no longer used in TagLib.
