### PR TITLE
std::map::erase() can take a key directly and has no-throw guarantee.

### DIFF
--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -145,9 +145,7 @@ template <class Key, class T>
 Map<Key, T> &Map<Key,T>::erase(const Key &key)
 {
   detach();
-  Iterator it = d->map.find(key);
-  if(it != d->map.end())
-    d->map.erase(it);
+  d->map.erase(key);
   return *this;
 }
 


### PR DESCRIPTION
http://www.cplusplus.com/reference/map/map/erase/