### PR TITLE
Reduce ref/deref operations by introducing swap() functions.

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -527,13 +527,13 @@ ByteVector::~ByteVector()
 
 ByteVector &ByteVector::setData(const char *s, uint length)
 {
-  *this = ByteVector(s, length);
+  ByteVector(s, length).swap(*this);
   return *this;
 }
 
 ByteVector &ByteVector::setData(const char *data)
 {
-  *this = ByteVector(data);
+  ByteVector(data).swap(*this);
   return *this;
 }
 
@@ -675,8 +675,7 @@ int ByteVector::endsWithPartialMatch(const ByteVector &pattern) const
 
 ByteVector &ByteVector::append(const ByteVector &v)
 {
-  if(v.d->length != 0)
-  {
+  if(!v.isEmpty()) {
     detach();
 
     uint originalSize = size();
@@ -689,7 +688,7 @@ ByteVector &ByteVector::append(const ByteVector &v)
 
 ByteVector &ByteVector::clear()
 {
-  *this = ByteVector();
+  ByteVector().swap(*this);
   return *this;
 }
 
@@ -889,14 +888,14 @@ bool ByteVector::operator<(const ByteVector &v) const
 {
   const int result = ::memcmp(data(), v.data(), std::min(size(), v.size()));
   if(result != 0)
-    return result < 0;
+    return (result < 0);
   else
-    return size() < v.size();
+    return (size() < v.size());
 }
 
 bool ByteVector::operator>(const ByteVector &v) const
 {
-  return v < *this;
+  return (v < *this);
 }
 
 ByteVector ByteVector::operator+(const ByteVector &v) const
@@ -908,27 +907,25 @@ ByteVector ByteVector::operator+(const ByteVector &v) const
 
 ByteVector &ByteVector::operator=(const ByteVector &v)
 {
-  if(&v == this)
-    return *this;
-
-  if(d->deref())
-    delete d;
-
-  d = v.d;
-  d->ref();
+  ByteVector(v).swap(*this);
   return *this;
 }
 
 ByteVector &ByteVector::operator=(char c)
 {
-  *this = ByteVector(c);
+  ByteVector(c).swap(*this);
   return *this;
 }
 
 ByteVector &ByteVector::operator=(const char *data)
 {
-  *this = ByteVector(data);
+  ByteVector(data).swap(*this);
   return *this;
+}
+
+void ByteVector::swap(ByteVector &v)
+{
+  std::swap(d, v.d);
 }
 
 ByteVector ByteVector::toHex() const

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -557,6 +557,11 @@ namespace TagLib {
     ByteVector &operator=(const char *data);
 
     /*!
+     * Exchanges the content of the ByteVector by the content of \a v.
+     */
+    void swap(ByteVector &v);
+
+    /*!
      * A static, empty ByteVector which is convenient and fast (since returning
      * an empty or "null" value does not require instantiating a new ByteVector).
      */

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -215,11 +215,16 @@ namespace TagLib {
     const T &operator[](uint i) const;
 
     /*!
-     * Make a shallow, implicitly shared, copy of \a l.  Because this is
+     * Makes a shallow, implicitly shared, copy of \a l.  Because this is
      * implicitly shared, this method is lightweight and suitable for
      * pass-by-value usage.
      */
     List<T> &operator=(const List<T> &l);
+
+    /*!
+     * Exchanges the content of the List by the content of \a l.
+     */
+    void swap(List<T> &l);
 
     /*!
      * Compares this list with \a l and returns true if all of the elements are
@@ -233,6 +238,11 @@ namespace TagLib {
     bool operator!=(const List<T> &l) const;
 
   protected:
+    /*!
+     * Makes a deep copy of \a l.
+     */
+    List(const std::list<T> &l);
+
     /*
      * If this List is being shared via implicit sharing, do a deep copy of the
      * data and separate from the shared members.  This should be called by all

--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -174,7 +174,21 @@ namespace TagLib {
      */
     Map<Key, T> &operator=(const Map<Key, T> &m);
 
+    /*!
+     * Exchanges the content of the Map by the content of \a m.
+     */
+    void swap(Map<Key, T> &m);
+
   protected:
+    /*!
+     * Makes a deep copy of \a m.
+     */
+#ifdef WANT_CLASS_INSTANTIATION_OF_MAP
+    Map(const std::map<class Key, class T> &m);
+#else
+    Map(const std::map<Key, T> &m);
+#endif
+
     /*
      * If this List is being shared via implicit sharing, do a deep copy of the
      * data and separate from the shared members.  This should be called by all

--- a/taglib/toolkit/trefcounter.cpp
+++ b/taglib/toolkit/trefcounter.cpp
@@ -72,17 +72,14 @@ namespace TagLib
   class RefCounter::RefCounterPrivate
   {
   public:
-    RefCounterPrivate() : refCount(1) {}
-
-    void ref() { ATOMIC_INC(refCount); }
-    bool deref() { return (ATOMIC_DEC(refCount) == 0); }
-    int count() const { return refCount; }
+    RefCounterPrivate() :
+      refCount(1) {}
 
     volatile ATOMIC_INT refCount;
   };
 
-  RefCounter::RefCounter()
-    : d(new RefCounterPrivate())
+  RefCounter::RefCounter() :
+    d(new RefCounterPrivate())
   {
   }
 
@@ -91,18 +88,23 @@ namespace TagLib
     delete d;
   }
 
-  void RefCounter::ref() 
-  { 
-    d->ref(); 
+  void RefCounter::ref()
+  {
+    ATOMIC_INC(d->refCount);
   }
 
-  bool RefCounter::deref() 
-  { 
-    return d->deref(); 
+  bool RefCounter::deref()
+  {
+    return (ATOMIC_DEC(d->refCount) == 0);
   }
 
-  int RefCounter::count() const 
-  { 
-    return d->count(); 
+  int RefCounter::count() const
+  {
+    return static_cast<int>(d->refCount);
+  }
+
+  bool RefCounter::unique() const
+  {
+    return (count() == 1);
   }
 }

--- a/taglib/toolkit/trefcounter.h
+++ b/taglib/toolkit/trefcounter.h
@@ -67,6 +67,7 @@ namespace TagLib
     void ref();
     bool deref();
     int count() const;
+    bool unique() const;
 
   private:
     class RefCounterPrivate;

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -683,90 +683,62 @@ String &String::operator+=(char c)
 
 String &String::operator=(const String &s)
 {
-  if(&s == this)
-    return *this;
+  if(d != s.d)
+    String(s).swap(*this);
 
-  if(d->deref())
-    delete d;
-  d = s.d;
-  d->ref();
   return *this;
 }
 
 String &String::operator=(const std::string &s)
 {
-  if(d->deref())
-    delete d;
-
-  d = new StringPrivate;
-  copyFromLatin1(s.c_str(), s.length());
-
+  String(s).swap(*this);
   return *this;
 }
 
 String &String::operator=(const wstring &s)
 {
-  if(d->deref())
-    delete d;
-  d = new StringPrivate(s);
+  String(s).swap(*this);
   return *this;
 }
 
 String &String::operator=(const wchar_t *s)
 {
-  if(d->deref())
-    delete d;
-
-  d = new StringPrivate(s);
+  String(s).swap(*this);
   return *this;
 }
 
 String &String::operator=(char c)
 {
-  if(d->deref())
-    delete d;
-
-  d = new StringPrivate(1, static_cast<uchar>(c));
+  String(c).swap(*this);
   return *this;
 }
 
 String &String::operator=(wchar_t c)
 {
-  if(d->deref())
-    delete d;
-
-  d = new StringPrivate(1, c);
+  String(c, WCharByteOrder).swap(*this); // Second parameter can be removed in taglib2.
   return *this;
 }
 
 String &String::operator=(const char *s)
 {
-  if(d->deref())
-    delete d;
-
-  d = new StringPrivate;
-  copyFromLatin1(s, ::strlen(s));
-
+  String(s).swap(*this);
   return *this;
 }
 
 String &String::operator=(const ByteVector &v)
 {
-  if(d->deref())
-    delete d;
-
-  d = new StringPrivate;
-  copyFromLatin1(v.data(), v.size());
-
-  // If we hit a null in the ByteVector, shrink the string again.
-  d->data.resize(::wcslen(d->data.c_str()));
-
+  String(v).swap(*this);
   return *this;
+}
+
+void String::swap(String &s)
+{
+  std::swap(d, s.d);
 }
 
 bool String::operator<(const String &s) const
 {
-  return d->data < s.d->data;
+  return (d->data < s.d->data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -775,10 +747,8 @@ bool String::operator<(const String &s) const
 
 void String::detach()
 {
-  if(d->count() > 1) {
-    d->deref();
-    d = new StringPrivate(d->data);
-  }
+  if(!d->unique())
+    String(d->data).swap(*this);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -468,12 +468,12 @@ namespace TagLib {
     String &operator=(const wchar_t *s);
 
     /*!
-     * Performs a deep copy of the data in \a s.
+     * Performs a deep copy of the data in \a c.
      */
     String &operator=(char c);
 
     /*!
-     * Performs a deep copy of the data in \a s.
+     * Performs a deep copy of the data in \a c.
      */
     String &operator=(wchar_t c);
 
@@ -488,9 +488,14 @@ namespace TagLib {
     String &operator=(const ByteVector &v);
 
     /*!
+     * Exchanges the content of the String by the content of \a s.
+     */
+    void swap(String &s);
+
+    /*!
      * To be able to use this class in a Map, this operator needed to be
-     * implemented.  Returns true if \a s is less than this string in a bytewise
-     * comparison.
+     * implemented.  Returns true if \a s is less than this string in a
+     * character-wise comparison.
      */
     bool operator<(const String &s) const;
 


### PR DESCRIPTION
Removed redundant ```ref```/```deref``` operations which make the memory management complicated from ```ByteVector```, ```String```, ```List``` and ```Map``` by introducing ```swap()``` functions.
Now, each class has only a pair of ```ref```/```deref``` except for ```ByteVector```. ```ByteVector``` is a little more complicated due to the nested ```RefCounter```s should be fixed in another patch.
