### PR TITLE
Added some missing detach()s to List<T>, ByteVector and String.

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -714,7 +714,8 @@ ByteVector &ByteVector::resize(uint size, char padding)
 
 ByteVector::Iterator ByteVector::begin()
 {
-  return d->data->data.begin() + d->offset;
+  detach();
+  return d->data->data.begin();
 }
 
 ByteVector::ConstIterator ByteVector::begin() const
@@ -724,7 +725,8 @@ ByteVector::ConstIterator ByteVector::begin() const
 
 ByteVector::Iterator ByteVector::end()
 {
-  return d->data->data.begin() + d->offset + d->length;
+  detach();
+  return d->data->data.end();
 }
 
 ByteVector::ConstIterator ByteVector::end() const
@@ -734,8 +736,8 @@ ByteVector::ConstIterator ByteVector::end() const
 
 ByteVector::ReverseIterator ByteVector::rbegin()
 {
-  std::vector<char> &v = d->data->data;
-  return v.rbegin() + (v.size() - (d->offset + d->length));
+  detach();
+  return d->data->data.rbegin();
 }
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
@@ -746,8 +748,8 @@ ByteVector::ConstReverseIterator ByteVector::rbegin() const
 
 ByteVector::ReverseIterator ByteVector::rend()
 {
-  std::vector<char> &v = d->data->data;
-  return v.rbegin() + (v.size() - d->offset);
+  detach();
+  return d->data->data.rend();
 }
 
 ByteVector::ConstReverseIterator ByteVector::rend() const

--- a/taglib/toolkit/tlist.tcc
+++ b/taglib/toolkit/tlist.tcc
@@ -208,6 +208,7 @@ bool List<T>::isEmpty() const
 template <class T>
 typename List<T>::Iterator List<T>::find(const T &value)
 {
+  detach();
   return std::find(d->list.begin(), d->list.end(), value);
 }
 

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -316,6 +316,7 @@ const wchar_t *String::toCWString() const
 
 String::Iterator String::begin()
 {
+  detach();
   return d->data.begin();
 }
 
@@ -326,6 +327,7 @@ String::ConstIterator String::begin() const
 
 String::Iterator String::end()
 {
+  detach();
   return d->data.end();
 }
 

--- a/tests/test_bytevector.cpp
+++ b/tests/test_bytevector.cpp
@@ -41,6 +41,7 @@ class TestByteVector : public CppUnit::TestFixture
   CPPUNIT_TEST(testToHex);
   CPPUNIT_TEST(testNumericCoversion);
   CPPUNIT_TEST(testReplace);
+  CPPUNIT_TEST(testIterator);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -288,6 +289,36 @@ public:
       a.replace(ByteVector("bf"), ByteVector("x"));
       CPPUNIT_ASSERT_EQUAL(ByteVector("abcdax"), a);
     }
+  }
+
+  void testIterator()
+  {
+    ByteVector v1("taglib");
+    ByteVector v2 = v1;
+
+    ByteVector::Iterator it1 = v1.begin();
+    ByteVector::Iterator it2 = v2.begin();
+
+    CPPUNIT_ASSERT_EQUAL('t', *it1);
+    CPPUNIT_ASSERT_EQUAL('t', *it2);
+
+    std::advance(it1, 4);
+    std::advance(it2, 4);
+    *it2 = 'I';
+    CPPUNIT_ASSERT_EQUAL('i', *it1);
+    CPPUNIT_ASSERT_EQUAL('I', *it2);
+
+    ByteVector::ReverseIterator it3 = v1.rbegin();
+    ByteVector::ReverseIterator it4 = v2.rbegin();
+
+    CPPUNIT_ASSERT_EQUAL('b', *it3);
+    CPPUNIT_ASSERT_EQUAL('b', *it4);
+
+    std::advance(it3, 4);
+    std::advance(it4, 4);
+    *it4 = 'A';
+    CPPUNIT_ASSERT_EQUAL('a', *it3);
+    CPPUNIT_ASSERT_EQUAL('A', *it4);
   }
 
 };

--- a/tests/test_list.cpp
+++ b/tests/test_list.cpp
@@ -51,8 +51,13 @@ public:
     l3.append(3);
     l3.append(4);
     CPPUNIT_ASSERT(l1 == l3);
+    
+    List<int> l4 = l1;
+    List<int>::Iterator it = l4.find(3);
+    *it = 33;
+    CPPUNIT_ASSERT_EQUAL(l1[2], 3);
+    CPPUNIT_ASSERT_EQUAL(l4[2], 33);
   }
-
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestList);

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -15,11 +15,21 @@ public:
 
   void testInsert()
   {
-    Map<String, int> m;
-    m.insert("foo", 3);
-    CPPUNIT_ASSERT_EQUAL(3, m["foo"]);
-    m.insert("foo", 7);
-    CPPUNIT_ASSERT_EQUAL(7, m["foo"]);
+    Map<String, int> m1;
+    m1.insert("foo", 3);
+    CPPUNIT_ASSERT_EQUAL(3, m1["foo"]);
+    m1.insert("foo", 7);
+    CPPUNIT_ASSERT_EQUAL(7, m1["foo"]);
+
+    m1.insert("alice",  5);
+    m1.insert("bob",    9);
+    m1.insert("carol", 11);
+
+    Map<String, int> m2 = m1;
+    Map<String, int>::Iterator it = m2.find("bob");
+    (*it).second = 99;
+    CPPUNIT_ASSERT_EQUAL(m1["bob"], 9);
+    CPPUNIT_ASSERT_EQUAL(m2["bob"], 99);
   }
 
 };

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -44,6 +44,7 @@ class TestString : public CppUnit::TestFixture
   CPPUNIT_TEST(testSubstr);
   CPPUNIT_TEST(testNewline);
   CPPUNIT_TEST(testEncode);
+  CPPUNIT_TEST(testIterator);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -278,6 +279,24 @@ public:
     CPPUNIT_ASSERT(empty5.isEmpty());
     CPPUNIT_ASSERT(empty6.empty());
     CPPUNIT_ASSERT(empty7.empty());
+  }
+
+  void testIterator()
+  {
+    String s1 = "taglib string";
+    String s2 = s1;
+
+    String::Iterator it1 = s1.begin();
+    String::Iterator it2 = s2.begin();
+
+    CPPUNIT_ASSERT_EQUAL(L't', *it1);
+    CPPUNIT_ASSERT_EQUAL(L't', *it2);
+
+    std::advance(it1, 4);
+    std::advance(it2, 4);
+    *it2 = L'I';
+    CPPUNIT_ASSERT_EQUAL(L'i', *it1);
+    CPPUNIT_ASSERT_EQUAL(L'I', *it2);
   }
 
 };


### PR DESCRIPTION
Non-const `begin()`/`end()` require a `detach()`.
Currently, `List<T>`, `ByteVector` and `String` behave like this: 

```
List<int> l1; // { 1, 2, 3, 4, 5 };
List<int> l2 = l1;
List<int>::Iterator it = l2.find(3);  // Logically, it points to l2[2]. Not l1[2].
*it = 33; // This modifies not only l2[2] but also l1[2]. 
```
