### PR TITLE
Fix various memleaks in the tests

### DIFF
--- a/tests/test_aiff.cpp
+++ b/tests/test_aiff.cpp
@@ -24,6 +24,7 @@ public:
 
     RIFF::AIFF::File *f = new RIFF::AIFF::File(filename.c_str());
     CPPUNIT_ASSERT_EQUAL(705, f->audioProperties()->bitrate());
+    delete f;
   }
 
 };

--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -136,6 +136,7 @@ public:
       FileRef *f = new FileRef(TEST_FILE_PATH_C("empty_flac.oga"));
       CPPUNIT_ASSERT(dynamic_cast<Ogg::Vorbis::File *>(f->file()) == NULL);
       CPPUNIT_ASSERT(dynamic_cast<Ogg::FLAC::File *>(f->file()) != NULL);
+      delete f;
   }
 
   void testOGA_Vorbis()
@@ -143,6 +144,7 @@ public:
       FileRef *f = new FileRef(TEST_FILE_PATH_C("empty_vorbis.oga"));
       CPPUNIT_ASSERT(dynamic_cast<Ogg::Vorbis::File *>(f->file()) != NULL);
       CPPUNIT_ASSERT(dynamic_cast<Ogg::FLAC::File *>(f->file()) == NULL);
+      delete f;
   }
 
   void testAPE()

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -69,6 +69,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("image/png"), pic->mimeType());
     CPPUNIT_ASSERT_EQUAL(String("A pixel."), pic->description());
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(150), pic->data().size());
+
+    delete f;
   }
 
   void testAddPicture()

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -207,6 +207,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("image/jpeg"), frame->mimeType());
     CPPUNIT_ASSERT_EQUAL(ID3v2::AttachedPictureFrame::FileIcon, frame->type());
     CPPUNIT_ASSERT_EQUAL(String("d"), frame->description());
+
+    delete frame;
   }
 
   void testDontRender22()

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -142,6 +142,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("82,164"), f->tag()->itemListMap()["----:com.apple.iTunes:replaygain_track_minmax"].toStringList()[0]);
     CPPUNIT_ASSERT_EQUAL(String("Pearl Jam"), f->tag()->artist());
     CPPUNIT_ASSERT_EQUAL(String("foo"), f->tag()->comment());
+    delete f;
   }
 
   void test64BitAtom()
@@ -158,6 +159,7 @@ public:
 
     f->tag()->itemListMap()["pgap"] = true;
     f->save();
+    delete atoms;
     delete f;
 
     f = new MP4::File(filename.c_str());
@@ -168,6 +170,7 @@ public:
     moov = atoms->atoms[0];
     // original size + 'pgap' size + padding
     CPPUNIT_ASSERT_EQUAL(long(77 + 25 + 974), moov->length);
+    delete atoms;
     delete f;
   }
 

--- a/tests/test_riff.cpp
+++ b/tests/test_riff.cpp
@@ -86,6 +86,8 @@ public:
 
     CPPUNIT_ASSERT_EQUAL(ByteVector("TEST"), f->chunkName(2));
     CPPUNIT_ASSERT_EQUAL(ByteVector("foo"), f->chunkData(2));
+
+    delete f;
   }
 
   void testLastChunkAtEvenPosition()

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #endif
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <string>
 #include <fstream>
@@ -26,7 +27,9 @@ inline string testFilePath(const string &filename)
 
 inline string copyFile(const string &filename, const string &ext)
 {
-  string newname = string(tempnam(NULL, NULL)) + ext;
+  char *newname_c = tempnam(NULL, NULL);
+  string newname = string(newname_c) + ext;
+  free(newname_c);
   string oldname = testFilePath(filename) + ext;
 #ifdef _WIN32
   CopyFileA(oldname.c_str(), newname.c_str(), FALSE);


### PR DESCRIPTION
Fix the memory leaks in the test suite to better detect the memory leaks occurring in the actual library code.
