### PR TITLE
Fix ByteVector sizes in some test cases

### DIFF
--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -199,7 +199,7 @@ public:
                                  "JPG"
                                  "\x01"
                                  "d\x00"
-                                 "\x00", 18);
+                                 "\x00", 14);
     ID3v2::AttachedPictureFrame *frame =
         static_cast<TagLib::ID3v2::AttachedPictureFrame*>(factory->createFrame(data, TagLib::uint(2)));
 
@@ -218,7 +218,7 @@ public:
                                  "JPG"
                                  "\x01"
                                  "d\x00"
-                                 "\x00", 18);
+                                 "\x00", 14);
     ID3v2::AttachedPictureFrame *frame =
         static_cast<TagLib::ID3v2::AttachedPictureFrame*>(factory->createFrame(data, TagLib::uint(2)));
 


### PR DESCRIPTION
The specified sizes were too large and read outside the allocated memory area.
