### PR TITLE
Implement missing AIFF::File::hasID3v2Tag().

### DIFF
--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -39,7 +39,8 @@ public:
   FilePrivate() :
     properties(0),
     tag(0),
-    tagChunkID("ID3 ")
+    tagChunkID("ID3 "),
+    hasID3v2(false)
   {
 
   }
@@ -53,6 +54,8 @@ public:
   Properties *properties;
   ID3v2::Tag *tag;
   ByteVector tagChunkID;
+
+  bool hasID3v2;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -100,7 +103,6 @@ PropertyMap RIFF::AIFF::File::setProperties(const PropertyMap &properties)
   return d->tag->setProperties(properties);
 }
 
-
 RIFF::AIFF::Properties *RIFF::AIFF::File::audioProperties() const
 {
   return d->properties;
@@ -119,10 +121,15 @@ bool RIFF::AIFF::File::save()
   }
 
   setChunkData(d->tagChunkID, d->tag->render());
+  d->hasID3v2 = true;
 
   return true;
 }
 
+bool RIFF::AIFF::File::hasID3v2Tag() const
+{
+  return d->hasID3v2;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // private members
@@ -134,6 +141,7 @@ void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertie
     if(chunkName(i) == "ID3 " || chunkName(i) == "id3 ") {
       d->tagChunkID = chunkName(i);
       d->tag = new ID3v2::Tag(this, chunkOffset(i));
+      d->hasID3v2 = true;
     }
     else if(chunkName(i) == "COMM" && readProperties)
       d->properties = new Properties(chunkData(i), propertiesStyle);

--- a/tests/test_aiff.cpp
+++ b/tests/test_aiff.cpp
@@ -13,6 +13,7 @@ class TestAIFF : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestAIFF);
   CPPUNIT_TEST(testReading);
+  CPPUNIT_TEST(testSaveID3v2);
   CPPUNIT_TEST(testAiffCProperties);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
@@ -24,6 +25,25 @@ public:
   {
     RIFF::AIFF::File f(TEST_FILE_PATH_C("empty.aiff"));
     CPPUNIT_ASSERT_EQUAL(705, f.audioProperties()->bitrate());
+  }
+
+  void testSaveID3v2()
+  {
+    ScopedFileCopy copy("empty", ".aiff");
+    string newname = copy.fileName();
+
+    {
+      RIFF::AIFF::File f(newname.c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.tag()->setTitle(L"TitleXXX");
+      f.save();
+    }
+
+    {
+      RIFF::AIFF::File f(newname.c_str());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL(String(L"TitleXXX"), f.tag()->title());
+    }
   }
 
   void testAiffCProperties()


### PR DESCRIPTION
```hasID3v2Tag()``` is in the header file but doesn't exist in the source file.
This is part of #488, but I decided to create a separate pull request since this is a fatal error and should be fixed immediately.