### PR TITLE
Make embPos unsigned

### DIFF
--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -237,7 +237,8 @@ void TableOfContentsFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  int pos = 0, embPos = 0;
+  int pos = 0;
+  unsigned embPos = 0;
   d->elementID = readStringField(data, String::Latin1, &pos).data(String::Latin1);
   d->elementID.append(char(0));
   d->isTopLevel = (data.at(pos) & 2) > 0;


### PR DESCRIPTION
This fixes:

```
/home/xhochy/Development/taglib/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp: In member function ‘virtual void TagLib::ID3v2::TableOfContentsFrame::parseF
ields(const TagLib::ByteVector&)’:
/home/xhochy/Development/taglib/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp:254:16: warning: comparison between signed and unsigned integer expressions [
-Wsign-compare]
   while(embPos < size - header()->size()) {
```

This change is valid as embPos is initially zero and only non-negative values are added to it.