### PR TITLE
Fix ByteVector to return correct iterators after detached.

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -712,7 +712,7 @@ ByteVector &ByteVector::resize(uint size, char padding)
 ByteVector::Iterator ByteVector::begin()
 {
   detach();
-  return d->data->data.begin();
+  return d->data->data.begin() + d->offset;
 }
 
 ByteVector::ConstIterator ByteVector::begin() const
@@ -723,7 +723,7 @@ ByteVector::ConstIterator ByteVector::begin() const
 ByteVector::Iterator ByteVector::end()
 {
   detach();
-  return d->data->data.end();
+  return d->data->data.begin() + d->offset + d->length;
 }
 
 ByteVector::ConstIterator ByteVector::end() const
@@ -734,25 +734,23 @@ ByteVector::ConstIterator ByteVector::end() const
 ByteVector::ReverseIterator ByteVector::rbegin()
 {
   detach();
-  return d->data->data.rbegin();
+  return d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length));
 }
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
-  std::vector<char> &v = d->data->data;
-  return v.rbegin() + (v.size() - (d->offset + d->length));
+  return d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length));
 }
 
 ByteVector::ReverseIterator ByteVector::rend()
 {
   detach();
-  return d->data->data.rend();
+  return d->data->data.rbegin() + (d->data->data.size() - d->offset);
 }
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
-  std::vector<char> &v = d->data->data;
-  return v.rbegin() + (v.size() - d->offset);
+  return d->data->data.rbegin() + (d->data->data.size() - d->offset);
 }
 
 bool ByteVector::isNull() const

--- a/tests/test_bytevector.cpp
+++ b/tests/test_bytevector.cpp
@@ -319,6 +319,10 @@ public:
     *it4 = 'A';
     CPPUNIT_ASSERT_EQUAL('a', *it3);
     CPPUNIT_ASSERT_EQUAL('A', *it4);
+
+    ByteVector v3;
+    v3 = ByteVector("taglib").mid(3);
+    CPPUNIT_ASSERT_EQUAL('l', *v3.begin());
   }
 
 };


### PR DESCRIPTION
This fixes #529.

It's a subtle bug of ```ByteVector``` and it have to be attributed to me. ```ByteVector::begin()``` and related functions return wrong iterator in some cases. For example, after doing like this:
```
// line 247 of oggpage.cpp
packetBuf = packetBuf.mid(SPLITSIZE);
```

Sorry for causing such a bug and thank you for cathing it.