### PR TITLE
Workaround for 64-bit MP4 atoms

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -20,11 +20,6 @@ if(NOT ${SIZEOF_INT} EQUAL 4)
   MESSAGE(FATAL_ERROR "TagLib requires that int is 32-bit wide.")
 endif()
 
-check_type_size("long" SIZEOF_LONG)
-if(${SIZEOF_LONG} EQUAL 8)
-  set(LONG_IS_INT64 1)
-endif()
-
 check_type_size("long long" SIZEOF_LONGLONG)
 if(NOT ${SIZEOF_LONGLONG} EQUAL 8)
   MESSAGE(FATAL_ERROR "TagLib requires that long long is 64-bit wide.")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -8,9 +8,6 @@
 /* 1 if little-endian, 2 if big-endian. */
 #cmakedefine   FLOAT_BYTEORDER  ${FLOAT_BYTEORDER}
 
-/* Defined if long is 64-bit wide */
-#cmakedefine   LONG_IS_INT64    ${LONG_IS_INT64}
-
 /* Defined if your compiler supports some byte swap functions */
 #cmakedefine   HAVE_GCC_BYTESWAP_16 1
 #cmakedefine   HAVE_GCC_BYTESWAP_32 1

--- a/taglib/mp4/mp4atom.cpp
+++ b/taglib/mp4/mp4atom.cpp
@@ -56,20 +56,21 @@ MP4::Atom::Atom(File *file)
 
   if(length == 1) {
     const long long longLength = file->readBlock(8).toLongLong();
-#ifdef LONG_IS_INT64
-    length = longLength;
-#else
-    if(longLength <= 0xFFFFFFFF) {
-        // The atom has a 64-bit length, but it's actually a 32-bit value
-        length = (long)longLength;
+    if(sizeof(long) == sizeof(long long)) {
+      length = longLength;
     }
     else {
+      if(longLength <= 0xFFFFFFFF) {
+        // The atom has a 64-bit length, but it's actually a 32-bit value
+        length = (long)longLength;
+      }
+      else {
         debug("MP4: 64-bit atoms are not supported");
         length = 0;
         file->seek(0, File::End);
         return;
+      }
     }
-#endif
   }
   if(length < 8) {
     debug("MP4: Invalid atom size");


### PR DESCRIPTION
Workaround for the issue #411.
TagLib already supports large files on the systems that `long` is 64-bit. (e.g. GCC on 64-bit Linux, MacOSX etc.) However, `MP4::Atom` can't handle 64-bit atoms even on such systems.
(This is just a workaround, so I think that we should change `MP4::Atom::offset` and `length` to `long long` or `offset_t` in `taglib2` branch).

The file provided by @flashanand is here: https://testanandsiva.sharefile.com/d/s6c01695aeb142eaa
I tested the file on my 64-bit Linux box and could read/write the tag properly.
I hope somebody would test the file on MacOS X. 
