### PR TITLE
cmake: improve distro integration allowing to use the standard CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,12 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-option(ENABLE_STATIC "Make static version of libtag"  OFF)
-if(ENABLE_STATIC)
+if(DEFINED ENABLE_STATIC)
+  message(FATAL_ERROR "This option is no longer available, use BUILD_SHARED_LIBS instead")
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
   add_definitions(-DTAGLIB_STATIC)
-  set(BUILD_SHARED_LIBS OFF)
-else()
-  set(BUILD_SHARED_LIBS ON)
 endif()
 OPTION(ENABLE_STATIC_RUNTIME "Visual Studio, link with runtime statically"  OFF)
 

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,7 @@ For a 10.6 Snow Leopard static library with both 32-bit and 64-bit code, use:
   cmake -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=10.6 \
     -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" \
-    -DENABLE_STATIC=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_INSTALL_PREFIX="<folder you want to build to>"
 
 After 'make', and 'make install', add libtag.a to your XCode project, and add
@@ -139,9 +139,9 @@ The easiest way is at the Command Prompt.
        4. Select: Project Only
        5. Select: Build Only INSTALL
 
-To build a static library enable the following two options with CMake.
-  -DENABLE_STATIC=ON -DENABLE_STATIC_RUNTIME=ON
-  
+To build a static library, set the following two options with CMake.
+  -DBUILD_SHARED_LIBS=OFF -DENABLE_STATIC_RUNTIME=ON
+
 Including ENABLE_STATIC_RUNTIME=ON indicates you want TagLib built using the
 static runtime library, rather than the DLL form of the runtime.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,9 +7,9 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/../taglib
 		     ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg/id3v2
 		     ${CMAKE_CURRENT_SOURCE_DIR}/../bindings/c/  )
 
-if(ENABLE_STATIC)
+if(NOT BUILD_SHARED_LIBS)
     add_definitions(-DTAGLIB_STATIC)
-endif(ENABLE_STATIC)
+endif()
 
 ########### next target ###############
 


### PR DESCRIPTION
Hi all,

This patch makes taglib more standard wrt CMake options, so makes easier its integration in distros.

Regards,

Samuel