### PR TITLE
Define only least required macros for LFS in config.h.

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -8,6 +8,7 @@ include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)
 include(TestBigEndian)
 include(TestFloatFormat)
+include(TestLargeFiles)
 
 # Determine whether your compiler supports C++0x/C++11 and enable it if possible.
 # This check covers GCC, Clang and ICC.
@@ -74,6 +75,15 @@ elseif(${FP_IEEE754} EQUAL 2)
   set(FLOAT_BYTEORDER 2)
 else()
   MESSAGE(FATAL_ERROR "TagLib requires that floating point types are IEEE754 compliant.")
+endif()
+
+# Determine whether your compiler supports large files.
+
+if(NOT WIN32)
+  test_large_files(SUPPORT_LARGE_FILES)
+  if(NOT SUPPORT_LARGE_FILES)
+    MESSAGE(FATAL_ERROR "TagLib requires large files support.")
+  endif()
 endif()
 
 # Determine which kind of atomic operations your compiler supports.

--- a/cmake/TestFileOffsetBits.c
+++ b/cmake/TestFileOffsetBits.c
@@ -1,0 +1,9 @@
+#include <sys/types.h>
+
+int main(int argc, char **argv)
+{
+  /* Cause a compile-time error if off_t is smaller than 64 bits */
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+  int off_t_is_large[ (LARGE_OFF_T % 2147483629 == 721 && LARGE_OFF_T % 2147483647 == 1) ? 1 : -1 ];  
+  return 0;
+}

--- a/cmake/TestLargeFiles.c.cmakein
+++ b/cmake/TestLargeFiles.c.cmakein
@@ -1,0 +1,23 @@
+#cmakedefine _LARGEFILE_SOURCE
+#cmakedefine _LARGEFILE64_SOURCE
+#cmakedefine _LARGE_FILES
+#cmakedefine _FILE_OFFSET_BITS ${_FILE_OFFSET_BITS}
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+  /* Cause a compile-time error if off_t is smaller than 64 bits,
+   * and make sure we have ftello / fseeko.
+   */
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+  int off_t_is_large[ (LARGE_OFF_T % 2147483629 == 721 && LARGE_OFF_T % 2147483647 == 1) ? 1 : -1 ];  
+  FILE *fp = fopen(argv[0],"r");
+  off_t offset = ftello( fp );
+
+  fseeko( fp, offset, SEEK_CUR );
+  fclose(fp);
+  return 0;
+}

--- a/cmake/modules/TestLargeFiles.cmake
+++ b/cmake/modules/TestLargeFiles.cmake
@@ -1,0 +1,104 @@
+# - Define macro to check large file support
+#
+#  TEST_LARGE_FILES(VARIABLE)
+#
+#  VARIABLE will be set to true if off_t is 64 bits, and fseeko/ftello present.
+#  This macro will also set defines necessary enable large file support, for instance
+#  _LARGE_FILES
+#  _LARGEFILE_SOURCE
+#  _FILE_OFFSET_BITS 64
+#  HAVE_FSEEKO
+#
+#  However, it is YOUR job to make sure these defines are set in a cmakedefine so they
+#  end up in a config.h file that is included in your source if necessary!
+
+#  This macro skips the Windows specific checks. Because TagLib uses Win32 API.
+
+MACRO(TEST_LARGE_FILES VARIABLE)
+  IF(NOT DEFINED ${VARIABLE})
+
+    # On most platforms it is probably overkill to first test the flags for 64-bit off_t,
+    # and then separately fseeko. However, in the future we might have 128-bit filesystems
+    # (ZFS), so it might be dangerous to indiscriminately set e.g. _FILE_OFFSET_BITS=64.
+
+    MESSAGE(STATUS "Checking for 64-bit off_t")
+
+    # First check without any special flags
+    TRY_COMPILE(FILE64_OK "${PROJECT_BINARY_DIR}"
+      "${CMAKE_SOURCE_DIR}/cmake/TestFileOffsetBits.c")
+    if(FILE64_OK)
+      MESSAGE(STATUS "Checking for 64-bit off_t - present")
+    endif(FILE64_OK)
+
+    if(NOT FILE64_OK)
+      # Test with _FILE_OFFSET_BITS=64
+      TRY_COMPILE(FILE64_OK "${PROJECT_BINARY_DIR}"
+        "${CMAKE_SOURCE_DIR}/cmake/TestFileOffsetBits.c"
+        COMPILE_DEFINITIONS "-D_FILE_OFFSET_BITS=64" )
+      if(FILE64_OK)
+        MESSAGE(STATUS "Checking for 64-bit off_t - present with _FILE_OFFSET_BITS=64")
+        set(_FILE_OFFSET_BITS 64)
+      endif(FILE64_OK)
+    endif(NOT FILE64_OK)
+
+    if(NOT FILE64_OK)
+      # Test with _LARGE_FILES
+      TRY_COMPILE(FILE64_OK "${PROJECT_BINARY_DIR}"
+        "${CMAKE_SOURCE_DIR}/cmake/TestFileOffsetBits.c"
+        COMPILE_DEFINITIONS "-D_LARGE_FILES" )
+      if(FILE64_OK)
+        MESSAGE(STATUS "Checking for 64-bit off_t - present with _LARGE_FILES")
+        set(_LARGE_FILES 1)
+      endif(FILE64_OK)
+    endif(NOT FILE64_OK)
+
+    if(NOT FILE64_OK)
+      # Test with _LARGEFILE_SOURCE
+      TRY_COMPILE(FILE64_OK "${PROJECT_BINARY_DIR}"
+        "${CMAKE_SOURCE_DIR}/cmake/TestFileOffsetBits.c"
+        COMPILE_DEFINITIONS "-D_LARGEFILE_SOURCE" )
+      if(FILE64_OK)
+        MESSAGE(STATUS "Checking for 64-bit off_t - present with _LARGEFILE_SOURCE")
+        set(_LARGEFILE_SOURCE 1)
+      endif(FILE64_OK)
+    endif(NOT FILE64_OK)
+
+    if(NOT FILE64_OK)
+      MESSAGE(STATUS "Checking for 64-bit off_t - not present")
+    else(NOT FILE64_OK)
+
+      # Set the flags we might have determined to be required above
+      configure_file("${CMAKE_SOURCE_DIR}/cmake/TestLargeFiles.c.cmakein"
+                     "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestLargeFiles.c")
+
+      MESSAGE(STATUS "Checking for fseeko/ftello")
+      # Test if ftello/fseeko are available
+      TRY_COMPILE(FSEEKO_COMPILE_OK "${PROJECT_BINARY_DIR}"
+        "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestLargeFiles.c")
+      if(FSEEKO_COMPILE_OK)
+        MESSAGE(STATUS "Checking for fseeko/ftello - present")
+      endif(FSEEKO_COMPILE_OK)
+
+      if(NOT FSEEKO_COMPILE_OK)
+        # glibc 2.2 neds _LARGEFILE_SOURCE for fseeko (but not 64-bit off_t...)
+        TRY_COMPILE(FSEEKO_COMPILE_OK "${PROJECT_BINARY_DIR}"
+          "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/TestLargeFiles.c"
+          COMPILE_DEFINITIONS "-D_LARGEFILE_SOURCE" )
+        if(FSEEKO_COMPILE_OK)
+          MESSAGE(STATUS "Checking for fseeko/ftello - present with _LARGEFILE_SOURCE")
+          set(_LARGEFILE_SOURCE 1)
+        endif(FSEEKO_COMPILE_OK)
+      endif(NOT FSEEKO_COMPILE_OK)
+
+    endif(NOT FILE64_OK)
+
+    if(FSEEKO_COMPILE_OK)
+      SET(${VARIABLE} 1 CACHE INTERNAL "Result of test for large file support" FORCE)
+      set(HAVE_FSEEKO 1)
+    else(FSEEKO_COMPILE_OK)
+      MESSAGE(STATUS "Checking for fseeko/ftello - not found")
+      SET(${VARIABLE} 0 CACHE INTERNAL "Result of test for large file support" FORCE)
+    endif(FSEEKO_COMPILE_OK)
+
+  ENDIF(NOT DEFINED ${VARIABLE})
+ENDMACRO(TEST_LARGE_FILES VARIABLE)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -8,6 +8,11 @@
 /* 1 if little-endian, 2 if big-endian. */
 #cmakedefine   FLOAT_BYTEORDER  ${FLOAT_BYTEORDER}
 
