### PR TITLE
Skip both ID3v1 and APE tags when seeking the last MPEG frame.

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -469,7 +469,16 @@ long MPEG::File::firstFrameOffset()
 
 long MPEG::File::lastFrameOffset()
 {
-  return previousFrameOffset(hasID3v1Tag() ? d->ID3v1Location - 1 : length());
+  long position;
+
+  if(hasAPETag())
+    position = d->APELocation - 1;
+  else if(hasID3v1Tag())
+    position = d->ID3v1Location - 1;
+  else
+    position = length();
+
+  return previousFrameOffset(position);
 }
 
 bool MPEG::File::hasID3v1Tag() const


### PR DESCRIPTION
Related to #577. I missed out on the fact that we can also skip an APE tag.