### PR TITLE
Fill string buffers with zero before using snprintf().

### DIFF
--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -160,7 +160,7 @@ namespace TagLib
       va_list args;
       va_start(args, format);
 
-      char buf[BufferSize];
+      char buf[BufferSize] = {};
       int length;
 
 #if defined(HAVE_SNPRINTF)

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -27,7 +27,7 @@ inline string testFilePath(const string &filename)
 
 inline string copyFile(const string &filename, const string &ext)
 {
-  char testFileName[1024];
+  char testFileName[1024] = {};
 
 #ifdef _WIN32
   GetTempPathA(sizeof(testFileName), testFileName);


### PR DESCRIPTION
```snprintf()``` doesn't necessarily terminate a string properly.
http://www.dwheeler.com/secure-programs/Secure-Programs-HOWTO/dangers-c.html