### PR TITLE
Bytevector truncate

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -709,6 +709,16 @@ ByteVector &ByteVector::resize(uint size, char padding)
   return *this;
 }
 
+ByteVector &ByteVector::truncate(uint offset)
+{
+  if (offset<d->length) {
+    detach();
+    d->length = offset;
+  }
+
+  return *this;
+}
+
 ByteVector::Iterator ByteVector::begin()
 {
   detach();

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -217,6 +217,12 @@ namespace TagLib {
      */
     ByteVector &resize(uint size, char padding = 0);
 
+
+    /*!
+     * Truncate the vector at offset. Returns a reference to the truncated vector.
+     */
+    ByteVector &truncate(uint offset);
+
     /*!
      * Returns an Iterator that points to the front of the vector.
      */

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -415,7 +415,7 @@ ByteVector String::data(Type t) const
 
       const size_t len = UTF16toUTF8(
         d->data.c_str(), d->data.size(), v.data(), v.size());
-      v.resize(len);
+      v.truncate(len);
 
       return v;
     }


### PR DESCRIPTION
Get rid of the additional buffer resize() in String.data(String::UTF8) by doing a cheap truncate on the ByteVector. The returned bytevector is mostly likely a short lived transitional buffer anyhow.