### PR TITLE
Skip duplicate chunks when reading AIFF/WAV files.

### DIFF
--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -150,8 +150,14 @@ void RIFF::AIFF::File::read(bool readProperties, Properties::ReadStyle propertie
         debug("RIFF::AIFF::File::read() - Duplicate ID3v2 tag found.");
       }
     }
-    else if(name == "COMM" && readProperties)
-      formatData = chunkData(i);
+    else if(name == "COMM" && readProperties) {
+      if(formatData.isEmpty()) {
+        formatData = chunkData(i);
+      }
+      else {
+        debug("RIFF::AIFF::File::read() - Duplicate 'COMM' chunk found.");
+      }
+    }
   }
 
   if(!d->tag)

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -217,10 +217,22 @@ void RIFF::WAV::File::read(bool readProperties, Properties::ReadStyle properties
         }
       }
     }
-    else if(name == "fmt " && readProperties)
-      formatData = chunkData(i);
-    else if(name == "data" && readProperties)
-      streamLength = chunkDataSize(i);
+    else if(name == "fmt " && readProperties) {
+      if(formatData.isEmpty()) {
+        formatData = chunkData(i);
+      }
+      else {
+        debug("RIFF::WAV::File::read() - Duplicate 'fmt ' chunk found.");
+      }
+    }
+    else if(name == "data" && readProperties) {
+      if(streamLength == 0) {
+        streamLength = chunkDataSize(i);
+      }
+      else {
+        debug("RIFF::WAV::File::read() - Duplicate 'data' chunk found.");
+      }
+    }
   }
 
   if(!d->tag[ID3v2Index])


### PR DESCRIPTION
Similar to #492.
There is no good reason to use the last chunk rather than the first one.