### PR TITLE
Skip empty ID3v2 frames when saving an ID3v2 tag.

### DIFF
--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -193,6 +193,9 @@ void Frame::setText(const String &)
 ByteVector Frame::render() const
 {
   ByteVector fieldData = renderFields();
+  if(fieldData.isEmpty())
+    fieldData = ByteVector("\x00", 1);
+
   d->header->setFrameSize(fieldData.size());
   ByteVector headerData = d->header->render();
 

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -193,9 +193,6 @@ void Frame::setText(const String &)
 ByteVector Frame::render() const
 {
   ByteVector fieldData = renderFields();
-  if(fieldData.isEmpty())
-    fieldData = ByteVector("\x00", 1);
-
   d->header->setFrameSize(fieldData.size());
   ByteVector headerData = d->header->render();
 

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -597,7 +597,7 @@ ByteVector ID3v2::Tag::render(int version) const
     }
     if(!(*it)->header()->tagAlterPreservation()) {
       const ByteVector frameData = (*it)->render();
-      if(frameData.size() == Frame::headerSize()) {
+      if(frameData.size() == Frame::headerSize((*it)->header()->version())) {
         debug("An empty ID3v2 frame \'"
           + String((*it)->header()->frameID()) + "\' has been discarded");
         continue;

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -591,12 +591,19 @@ ByteVector ID3v2::Tag::render(int version) const
   for(FrameList::ConstIterator it = frameList.begin(); it != frameList.end(); it++) {
     (*it)->header()->setVersion(version);
     if((*it)->header()->frameID().size() != 4) {
-      debug("A frame of unsupported or unknown type \'"
+      debug("An ID3v2 frame of unsupported or unknown type \'"
           + String((*it)->header()->frameID()) + "\' has been discarded");
       continue;
     }
-    if(!(*it)->header()->tagAlterPreservation())
+    if(!(*it)->header()->tagAlterPreservation()) {
+      const ByteVector frameData = (*it)->render();
+      if(frameData.size() == Frame::headerSize()) {
+        debug("An empty ID3v2 frame \'"
+          + String((*it)->header()->frameID()) + "\' has been discarded");
+        continue;
+      }
       tagData.append((*it)->render());
+    }
   }
 
   // Compute the amount of padding, and append that to tagData.

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -92,6 +92,7 @@ class TestID3v2 : public CppUnit::TestFixture
   CPPUNIT_TEST(testParseTableOfContentsFrame);
   CPPUNIT_TEST(testRenderTableOfContentsFrame);
   CPPUNIT_TEST(testShrinkPadding);
+  CPPUNIT_TEST(testEmptyFrame);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -1036,6 +1037,35 @@ public:
 
       f.save();
       CPPUNIT_ASSERT(f.length() < 10 * 1024);
+    }
+  }
+
+  void testEmptyFrame()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+    string newname = copy.fileName();
+
+    {
+      MPEG::File f(newname.c_str());
+      ID3v2::Tag *tag = f.ID3v2Tag(true);
+
+      ID3v2::UrlLinkFrame *frame1 = new ID3v2::UrlLinkFrame(
+        ByteVector("WOAF\x00\x00\x00\x01\x00\x00\x00", 11));
+      tag->addFrame(frame1);
+
+      ID3v2::TextIdentificationFrame *frame2 = new ID3v2::TextIdentificationFrame("TIT2");
+      frame2->setText("Title");
+      tag->addFrame(frame2);
+
+      f.save();
+    }
+
+    {
+      MPEG::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(true, f.hasID3v2Tag());
+
+      ID3v2::Tag *tag = f.ID3v2Tag();
+      CPPUNIT_ASSERT_EQUAL(String("Title"), tag->title());
     }
   }
 

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -1066,6 +1066,7 @@ public:
 
       ID3v2::Tag *tag = f.ID3v2Tag();
       CPPUNIT_ASSERT_EQUAL(String("Title"), tag->title());
+      CPPUNIT_ASSERT_EQUAL(true, tag->frameListMap()["WOAF"].isEmpty());
     }
   }
 


### PR DESCRIPTION
This fixes #512.