### PR TITLE
Avoid corrupting a file when saving ASF/WAV file twice.

### DIFF
--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -120,6 +120,14 @@ namespace TagLib {
         virtual bool save();
 
         /*!
+         * Saves the file.
+         *
+         * The \a id3v2Version parameter specifies the version of the saved
+         * ID3v2 tag. It can be either 4 or 3.
+         */
+        bool save(int id3v2Version);
+
+        /*!
          * Returns whether or not the file on disk actually has an ID3v2 tag.
          *
          * \see ID3v2Tag()

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -179,6 +179,14 @@ namespace TagLib {
          */
         uint findInfoTagChunk();
 
+        /*!
+         * Removes the chunk \a that its name is "LIST" and list type is "INFO".
+         *
+         * \warning This will update the file immediately.
+         * \warning This removes all the chunks that meet the condition.
+         */
+        void removeInfoTagChunk();
+
         class FilePrivate;
         FilePrivate *d;
       };

--- a/tests/test_aiff.cpp
+++ b/tests/test_aiff.cpp
@@ -13,11 +13,13 @@ class TestAIFF : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestAIFF);
   CPPUNIT_TEST(testReading);
-  CPPUNIT_TEST(testSaveID3v2);
+  CPPUNIT_TEST(testSaveID3v24);
+  CPPUNIT_TEST(testSaveID3v23);
   CPPUNIT_TEST(testAiffCProperties);
   CPPUNIT_TEST(testDuplicateID3v2);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -28,7 +30,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(705, f.audioProperties()->bitrate());
   }
 
-  void testSaveID3v2()
+  void testSaveID3v24()
   {
     ScopedFileCopy copy("empty", ".aiff");
     string newname = copy.fileName();
@@ -43,7 +45,27 @@ public:
     {
       RIFF::AIFF::File f(newname.c_str());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL(TagLib::uint(4), f.tag()->header()->majorVersion());
       CPPUNIT_ASSERT_EQUAL(String(L"TitleXXX"), f.tag()->title());
+    }
+  }
+
+  void testSaveID3v23()
+  {
+    ScopedFileCopy copy("empty", ".aiff");
+    string newname = copy.fileName();
+
+    {
+      RIFF::AIFF::File f(newname.c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.tag()->setTitle(L"TitleXXX");
+      f.save(3);
+    }
+
+    {
+      RIFF::AIFF::File f(newname.c_str());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL(TagLib::uint(3), f.tag()->header()->majorVersion());
     }
   }
 
@@ -57,13 +79,29 @@ public:
 
   void testDuplicateID3v2()
   {
-    RIFF::AIFF::File f(TEST_FILE_PATH_C("duplicate_id3v2.aiff"));
+    ScopedFileCopy copy("duplicate_id3v2", ".aiff");
+    string newname = copy.fileName();
 
-    // duplicate_id3v2.aiff has duplicate ID3v2 tags.
-    // title() returns "Title2" if can't skip the second tag.
+    {
+      RIFF::AIFF::File f(newname.c_str());
 
-    CPPUNIT_ASSERT(f.hasID3v2Tag());
-    CPPUNIT_ASSERT_EQUAL(String("Title1"), f.tag()->title());
+      // duplicate_id3v2.aiff has duplicate ID3v2 tags.
+      // title() returns "Title2" if can't skip the second tag.
+
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL(String("Title1"), f.tag()->title());
+
+      ID3v2::FrameList frames = f.tag()->frameList();
+      for(ID3v2::FrameList::ConstIterator it = frames.begin(); it != frames.end(); ++it) {
+        f.tag()->removeFrame(*it);
+      }
+      CPPUNIT_ASSERT(f.tag()->isEmpty());
+      f.save();
+    }
+    {
+      RIFF::AIFF::File f(newname.c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+    }
   }
 
   void testFuzzedFile1()
@@ -76,6 +114,45 @@ public:
   {
     RIFF::AIFF::File f(TEST_FILE_PATH_C("excessive_alloc.aif"));
     CPPUNIT_ASSERT(!f.isValid());
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("empty", ".aiff");
+    ScopedFileCopy copy2("empty", ".aiff");
+
+    ByteVector audioStream;
+    {
+      RIFF::AIFF::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5936, f.length());
+
+      f.seek(0x0008);
+      audioStream = f.readBlock(5920);
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)7012, f.length());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(5920));
+    }
+
+    {
+      RIFF::AIFF::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)7012, f.length());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(5920));
+
+      f.tag()->setTitle("");
+      f.save();
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(5920));
+    }
   }
 
 };

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -22,6 +22,10 @@ class TestWAV : public CppUnit::TestFixture
   CPPUNIT_TEST(testDuplicateTags);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testSaveInfoTwice);
