### PR TITLE
(wishlist) AIFF: AudioProperties improvements

### DIFF
--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -40,10 +40,7 @@ public:
     properties(0),
     tag(0),
     tagChunkID("ID3 "),
-    hasID3v2(false)
-  {
-
-  }
+    hasID3v2(false) {}
 
   ~FilePrivate()
   {
@@ -62,20 +59,20 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::AIFF::File::File(FileName file, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(file, BigEndian)
+RIFF::AIFF::File::File(FileName file, bool readProperties, Properties::ReadStyle) :
+  RIFF::File(file, BigEndian),
+  d(new FilePrivate())
 {
-  d = new FilePrivate;
   if(isOpen())
-    read(readProperties, propertiesStyle);
+    read(readProperties);
 }
 
-RIFF::AIFF::File::File(IOStream *stream, bool readProperties,
-                       Properties::ReadStyle propertiesStyle) : RIFF::File(stream, BigEndian)
+RIFF::AIFF::File::File(IOStream *stream, bool readProperties, Properties::ReadStyle) :
+  RIFF::File(stream, BigEndian),
+  d(new FilePrivate())
 {
-  d = new FilePrivate;
   if(isOpen())
-    read(readProperties, propertiesStyle);
+    read(readProperties);
 }
 
 RIFF::AIFF::File::~File()
@@ -135,7 +132,7 @@ bool RIFF::AIFF::File::hasID3v2Tag() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
+void RIFF::AIFF::File::read(bool readProperties)
 {
   for(uint i = 0; i < chunkCount(); ++i) {
     const ByteVector name = chunkName(i);
@@ -155,5 +152,5 @@ void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertie
     d->tag = new ID3v2::Tag();
 
   if(readProperties)
-    d->properties = new Properties(this, propertiesStyle);
+    d->properties = new Properties(this, Properties::Average);
 }

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -137,42 +137,23 @@ bool RIFF::AIFF::File::hasID3v2Tag() const
 
 void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertiesStyle)
 {
-  ByteVector formatData;
-  for(uint i = 0; i < chunkCount(); i++) {
+  for(uint i = 0; i < chunkCount(); ++i) {
     const ByteVector name = chunkName(i);
     if(name == "ID3 " || name == "id3 ") {
       if(!d->tag) {
-        d->tagChunkID = name;
         d->tag = new ID3v2::Tag(this, chunkOffset(i));
+        d->tagChunkID = name;
         d->hasID3v2 = true;
       }
       else {
         debug("RIFF::AIFF::File::read() - Duplicate ID3v2 tag found.");
       }
     }
-    else if(readProperties) {
-      if(name == "COMM") {
-        if(formatData.isEmpty()) {
-          formatData = chunkData(i);
-        }
-        else {
-          debug("RIFF::AIFF::File::read() - Duplicate 'COMM' chunk found.");
-        }
-      }
-      else if(name == "SSND") {
-        if(streamLength == 0) {
-          streamLength = chunkDataSize(i) + chunkPadding(i);
-        }
-        else {
-          debug("RIFF::AIFF::File::read() - Duplicate 'SSND' chunk found.");
-        }
-      }
-    }
   }
 
   if(!d->tag)
-    d->tag = new ID3v2::Tag;
+    d->tag = new ID3v2::Tag();
 
-  if(!formatData.isEmpty())
-    d->properties = new Properties(formatData, propertiesStyle);
+  if(readProperties)
+    d->properties = new Properties(this, propertiesStyle);
 }

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -150,12 +150,22 @@ void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertie
         debug("RIFF::AIFF::File::read() - Duplicate ID3v2 tag found.");
       }
     }
-    else if(name == "COMM" && readProperties) {
-      if(formatData.isEmpty()) {
-        formatData = chunkData(i);
+    else if(readProperties) {
+      if(name == "COMM") {
+        if(formatData.isEmpty()) {
+          formatData = chunkData(i);
+        }
+        else {
+          debug("RIFF::AIFF::File::read() - Duplicate 'COMM' chunk found.");
+        }
       }
-      else {
-        debug("RIFF::AIFF::File::read() - Duplicate 'COMM' chunk found.");
+      else if(name == "SSND") {
+        if(streamLength == 0) {
+          streamLength = chunkDataSize(i) + chunkPadding(i);
+        }
+        else {
+          debug("RIFF::AIFF::File::read() - Duplicate 'SSND' chunk found.");
+        }
       }
     }
   }

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -130,7 +130,7 @@ namespace TagLib {
         File(const File &);
         File &operator=(const File &);
 
-        void read(bool readProperties, Properties::ReadStyle propertiesStyle);
+        void read(bool readProperties);
 
         friend class Properties;
 

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -132,6 +132,8 @@ namespace TagLib {
 
         void read(bool readProperties, Properties::ReadStyle propertiesStyle);
 
+        friend class Properties;
+
         class FilePrivate;
         FilePrivate *d;
       };

--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -57,7 +57,7 @@ public:
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-RIFF::AIFF::Properties::Properties(const ByteVector & /*data*/, ReadStyle style) :
+RIFF::AIFF::Properties::Properties(const ByteVector &, ReadStyle style) :
   AudioProperties(style),
   d(new PropertiesPrivate())
 {

--- a/taglib/riff/aiff/aiffproperties.h
+++ b/taglib/riff/aiff/aiffproperties.h
@@ -49,8 +49,16 @@ namespace TagLib {
         /*!
          * Create an instance of AIFF::Properties with the data read from the
          * ByteVector \a data.
+         *
+         * \deprecated
          */
         Properties(const ByteVector &data, ReadStyle style);
+
+        /*!
+         * Create an instance of AIFF::Properties with the data read from the
+         * AIFF::File \a file.
+         */
+        Properties(File *file, ReadStyle style);
 
         /*!
          * Destroys this AIFF::Properties instance.
@@ -146,7 +154,7 @@ namespace TagLib {
         Properties(const Properties &);
         Properties &operator=(const Properties &);
 
-        void read(const ByteVector &data);
+        void read(File *file);
 
         class PropertiesPrivate;
         PropertiesPrivate *d;

--- a/taglib/riff/aiff/aiffproperties.h
+++ b/taglib/riff/aiff/aiffproperties.h
@@ -57,14 +57,65 @@ namespace TagLib {
          */
         virtual ~Properties();
 
-        // Reimplementations.
-
+        /*!
+         * Returns the length of the file in seconds.  The length is rounded down to
+         * the nearest whole second.
+         *
+         * \note This method is just an alias of lengthInSeconds().
+         *
+         * \deprecated
+         */
         virtual int length() const;
+
+        /*!
+         * Returns the length of the file in seconds.  The length is rounded down to
+         * the nearest whole second.
+         *
+         * \see lengthInMilliseconds()
+         */
+        // BIC: make virtual
+        int lengthInSeconds() const;
+
+        /*!
+         * Returns the length of the file in milliseconds.
+         *
+         * \see lengthInSeconds()
+         */
+        // BIC: make virtual
+        int lengthInMilliseconds() const;
+
+        /*!
+         * Returns the average bit rate of the file in kb/s.
+         */
         virtual int bitrate() const;
+
+        /*!
+         * Returns the sample rate in Hz.
+         */
         virtual int sampleRate() const;
+
+        /*!
+         * Returns the number of audio channels.
+         */
         virtual int channels() const;
 
+        /*!
+         * Returns the number of bits per audio sample.
+         */
+        int bitsPerSample() const;
+
+        /*!
+         * Returns the number of bits per audio sample.
+         *
+         * \note This method is just an alias of bitsPerSample().
+         *
+         * \deprecated
+         */
         int sampleWidth() const;
+
+        /*!
+         * Returns the number of sample frames
+         */
         uint sampleFrames() const;
 
         /*!

--- a/tests/test_aiff.cpp
+++ b/tests/test_aiff.cpp
@@ -12,9 +12,9 @@ using namespace TagLib;
 class TestAIFF : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestAIFF);
-  CPPUNIT_TEST(testReading);
-  CPPUNIT_TEST(testSaveID3v2);
+  CPPUNIT_TEST(testAiffProperties);
   CPPUNIT_TEST(testAiffCProperties);
+  CPPUNIT_TEST(testSaveID3v2);
   CPPUNIT_TEST(testDuplicateID3v2);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
@@ -22,10 +22,38 @@ class TestAIFF : public CppUnit::TestFixture
 
 public:
 
-  void testReading()
+  void testAiffProperties()
   {
     RIFF::AIFF::File f(TEST_FILE_PATH_C("empty.aiff"));
-    CPPUNIT_ASSERT_EQUAL(705, f.audioProperties()->bitrate());
+    CPPUNIT_ASSERT(f.audioProperties());
+    CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->length());
+    CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->lengthInSeconds());
+    CPPUNIT_ASSERT_EQUAL(67, f.audioProperties()->lengthInMilliseconds());
+    CPPUNIT_ASSERT_EQUAL(706, f.audioProperties()->bitrate());
+    CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
+    CPPUNIT_ASSERT_EQUAL(1, f.audioProperties()->channels());
+    CPPUNIT_ASSERT_EQUAL(16, f.audioProperties()->bitsPerSample());
+    CPPUNIT_ASSERT_EQUAL(16, f.audioProperties()->sampleWidth());
+    CPPUNIT_ASSERT_EQUAL(2941U, f.audioProperties()->sampleFrames());
+    CPPUNIT_ASSERT_EQUAL(false, f.audioProperties()->isAiffC());
+  }
+
+  void testAiffCProperties()
+  {
+    RIFF::AIFF::File f(TEST_FILE_PATH_C("alaw.aifc"));
+    CPPUNIT_ASSERT(f.audioProperties());
+    CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->length());
+    CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->lengthInSeconds());
+    CPPUNIT_ASSERT_EQUAL(37, f.audioProperties()->lengthInMilliseconds());
+    CPPUNIT_ASSERT_EQUAL(706, f.audioProperties()->bitrate());
+    CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
+    CPPUNIT_ASSERT_EQUAL(1, f.audioProperties()->channels());
+    CPPUNIT_ASSERT_EQUAL(16, f.audioProperties()->bitsPerSample());
+    CPPUNIT_ASSERT_EQUAL(16, f.audioProperties()->sampleWidth());
+    CPPUNIT_ASSERT_EQUAL(1622U, f.audioProperties()->sampleFrames());
+    CPPUNIT_ASSERT_EQUAL(true, f.audioProperties()->isAiffC());
+    CPPUNIT_ASSERT_EQUAL(ByteVector("ALAW"), f.audioProperties()->compressionType());
+    CPPUNIT_ASSERT_EQUAL(String("SGI CCITT G.711 A-law"), f.audioProperties()->compressionName());
   }
 
   void testSaveID3v2()
@@ -45,14 +73,6 @@ public:
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL(String(L"TitleXXX"), f.tag()->title());
     }
-  }
-
-  void testAiffCProperties()
-  {
-    RIFF::AIFF::File f(TEST_FILE_PATH_C("alaw.aifc"));
-    CPPUNIT_ASSERT(f.audioProperties()->isAiffC());
-    CPPUNIT_ASSERT_EQUAL(ByteVector("ALAW"), f.audioProperties()->compressionType());
-    CPPUNIT_ASSERT_EQUAL(String("SGI CCITT G.711 A-law"), f.audioProperties()->compressionName());
   }
 
   void testDuplicateID3v2()

--- a/tests/test_aiff.cpp
+++ b/tests/test_aiff.cpp
@@ -45,7 +45,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->length());
     CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->lengthInSeconds());
     CPPUNIT_ASSERT_EQUAL(37, f.audioProperties()->lengthInMilliseconds());
-    CPPUNIT_ASSERT_EQUAL(706, f.audioProperties()->bitrate());
+    CPPUNIT_ASSERT_EQUAL(355, f.audioProperties()->bitrate());
     CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
     CPPUNIT_ASSERT_EQUAL(1, f.audioProperties()->channels());
     CPPUNIT_ASSERT_EQUAL(16, f.audioProperties()->bitsPerSample());


### PR DESCRIPTION
This replaces a part of #506.

Add lengthInSeconds(), lengthInMilliseconds() properties. (#503)
Add bitsPerSample() property besides sampleWidth(). (#360)
Add some tests for audio properties.
Add some supplementary comments.