### PR TITLE
Avoid memmove across different buffers in ByteVector::replace()

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -629,17 +629,19 @@ ByteVector &ByteVector::replace(const ByteVector &pattern, const ByteVector &wit
       break;
 
     if(diff < 0) {
+      char *pData = data();
       ::memmove(
-        data() + offset + withSize,
-        data() + offset + patternSize,
+        pData + offset + withSize,
+        pData + offset + patternSize,
         size() - offset - patternSize);
       resize(size() + diff);
     }
     else if(diff > 0) {
       resize(size() + diff);
+      char *pData = data();
       ::memmove(
-        data() + offset + withSize,
-        data() + offset + patternSize,
+        pData + offset + withSize,
+        pData + offset + patternSize,
         size() - diff - offset - patternSize);
     }
 

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -622,13 +622,11 @@ ByteVector &ByteVector::replace(const ByteVector &pattern, const ByteVector &wit
   const ptrdiff_t diff = withSize - patternSize;
 
   size_t offset = 0;
-  while (true)
-  {
+  while (true) {
+
     offset = find(pattern, offset);
     if(offset == static_cast<size_t>(-1)) // Use npos in taglib2.
       break;
-
-    detach();
 
     if(diff < 0) {
       ::memmove(


### PR DESCRIPTION
detach() is called inside ByteVector::data().