### PR TITLE
No need to call ID3v2::Frame::render() twice when saving an ID3v2 tag.

### DIFF
--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -602,7 +602,7 @@ ByteVector ID3v2::Tag::render(int version) const
           + String((*it)->header()->frameID()) + "\' has been discarded");
         continue;
       }
-      tagData.append((*it)->render());
+      tagData.append(frameData);
     }
   }
 


### PR DESCRIPTION
Omission in #515.