### PR TITLE
Simplify overly complicated ByteVector::mid() implementation.

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -661,8 +661,9 @@ ByteVector::ReverseIterator ByteVector::rbegin()
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
-  // we need a const reference to the data vector so we can ensure the const version of rbegin() is called
-  const std::vector<char> &v = d->data->data;
+  // Workaround for the Solaris Studio 12.4 compiler.
+  // We need a const reference to the data vector so we can ensure the const version of rbegin() is called.
+  const std::vector<char> &v = *d->data;
   return v.rbegin() + (v.size() - (d->offset + d->length));
 }
 
@@ -674,8 +675,9 @@ ByteVector::ReverseIterator ByteVector::rend()
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
-  // we need a const reference to the data vector so we can ensure the const version of rbegin() is called
-  const std::vector<char> &v = d->data->data;
+  // Workaround for the Solaris Studio 12.4 compiler.
+  // We need a const reference to the data vector so we can ensure the const version of rbegin() is called.
+  const std::vector<char> &v = *d->data;
   return v.rbegin() + (v.size() - d->offset);
 }
 

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -451,12 +451,12 @@ ByteVector &ByteVector::setData(const char *data)
 char *ByteVector::data()
 {
   detach();
-  return (size() > 0) ? (&d->data->front() + d->offset) : 0;
+  return (size() > 0) ? (&(*d->data)[d->offset]) : 0;
 }
 
 const char *ByteVector::data() const
 {
-  return (size() > 0) ? (&d->data->front() + d->offset) : 0;
+  return (size() > 0) ? (&(*d->data)[d->offset]) : 0;
 }
 
 ByteVector ByteVector::mid(uint index, uint length) const

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -49,8 +49,6 @@
 //
 // http://www.informit.com/isapi/product_id~{9C84DAB4-FE6E-49C5-BB0A-FB50331233EA}/content/index.asp
 
-#define DATA(x) (&(*(x)->data)[0])
-
 namespace TagLib {
 
 static const char hexTable[17] = "0123456789abcdef";
@@ -474,12 +472,12 @@ ByteVector &ByteVector::setData(const char *data)
 char *ByteVector::data()
 {
   detach();
-  return (size() > 0) ? (DATA(d) + d->offset) : 0;
+  return (size() > 0) ? (&d->data->front() + d->offset) : 0;
 }
 
 const char *ByteVector::data() const
 {
-  return (size() > 0) ? (DATA(d) + d->offset) : 0;
+  return (size() > 0) ? (&d->data->front() + d->offset) : 0;
 }
 
 ByteVector ByteVector::mid(uint index, uint length) const
@@ -492,7 +490,7 @@ ByteVector ByteVector::mid(uint index, uint length) const
 
 char ByteVector::at(uint index) const
 {
-  return (index < size()) ? DATA(d)[d->offset + index] : 0;
+  return (index < size()) ? (*d->data)[d->offset + index] : 0;
 }
 
 int ByteVector::find(const ByteVector &pattern, uint offset, int byteAlign) const
@@ -797,13 +795,13 @@ long double ByteVector::toFloat80BE(size_t offset) const
 
 const char &ByteVector::operator[](int index) const
 {
-  return DATA(d)[d->offset + index];
+  return (*d->data)[d->offset + index];
 }
 
 char &ByteVector::operator[](int index)
 {
   detach();
-  return DATA(d)[d->offset + index];
+  return (*d->data)[d->offset + index];
 }
 
 bool ByteVector::operator==(const ByteVector &v) const
@@ -900,7 +898,7 @@ void ByteVector::detach()
 {
   if(d->counter->count() > 1) {
     if(!isEmpty())
-      ByteVector(DATA(d) + d->offset, d->length).swap(*this);
+      ByteVector(&d->data->front() + d->offset, d->length).swap(*this);
     else
       ByteVector().swap(*this);
   }

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -202,6 +202,11 @@ namespace TagLib {
     ByteVector &append(const ByteVector &v);
 
     /*!
+     * Appends \a c to the end of the ByteVector.
+     */
+    ByteVector &append(char c);
+
+    /*!
      * Clears the data.
      */
     ByteVector &clear();
@@ -566,6 +571,11 @@ namespace TagLib {
      * \warning The behavior is undefined if \a data is not null terminated.
      */
     ByteVector &operator=(const char *data);
+
+    /*!
+     * Exchanges the content of the ByteVector by the content of \a v.
+     */
+    void swap(ByteVector &v);
 
     /*!
      * A static, empty ByteVector which is convenient and fast (since returning

--- a/tests/test_bytevector.cpp
+++ b/tests/test_bytevector.cpp
@@ -43,6 +43,7 @@ class TestByteVector : public CppUnit::TestFixture
   CPPUNIT_TEST(testReplace);
   CPPUNIT_TEST(testIterator);
   CPPUNIT_TEST(testResize);
+  CPPUNIT_TEST(testAppend);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -312,6 +313,8 @@ public:
     *it2 = 'I';
     CPPUNIT_ASSERT_EQUAL('i', *it1);
     CPPUNIT_ASSERT_EQUAL('I', *it2);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("taglib"), v1);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("taglIb"), v2);
 
     ByteVector::ReverseIterator it3 = v1.rbegin();
     ByteVector::ReverseIterator it4 = v2.rbegin();
@@ -324,6 +327,8 @@ public:
     *it4 = 'A';
     CPPUNIT_ASSERT_EQUAL('a', *it3);
     CPPUNIT_ASSERT_EQUAL('A', *it4);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("taglib"), v1);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("tAglIb"), v2);
 
     ByteVector v3;
     v3 = ByteVector("0123456789").mid(3, 4);
@@ -381,6 +386,20 @@ public:
     c.resize(3, 'C');
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(3), c.size());
     CPPUNIT_ASSERT_EQUAL(-1, c.find('C'));
+  }
+
+  void testAppend()
+  {
+    ByteVector v1("taglib");
+    ByteVector v2 = v1;
+
+    v1.append("ABC");
+    CPPUNIT_ASSERT_EQUAL(ByteVector("taglibABC"), v1);
+    v1.append('1');
+    v1.append('2');
+    v1.append('3');
+    CPPUNIT_ASSERT_EQUAL(ByteVector("taglibABC123"), v1);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("taglib"), v2);
   }
 
 };


### PR DESCRIPTION
Especially remove the useless nested RefCounters.

#### Background

I implemented the copy-on-write operation of ```ByteVector::mid()``` almost two years ago to fix #121 or to speed up parsing some huge tags, and I think it was successful. However, its implementation was overly complicated due to my hastiness and poor coding skill. (especially, it has nested ```RefCounter```s) I have been concerned with it for a long time.

Even though this is focused on simplifying the code, not improving the performance, it makes the ```mid()``` operations slightly faster.