### PR TITLE
Skip duplicate ID3v2 tags by taking them into the first one as padding.

### DIFF
--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -663,6 +663,24 @@ void ID3v2::Tag::read()
       return;
 
     parse(d->file->readBlock(d->header.tagSize()));
+
+    // Take duplicate ID3v2 tags into the first one as padding.
+
+    // Workaround for some faulty files that have duplicate ID3v2 tags.
+    // As far as we recognize, the combination of Exact Audio Copy and LAME
+    // creates such files when configured incorrectly.
+
+    while(true) {
+      d->file->seek(d->tagOffset + d->header.completeTagSize());
+      const ByteVector nextHeaderData = d->file->readBlock(ID3v2::Header::size());
+      if(!nextHeaderData.startsWith(ID3v2::Header::fileIdentifier()))
+        break;
+
+      const ID3v2::Header nextHeader(nextHeaderData);
+      d->header.setTagSize(d->header.tagSize() + nextHeader.completeTagSize());
+
+      debug("ID3v2::Tag::read() - Duplicate ID3v2 tag found.");
+    }
   }
 }
 

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -616,13 +616,14 @@ ByteVector ID3v2::Tag::render(int version) const
     // Padding won't increase beyond 1% of the file size.
 
     if(paddingSize > DefaultPaddingSize) {
-      const uint threshold = d->file->length() / 100; // should be ulonglong in taglib2.
-      if(paddingSize > threshold)
+      const ulong threshold = d->file->length() / 100; // should be ulonglong in taglib2.
+      if(paddingSize > threshold) {
         paddingSize = DefaultPaddingSize;
+      }
     }
   }
 
-  tagData.append(ByteVector(paddingSize, '\0'));
+  tagData.resize(tagData.size() + paddingSize, '\0');
 
   // Set the version and data size.
   d->header.setMajorVersion(version);

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -433,23 +433,8 @@ long MPEG::File::firstFrameOffset()
 {
   long position = 0;
 
-  if(hasID3v2Tag()) {
+  if(hasID3v2Tag())
     position = d->ID3v2Location + ID3v2Tag()->header()->completeTagSize();
-
-    // Skip duplicate ID3v2 tags.
-
-    // Workaround for some faulty files that have duplicate ID3v2 tags.
-    // Combination of EAC and LAME creates such files when configured incorrectly.
-
-    long location;
-    while((location = findID3v2(position)) >= 0) {
-      seek(location);
-      const ID3v2::Header header(readBlock(ID3v2::Header::size()));
-      position = location + header.completeTagSize();
-
-      debug("MPEG::File::firstFrameOffset() - Duplicate ID3v2 tag found.");
-    }
-  }
 
   return nextFrameOffset(position);
 }

--- a/tests/test_mpeg.cpp
+++ b/tests/test_mpeg.cpp
@@ -16,7 +16,6 @@ class TestMPEG : public CppUnit::TestFixture
   CPPUNIT_TEST(testSaveID3v24);
   CPPUNIT_TEST(testSaveID3v24WrongParam);
   CPPUNIT_TEST(testSaveID3v23);
-  CPPUNIT_TEST(testDuplicateID3v2);
   CPPUNIT_TEST(testFuzzedFile);
   CPPUNIT_TEST(testFrameOffset);
   CPPUNIT_TEST_SUITE_END();
@@ -93,17 +92,6 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("Artist A"), f2.tag()->artist());
       CPPUNIT_ASSERT_EQUAL(xxx, f2.tag()->title());
     }
-  }
-
-  void testDuplicateID3v2()
-  {
-    MPEG::File f(TEST_FILE_PATH_C("duplicate_id3v2.mp3"));
-
-    // duplicate_id3v2.mp3 has duplicate ID3v2 tags.
-    // Sample rate will be 32000 if can't skip the second tag.
-
-    CPPUNIT_ASSERT(f.hasID3v2Tag());
-    CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
   }
 
   void testFuzzedFile()


### PR DESCRIPTION
Related to the discussion at #576. This patch will erase duplicate ID3v2 tags by treating them as a part of the first one's padding.

Any thoughts?