### PR TITLE
Ignoring files generated when creating an Xcode project via cmake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ CMakeFiles/
 /taglib/tag.dir/Release
 /ALL_BUILD.dir
 /ZERO_CHECK.dir
+taglib.xcodeproj
+CMakeScripts


### PR DESCRIPTION
As requested by @lalinsky in issue #428 
