### PR TITLE
 bytevector.mid(pos,4).toUInt() => bytevector.toUInt(pos)

### DIFF
--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -221,13 +221,13 @@ void ChapterFrame::parseFields(const ByteVector &data)
   int pos = 0, embPos = 0;
   d->elementID = readStringField(data, String::Latin1, &pos).data(String::Latin1);
   d->elementID.append(char(0));
-  d->startTime = data.toUInt(pos,true);
+  d->startTime = data.toUInt(pos, true);
   pos += 4;
-  d->endTime = data.toUInt(pos,true);
+  d->endTime = data.toUInt(pos, true);
   pos += 4;
-  d->startOffset = data.toUInt(pos,true);
+  d->startOffset = data.toUInt(pos, true);
   pos += 4;
-  d->endOffset = data.toUInt(pos,true);
+  d->endOffset = data.toUInt(pos, true);
   pos += 4;
   size -= pos;
 

--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -221,13 +221,13 @@ void ChapterFrame::parseFields(const ByteVector &data)
   int pos = 0, embPos = 0;
   d->elementID = readStringField(data, String::Latin1, &pos).data(String::Latin1);
   d->elementID.append(char(0));
-  d->startTime = data.mid(pos, 4).toUInt(true);
+  d->startTime = data.toUInt(pos,true);
   pos += 4;
-  d->endTime = data.mid(pos, 4).toUInt(true);
+  d->endTime = data.toUInt(pos,true);
   pos += 4;
-  d->startOffset = data.mid(pos, 4).toUInt(true);
+  d->startOffset = data.toUInt(pos,true);
   pos += 4;
-  d->endOffset = data.mid(pos, 4).toUInt(true);
+  d->endOffset = data.toUInt(pos,true);
   pos += 4;
   size -= pos;
 

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
@@ -193,7 +193,7 @@ void SynchronizedLyricsFrame::parseFields(const ByteVector &data)
     if(text.isNull() || pos + 4 > end)
       return;
 
-    uint time = data.mid(pos, 4).toUInt(true);
+    uint time = data.toUInt(pos,true);
     pos += 4;
 
     d->synchedText.append(SynchedText(time, text));

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
@@ -193,7 +193,7 @@ void SynchronizedLyricsFrame::parseFields(const ByteVector &data)
     if(text.isNull() || pos + 4 > end)
       return;
 
-    uint time = data.toUInt(pos,true);
+    uint time = data.toUInt(pos, true);
     pos += 4;
 
     d->synchedText.append(SynchedText(time, text));


### PR DESCRIPTION
Replace use of bytevector.mid(pos,4).toUInt() with more optimized bytevector.toUInt(pos)