### PR TITLE
Fix the wrong padding of ByteVector::resize().

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -702,6 +702,7 @@ ByteVector &ByteVector::resize(uint size, char padding)
 {
   if(size != d->length) {
     detach();
+    d->data->data.resize(d->offset + d->length);
     d->data->data.resize(d->offset + size, padding);
     d->length = size;
   }

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -703,11 +703,15 @@ ByteVector &ByteVector::resize(uint size, char padding)
   if(size != d->length) {
     detach();
 
-    if(size > d->data->data.size() - d->offset)
-      d->data->data.resize(d->offset + size);
+    const size_t bufferSize = d->data->data.size();
 
-    if(size > d->length)
-      ::memset(DATA(d) + d->offset + d->length, padding, size - d->length);
+    if(size > bufferSize - d->offset) {
+      d->data->data.resize(d->offset + size, padding);
+      ::memset(&*end(), padding, bufferSize - (d->length + d->offset));
+    }
+    else if(size > d->length) {
+      ::memset(&*end(), padding, size - d->length);
+    }
 
     d->length = size;
   }

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -702,8 +702,13 @@ ByteVector &ByteVector::resize(uint size, char padding)
 {
   if(size != d->length) {
     detach();
-    d->data->data.resize(d->offset + d->length);
-    d->data->data.resize(d->offset + size, padding);
+
+    if(size > d->data->data.size() - d->offset)
+      d->data->data.resize(d->offset + size);
+
+    if(size > d->length)
+      ::memset(DATA(d) + d->offset + d->length, padding, size - d->length);
+
     d->length = size;
   }
 

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -703,15 +703,12 @@ ByteVector &ByteVector::resize(uint size, char padding)
   if(size != d->length) {
     detach();
 
-    const size_t bufferSize = d->data->data.size();
+    // Remove the excessive length of the internal buffer first to pad correctly.
+    // This doesn't reallocate the buffer, since std::vector::resize() doesn't
+    // reallocate the buffer when shrinking.
 
-    if(size > bufferSize - d->offset) {
-      d->data->data.resize(d->offset + size, padding);
-      ::memset(&*end(), padding, bufferSize - (d->length + d->offset));
-    }
-    else if(size > d->length) {
-      ::memset(&*end(), padding, size - d->length);
-    }
+    d->data->data.resize(d->offset + d->length);
+    d->data->data.resize(d->offset + size, padding);
 
     d->length = size;
   }

--- a/tests/test_bytevector.cpp
+++ b/tests/test_bytevector.cpp
@@ -123,6 +123,12 @@ public:
     CPPUNIT_ASSERT(i.containsAt(j, 5, 0));
     CPPUNIT_ASSERT(i.containsAt(j, 6, 1));
     CPPUNIT_ASSERT(i.containsAt(j, 6, 1, 3));
+
+    ByteVector k = ByteVector("0123456789").mid(3, 4);
+    k.resize(6, 'A');
+    CPPUNIT_ASSERT_EQUAL(uint(6), k.size());
+    CPPUNIT_ASSERT_EQUAL('6', k[3]);
+    CPPUNIT_ASSERT_EQUAL('A', k[4]);
   }
 
   void testFind1()

--- a/tests/test_bytevector.cpp
+++ b/tests/test_bytevector.cpp
@@ -42,6 +42,7 @@ class TestByteVector : public CppUnit::TestFixture
   CPPUNIT_TEST(testNumericCoversion);
   CPPUNIT_TEST(testReplace);
   CPPUNIT_TEST(testIterator);
+  CPPUNIT_TEST(testResize);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -123,12 +124,6 @@ public:
     CPPUNIT_ASSERT(i.containsAt(j, 5, 0));
     CPPUNIT_ASSERT(i.containsAt(j, 6, 1));
     CPPUNIT_ASSERT(i.containsAt(j, 6, 1, 3));
-
-    ByteVector k = ByteVector("0123456789").mid(3, 4);
-    k.resize(6, 'A');
-    CPPUNIT_ASSERT_EQUAL(uint(6), k.size());
-    CPPUNIT_ASSERT_EQUAL('6', k[3]);
-    CPPUNIT_ASSERT_EQUAL('A', k[4]);
   }
 
   void testFind1()
@@ -338,6 +333,50 @@ public:
     it4 = v3.rend() - 1;
     CPPUNIT_ASSERT_EQUAL('6', *it3);
     CPPUNIT_ASSERT_EQUAL('3', *it4);
+  }
+
+  void testResize()
+  {
+    ByteVector a = ByteVector("0123456789");
+    ByteVector b = a.mid(3, 4);
+    b.resize(6, 'A');
+    CPPUNIT_ASSERT_EQUAL(uint(6), b.size());
+    CPPUNIT_ASSERT_EQUAL('6', b[3]);
+    CPPUNIT_ASSERT_EQUAL('A', b[4]);
+    CPPUNIT_ASSERT_EQUAL('A', b[5]);
+    b.resize(10, 'B');
+    CPPUNIT_ASSERT_EQUAL(uint(10), b.size());
+    CPPUNIT_ASSERT_EQUAL('6', b[3]);
+    CPPUNIT_ASSERT_EQUAL('B', b[6]);
+    CPPUNIT_ASSERT_EQUAL('B', b[9]);
+    b.resize(3, 'C');
+    CPPUNIT_ASSERT_EQUAL(uint(3), b.size());
+    CPPUNIT_ASSERT_EQUAL(-1, b.find('C'));
+    b.resize(3);
+    CPPUNIT_ASSERT_EQUAL(uint(3), b.size());
+
+    // Check if a and b were properly detached.
+
+    CPPUNIT_ASSERT_EQUAL(uint(10), a.size());
+    CPPUNIT_ASSERT_EQUAL('3', a[3]);
+    CPPUNIT_ASSERT_EQUAL('5', a[5]);
+
+    // Special case that refCount == 1 and d->offset != 0.
+
+    ByteVector c = ByteVector("0123456789").mid(3, 4);
+    c.resize(6, 'A');
+    CPPUNIT_ASSERT_EQUAL(uint(6), c.size());
+    CPPUNIT_ASSERT_EQUAL('6', c[3]);
+    CPPUNIT_ASSERT_EQUAL('A', c[4]);
+    CPPUNIT_ASSERT_EQUAL('A', c[5]);
+    c.resize(10, 'B');
+    CPPUNIT_ASSERT_EQUAL(uint(10), c.size());
+    CPPUNIT_ASSERT_EQUAL('6', c[3]);
+    CPPUNIT_ASSERT_EQUAL('B', c[6]);
+    CPPUNIT_ASSERT_EQUAL('B', c[9]);
+    c.resize(3, 'C');
+    CPPUNIT_ASSERT_EQUAL(uint(3), c.size());
+    CPPUNIT_ASSERT_EQUAL(-1, c.find('C'));
   }
 
 };


### PR DESCRIPTION
The expanded area will be filled with garbage instead of correct padding in some corner cases.

Related to #531, I found another corner case bug of ```ByteVector```. It won't affect badly as far as I tested, but bug is bug.