### PR TITLE
FileRef: Allow an IOStream to be used

### DIFF
--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -128,7 +128,21 @@ namespace TagLib {
                      audioPropertiesStyle = AudioProperties::Average);
 
     /*!
-     * Construct a FileRef using \a file.  The FileRef now takes ownership of the
+     * Construct a FileRef from an opened \a IOStream.  If \a readAudioProperties is true then
+     * the audio properties will be read using \a audioPropertiesStyle.  If
+     * \a readAudioProperties is false then \a audioPropertiesStyle will be
+     * ignored.
+     *
+     * Also see the note in the class documentation about why you may not want to
+     * use this method in your application.
+     */
+    explicit FileRef(IOStream* stream,
+                     bool readAudioProperties = true,
+                     AudioProperties::ReadStyle
+                     audioPropertiesStyle = AudioProperties::Average);
+
+    /*!
+     * Contruct a FileRef using \a file.  The FileRef now takes ownership of the
      * pointer and will delete the File when it passes out of scope.
      */
     explicit FileRef(File *file);

--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -6,6 +6,7 @@
 #include <vorbisfile.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
+#include <tfilestream.h>
 
 using namespace std;
 using namespace TagLib;
@@ -66,6 +67,17 @@ public:
     delete f;
 
     f = new FileRef(newname.c_str());
+    CPPUNIT_ASSERT(!f->isNull());
+    CPPUNIT_ASSERT_EQUAL(f->tag()->artist(), String("ttest artist"));
+    CPPUNIT_ASSERT_EQUAL(f->tag()->title(), String("ytest title"));
+    CPPUNIT_ASSERT_EQUAL(f->tag()->genre(), String("uTest!"));
+    CPPUNIT_ASSERT_EQUAL(f->tag()->album(), String("ialbummmm"));
+    CPPUNIT_ASSERT_EQUAL(f->tag()->track(), TagLib::uint(7));
+    CPPUNIT_ASSERT_EQUAL(f->tag()->year(), TagLib::uint(2080));
+    delete f;
+
+    FileStream fs(newname.c_str());
+    f = new FileRef(&fs);
     CPPUNIT_ASSERT(!f->isNull());
     CPPUNIT_ASSERT_EQUAL(f->tag()->artist(), String("ttest artist"));
     CPPUNIT_ASSERT_EQUAL(f->tag()->title(), String("ytest title"));


### PR DESCRIPTION
Refs issue #526 

I haven't tested it on WinRT (which is the main reason for this, but it works fine on linux)
I'm submitting this for early review and will post the WinRT results as soon as I have a build & it's integrated.

Cheers,