### PR TITLE
Changed cmake_minimum_required from 2.6.0 to 2.8.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(taglib)
 
-cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
 
 option(ENABLE_STATIC "Make static version of libtag"  OFF)
 if(ENABLE_STATIC)


### PR DESCRIPTION
TagLib actually requires CMake 2.8.0 due to `file(COPY ...)` command at the line 110 of `CMakeLists.txt` .
