### PR TITLE
Remove an unused file from taglib/CMakeLists.txt.

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -318,7 +318,6 @@ if(HAVE_ZLIB_SOURCE)
     ${ZLIB_SOURCE}/inffast.c
     ${ZLIB_SOURCE}/inflate.c
     ${ZLIB_SOURCE}/inftrees.c
-    ${ZLIB_SOURCE}/uncompr.c
     ${ZLIB_SOURCE}/zutil.c
   )
 endif()


### PR DESCRIPTION
uncompr.c is no longer used since caa53e8