+  CPPUNIT_TEST(testSaveID3v2Twice);
+  CPPUNIT_TEST(testSaveTags1);
+  CPPUNIT_TEST(testSaveTags2);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -144,16 +148,39 @@ public:
 
   void testDuplicateTags()
   {
-    RIFF::WAV::File f(TEST_FILE_PATH_C("duplicate_tags.wav"));
+    ScopedFileCopy copy("duplicate_tags", ".wav");
+    string newname = copy.fileName();
 
-    // duplicate_tags.wav has duplicate ID3v2/INFO tags.
-    // title() returns "Title2" if can't skip the second tag.
+    {
+      RIFF::WAV::File f(newname.c_str());
 
-    CPPUNIT_ASSERT(f.hasID3v2Tag());
-    CPPUNIT_ASSERT_EQUAL(String("Title1"), f.ID3v2Tag()->title());
+      // duplicate_tags.wav has duplicate ID3v2/INFO tags.
+      // title() returns "Title2" if can't skip the second tag.
 
-    CPPUNIT_ASSERT(f.hasInfoTag());
-    CPPUNIT_ASSERT_EQUAL(String("Title1"), f.InfoTag()->title());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL(String("Title1"), f.ID3v2Tag()->title());
+
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL(String("Title1"), f.InfoTag()->title());
+
+      ID3v2::FrameList frames = f.ID3v2Tag()->frameList();
+      for(ID3v2::FrameList::ConstIterator it = frames.begin(); it != frames.end(); ++it) {
+        f.ID3v2Tag()->removeFrame(*it);
+      }
+      CPPUNIT_ASSERT(f.ID3v2Tag()->isEmpty());
+
+      RIFF::Info::FieldListMap fields = f.InfoTag()->fieldListMap();
+      for(RIFF::Info::FieldListMap::ConstIterator it = fields.begin(); it != fields.end(); ++it) {
+        f.InfoTag()->removeField(it->first);
+      }
+      CPPUNIT_ASSERT(f.InfoTag()->isEmpty());
+      f.save();
+    }
+    {
+      RIFF::WAV::File f(newname.c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasInfoTag());
+    }
   }
 
   void testFuzzedFile1()
@@ -166,6 +193,165 @@ public:
   {
     RIFF::WAV::File f2(TEST_FILE_PATH_C("segfault.wav"));
     CPPUNIT_ASSERT(f2.isValid());
+  }
+
+  void testSaveInfoTwice()
+  {
+    ScopedFileCopy copy1("empty", ".wav");
+    ScopedFileCopy copy2("empty", ".wav");
+
+    ByteVector audioStream;
+    {
+      RIFF::WAV::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL((long)14744, f.length());
+
+      f.seek(0x0008);
+      audioStream = f.readBlock(14736);
+
+      f.InfoTag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL((long)14788, f.length());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+    }
+
+    {
+      RIFF::WAV::File f(copy2.fileName().c_str());
+      f.InfoTag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL((long)14788, f.length());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+
+      f.InfoTag()->setTitle("");
+      f.save();
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+    }
+  }
+
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy1("empty", ".wav");
+    ScopedFileCopy copy2("empty", ".wav");
+
+    ByteVector audioStream;
+    {
+      RIFF::WAV::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)14744, f.length());
+
+      f.seek(0x0008);
+      audioStream = f.readBlock(14736);
+
+      f.ID3v2Tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)15820, f.length());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+    }
+
+    {
+      RIFF::WAV::File f(copy2.fileName().c_str());
+      f.ID3v2Tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)15820, f.length());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+
+      f.ID3v2Tag()->setTitle("");
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+    }
+  }
+
+  void testSaveTags1()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+
+    ByteVector audioStream;
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      f.seek(0x0008);
+      audioStream = f.readBlock(14736);
+
+      CPPUNIT_ASSERT(!f.hasInfoTag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.InfoTag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v2Tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+    }
+
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)15864, f.length());
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.InfoTag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+    }
+  }
+
+  void testSaveTags2()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+
+    ByteVector audioStream;
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      f.seek(0x0008);
+      audioStream = f.readBlock(14736);
+
+      CPPUNIT_ASSERT(!f.hasInfoTag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v2Tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(!f.hasInfoTag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      f.InfoTag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+    }
+
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)15864, f.length());
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.InfoTag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+
+      f.seek(0x0008);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(14736));
+    }
   }
 
 };


### PR DESCRIPTION
Related to #576.

I found that AIFF and WAV have weird and inconsistent behavior.
WAV removes duplicate chunks when saving an ID3v2 tag (but incompletely), but doesn't do so when saving INFO tag.
And AIFF doesn't remove duplicate chunks.

This PR makes them always remove duplicate tags.