### PR TITLE
Debug: CMakelists handles NDEBUG as well as config.h.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ if(TRACE_IN_RELEASE)
   set(TRACE_IN_RELEASE TRUE)
 endif()
 
+option( NDEBUG "Do not output debug messages"  OFF )
+if(NDEBUG)
+  set(NDEBUG TRUE)
+endif()
+
 configure_file(taglib/taglib_config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/taglib_config.h)
 
 add_subdirectory(taglib) 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -34,4 +34,7 @@
 /* Indicates whether debug messages are shown even in release mode */
 #cmakedefine   TRACE_IN_RELEASE 1
 
+/* Indicates whether debug messages are shown */
+#cmakedefine   NDEBUG 1
+
 #cmakedefine TESTS_DIR "@TESTS_DIR@"


### PR DESCRIPTION
They were no way to set NDEBUG before
