### PR TITLE
Map::erase() can take a key directly so no need to call find() before…

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -284,9 +284,7 @@ const APE::ItemListMap& APE::Tag::itemListMap() const
 
 void APE::Tag::removeItem(const String &key)
 {
-  Map<const String, Item>::Iterator it = d->itemListMap.find(key.upper());
-  if(it != d->itemListMap.end())
-    d->itemListMap.erase(it);
+  d->itemListMap.erase(key.upper());
 }
 
 void APE::Tag::addValue(const String &key, const String &value, bool replace)

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -172,9 +172,7 @@ bool ASF::Tag::contains(const String &key) const
 
 void ASF::Tag::removeItem(const String &key)
 {
-  AttributeListMap::Iterator it = d->attributeListMap.find(key);
-  if(it != d->attributeListMap.end())
-    d->attributeListMap.erase(it);
+  d->attributeListMap.erase(key);
 }
 
 ASF::AttributeList ASF::Tag::attribute(const String &name) const


### PR DESCRIPTION
…hand.