### PR TITLE
Replace cmake ENABLE_STATIC with more generic BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 option(BUILD_SHARED_LIBS "Build as shared library"  ON)
 
-if(DEFINED ENABLE_STATIC)
+if(ENABLE_STATIC)
   message(FATAL_ERROR "ENABLE_STATIC no longer supported. Use BUILD_SHARED_LIBS to control linkage")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,14 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
-option(ENABLE_STATIC "Make static version of libtag"  OFF)
-if(ENABLE_STATIC)
+option(BUILD_SHARED_LIBS "Build as shared library"  ON)
+
+if(DEFINED ENABLE_STATIC)
+  message(FATAL_ERROR "ENABLE_STATIC no longer supported. Use BUILD_SHARED_LIBS to control linkage")
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
   add_definitions(-DTAGLIB_STATIC)
-  set(BUILD_SHARED_LIBS OFF)
-else()
-  set(BUILD_SHARED_LIBS ON)
 endif()
 OPTION(ENABLE_STATIC_RUNTIME "Visual Studio, link with runtime statically"  OFF)
 
@@ -61,7 +63,7 @@ set(TAGLIB_LIB_VERSION_STRING "${TAGLIB_LIB_MAJOR_VERSION}.${TAGLIB_LIB_MINOR_VE
 # 1. If the library source code has changed at all since the last update, then increment revision.
 # 2. If any interfaces have been added, removed, or changed since the last update, increment current, and set revision to 0.
 # 3. If any interfaces have been added since the last public release, then increment age.
-# 4. If any interfaces have been removed since the last public release, then set age to 0. 
+# 4. If any interfaces have been removed since the last public release, then set age to 0.
 set(TAGLIB_SOVERSION_CURRENT  15)
 set(TAGLIB_SOVERSION_REVISION 0)
 set(TAGLIB_SOVERSION_AGE      14)
@@ -109,7 +111,7 @@ endif()
 
 configure_file(taglib/taglib_config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/taglib_config.h)
 
-add_subdirectory(taglib) 
+add_subdirectory(taglib)
 add_subdirectory(bindings)
 if(BUILD_TESTS)
     enable_testing()

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,7 @@ For a 10.6 Snow Leopard static library with both 32-bit and 64-bit code, use:
   cmake -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_OSX_DEPLOYMENT_TARGET=10.6 \
     -DCMAKE_OSX_ARCHITECTURES="i386;x86_64" \
-    -DENABLE_STATIC=ON \
+    -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_INSTALL_PREFIX="<folder you want to build to>"
 
 After 'make', and 'make install', add libtag.a to your XCode project, and add
@@ -140,8 +140,8 @@ The easiest way is at the Command Prompt.
        5. Select: Build Only INSTALL
 
 To build a static library enable the following two options with CMake.
-  -DENABLE_STATIC=ON -DENABLE_STATIC_RUNTIME=ON
-  
+  -DBUILD_SHARED_LIBS=OFF -DENABLE_STATIC_RUNTIME=ON
+
 Including ENABLE_STATIC_RUNTIME=ON indicates you want TagLib built using the
 static runtime library, rather than the DLL form of the runtime.
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,9 +7,9 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR}/../taglib
 		     ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg/id3v2
 		     ${CMAKE_CURRENT_SOURCE_DIR}/../bindings/c/  )
 
-if(ENABLE_STATIC)
+if(NOT BUILD_SHARED_LIBS)
     add_definitions(-DTAGLIB_STATIC)
-endif(ENABLE_STATIC)
+endif()
 
 ########### next target ###############
 


### PR DESCRIPTION
This replaces the #444 pull request (which had a typo). In addition it builds a shared library by default, something the previous patch didn't do.