### PR TITLE
Fix #162: Xiph and APE generic getters return space-concatenated values

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -89,35 +89,35 @@ String APE::Tag::title() const
 {
   if(d->itemListMap["TITLE"].isEmpty())
     return String::null;
-  return d->itemListMap["TITLE"].toString();
+  return d->itemListMap["TITLE"].values().toString();
 }
 
 String APE::Tag::artist() const
 {
   if(d->itemListMap["ARTIST"].isEmpty())
     return String::null;
-  return d->itemListMap["ARTIST"].toString();
+  return d->itemListMap["ARTIST"].values().toString();
 }
 
 String APE::Tag::album() const
 {
   if(d->itemListMap["ALBUM"].isEmpty())
     return String::null;
-  return d->itemListMap["ALBUM"].toString();
+  return d->itemListMap["ALBUM"].values().toString();
 }
 
 String APE::Tag::comment() const
 {
   if(d->itemListMap["COMMENT"].isEmpty())
     return String::null;
-  return d->itemListMap["COMMENT"].toString();
+  return d->itemListMap["COMMENT"].values().toString();
 }
 
 String APE::Tag::genre() const
 {
   if(d->itemListMap["GENRE"].isEmpty())
     return String::null;
-  return d->itemListMap["GENRE"].toString();
+  return d->itemListMap["GENRE"].values().toString();
 }
 
 TagLib::uint APE::Tag::year() const

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -63,33 +63,33 @@ String Ogg::XiphComment::title() const
 {
   if(d->fieldListMap["TITLE"].isEmpty())
     return String::null;
-  return d->fieldListMap["TITLE"].front();
+  return d->fieldListMap["TITLE"].toString();
 }
 
 String Ogg::XiphComment::artist() const
 {
   if(d->fieldListMap["ARTIST"].isEmpty())
     return String::null;
-  return d->fieldListMap["ARTIST"].front();
+  return d->fieldListMap["ARTIST"].toString();
 }
 
 String Ogg::XiphComment::album() const
 {
   if(d->fieldListMap["ALBUM"].isEmpty())
     return String::null;
-  return d->fieldListMap["ALBUM"].front();
+  return d->fieldListMap["ALBUM"].toString();
 }
 
 String Ogg::XiphComment::comment() const
 {
   if(!d->fieldListMap["DESCRIPTION"].isEmpty()) {
     d->commentField = "DESCRIPTION";
-    return d->fieldListMap["DESCRIPTION"].front();
+    return d->fieldListMap["DESCRIPTION"].toString();
   }
 
   if(!d->fieldListMap["COMMENT"].isEmpty()) {
     d->commentField = "COMMENT";
-    return d->fieldListMap["COMMENT"].front();
+    return d->fieldListMap["COMMENT"].toString();
   }
 
   return String::null;
@@ -99,7 +99,7 @@ String Ogg::XiphComment::genre() const
 {
   if(d->fieldListMap["GENRE"].isEmpty())
     return String::null;
-  return d->fieldListMap["GENRE"].front();
+  return d->fieldListMap["GENRE"].toString();
 }
 
 TagLib::uint Ogg::XiphComment::year() const

--- a/tests/test_apetag.cpp
+++ b/tests/test_apetag.cpp
@@ -52,7 +52,7 @@ public:
     tag.setProperties(dict);
     CPPUNIT_ASSERT_EQUAL(String("17"), tag.itemListMap()["TRACK"].values()[0]);
     CPPUNIT_ASSERT_EQUAL(2u, tag.itemListMap()["ARTIST"].values().size());
-    CPPUNIT_ASSERT_EQUAL(String("artist 1"), tag.artist());
+    CPPUNIT_ASSERT_EQUAL(String("artist 1 artist 2"), tag.artist());
     CPPUNIT_ASSERT_EQUAL(17u, tag.track());
   }
 


### PR DESCRIPTION
Now they behave in the same way as ID3v2::Tag, fixing issue #162.
