### PR TITLE
Removed a wrong note from a comment in tstring.h.

### DIFF
--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -173,9 +173,6 @@ namespace TagLib {
 
     /*!
      * Makes a deep copy of the data in \a v.
-     *
-     * \note This should only be used with the 8-bit codecs Latin1 and UTF8, when
-     * used with other codecs it will simply print a warning and exit.
      */
     String(const ByteVector &v, Type t = Latin1);
 


### PR DESCRIPTION
The constructor actually can accept UTF-16 strings.
