### PR TITLE
Removed some redundant code from tsmartptr.h.

### DIFF
--- a/taglib/toolkit/trefcounter.h
+++ b/taglib/toolkit/trefcounter.h
@@ -44,6 +44,7 @@ namespace TagLib
 
     void ref();
     bool deref();
+    int count() const;
     bool unique() const;
 
   private:


### PR DESCRIPTION
Oops! I made a similar pull request #374 but I overlooked a lot of redundancy.