+/* Defined if required for large files support */
+#cmakedefine   _LARGE_FILES      ${_LARGE_FILES}
+#cmakedefine   _LARGEFILE_SOURCE ${_LARGEFILE_SOURCE}
+#cmakedefine   _FILE_OFFSET_BITS ${_FILE_OFFSET_BITS}
+
 /* Defined if your compiler supports some atomic operations */
 #cmakedefine   HAVE_STD_ATOMIC 1
 #cmakedefine   HAVE_BOOST_ATOMIC 1

--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -36,19 +36,6 @@
 #define TAGLIB_CONSTRUCT_BITSET(x) static_cast<unsigned long>(x)
 #endif
 
-#ifdef _WIN32
-# if !defined(NOMINMAX)
-#   define NOMINMAX
-# endif
-# include <windows.h>
-#else
-# ifndef _LARGEFILE_SOURCE
-#   define _LARGEFILE_SOURCE
-# endif
-# define _FILE_OFFSET_BITS 64
-# include <sys/types.h>
-#endif
-
 //! A namespace for all TagLib related classes and functions
 
 /*!
@@ -59,7 +46,7 @@
  * \endcode
  */
 
-namespace TagLib 
+namespace TagLib
 {
   typedef wchar_t            wchar;   // Assumed to be sufficient to store a UTF-16 char.
   typedef unsigned char      uchar;
@@ -68,15 +55,10 @@ namespace TagLib
   typedef unsigned long long ulonglong;
 
   // long/ulong can be either 32-bit or 64-bit wide.
-  typedef unsigned long  ulong;
+  typedef unsigned long      ulong;
 
-  // Offset or length type for I/O streams.  
-  // In Win32, always signed 64-bit. Otherwise, equivalent to off_t.
-#ifdef _WIN32
-  typedef LONGLONG offset_t;
-#else
-  typedef off_t    offset_t;
-#endif
+  // Offset or length type for I/O streams. Always signed 64-bit.
+  typedef long long          offset_t;
 
   enum ByteOrder
   {

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -23,6 +23,11 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
+// Required for large files support.
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "tfilestream.h"
 #include "tstring.h"
 #include "tdebug.h"

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -27,6 +27,7 @@
 #define TAGLIB_LIST_H
 
 #include "taglib.h"
+#include <cstddef>
 #include <list>
 
 namespace TagLib {

--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -27,6 +27,7 @@
 #define TAGLIB_MAP_H
 
 #include "taglib.h"
+#include <cstddef>
 #include <map>
 
 namespace TagLib {


### PR DESCRIPTION
While investigating the issue #411, I found that current TagLib2 branch doesn't work on some systems (e.g. PowerPC version of Ubuntu) due to the wrong definition of offset_t. 
So I fixed the definition of `offset_t`. Also moved some complicated macro definitions from `taglib.h` to `config.h` and changed them to be defined when required.
