### PR TITLE
Fix checking for RIFF chunk names.

### DIFF
--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -67,6 +67,20 @@ RIFF::File::~File()
   delete d;
 }
 
+bool RIFF::File::isValidChunkName(const ByteVector &name)   // static
+{
+  if(name.size() != 4)
+    return false;
+
+  for(ByteVector::ConstIterator it = name.begin(); it != name.end(); ++it) {
+    const uchar c = static_cast<uchar>(*it);
+    if(c < 32 || 127 < c)
+      return false;
+  }
+
+  return true;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
@@ -243,19 +257,6 @@ void RIFF::File::removeChunk(const ByteVector &name)
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-static bool isValidChunkID(const ByteVector &name)
-{
-  if(name.size() != 4) {
-    return false;
-  }
-  for(int i = 0; i < 4; i++) {
-    if(name[i] < 32 || name[i] > 127) {
-      return false;
-    }
-  }
-  return true;
-}
-
 void RIFF::File::read()
 {
   bool bigEndian = (d->endianness == BigEndian);
@@ -269,7 +270,7 @@ void RIFF::File::read()
     ByteVector chunkName = readBlock(4);
     uint chunkSize = readBlock(4).toUInt(bigEndian);
 
-    if(!isValidChunkID(chunkName)) {
+    if(!isValidChunkName(chunkName)) {
       debug("RIFF::File::read() -- Chunk '" + chunkName + "' has invalid ID");
       setValid(false);
       break;

--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -23,13 +23,15 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
+#include <algorithm>
+#include <vector>
+
 #include <tbytevector.h>
 #include <tdebug.h>
 #include <tstring.h>
 
 #include "rifffile.h"
-#include <algorithm>
-#include <vector>
+#include "riffutils.h"
 
 using namespace TagLib;
 
@@ -65,20 +67,6 @@ public:
 RIFF::File::~File()
 {
   delete d;
-}
-
-bool RIFF::File::isValidChunkName(const ByteVector &name)   // static
-{
-  if(name.size() != 4)
-    return false;
-
-  for(ByteVector::ConstIterator it = name.begin(); it != name.end(); ++it) {
-    const uchar c = static_cast<uchar>(*it);
-    if(c < 32 || 127 < c)
-      return false;
-  }
-
-  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/riff/rifffile.h
+++ b/taglib/riff/rifffile.h
@@ -51,6 +51,11 @@ namespace TagLib {
        */
       virtual ~File();
 
+      /*!
+       * Returns whether or not \a name is valid as a chunk name.
+       */
+      static bool isValidChunkName(const ByteVector &name);
+
     protected:
 
       enum Endianness { BigEndian, LittleEndian };

--- a/taglib/riff/rifffile.h
+++ b/taglib/riff/rifffile.h
@@ -51,11 +51,6 @@ namespace TagLib {
        */
       virtual ~File();
 
-      /*!
-       * Returns whether or not \a name is valid as a chunk name.
-       */
-      static bool isValidChunkName(const ByteVector &name);
-
     protected:
 
       enum Endianness { BigEndian, LittleEndian };

--- a/taglib/riff/riffutils.h
+++ b/taglib/riff/riffutils.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+    copyright            : (C) 2015 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_RIFFUTILS_H
+#define TAGLIB_RIFFUTILS_H
+
+// THIS FILE IS NOT A PART OF THE TAGLIB API
+
+#ifndef DO_NOT_DOCUMENT  // tell Doxygen not to document this header
+
+#include <tbytevector.h>
+
+namespace TagLib
+{
+  namespace RIFF
+  {
+
+    /*!
+     * Returns whether or not \a name is valid as a RIFF chunk name.
+     */
+    inline bool isValidChunkName(const ByteVector &name)
+    {
+      if(name.size() != 4)
+        return false;
+
+      for(ByteVector::ConstIterator it = name.begin(); it != name.end(); ++it) {
+        const uchar c = static_cast<uchar>(*it);
+        if(c < 32 || 127 < c)
+          return false;
+      }
+
+      return true;
+    }
+
+  }
+}
+
+#endif
+
+#endif

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -28,6 +28,7 @@
 
 #include "rifffile.h"
 #include "infotag.h"
+#include "riffutils.h"
 
 using namespace TagLib;
 using namespace RIFF::Info;
@@ -187,7 +188,7 @@ String RIFF::Info::Tag::fieldText(const ByteVector &id) const
 void RIFF::Info::Tag::setFieldText(const ByteVector &id, const String &s)
 {
   // id must be four-byte long pure ascii string.
-  if(!RIFF::File::isValidChunkName(id))
+  if(!isValidChunkName(id))
     return;
 
   if(!s.isEmpty())
@@ -247,10 +248,10 @@ void RIFF::Info::Tag::parse(const ByteVector &data)
     if(size > data.size() - p - 8)
       break;
 
-    const ByteVector id = data.mid(p, 4);
-    if(RIFF::File::isValidChunkName(id)) {
+    const ByteVector name = data.mid(p, 4);
+    if(isValidChunkName(name)) {
       const String text = TagPrivate::stringHandler->parse(data.mid(p + 8, size));
-      d->fieldListMap[id] = text;
+      d->fieldListMap[name] = text;
     }
 
     p += ((size + 1) & ~1) + 8;

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -26,25 +26,11 @@
 #include <tdebug.h>
 #include <tfile.h>
 
+#include "rifffile.h"
 #include "infotag.h"
 
 using namespace TagLib;
 using namespace RIFF::Info;
-
-namespace {
-  static bool isValidChunkID(const ByteVector &name)
-  {
-    if(name.size() != 4)
-      return false;
-
-    for(int i = 0; i < 4; i++) {
-      if(name[i] < 32 || name[i] > 127)
-        return false;
-    }
-
-    return true;
-  }
-}
 
 class RIFF::Info::Tag::TagPrivate
 {
@@ -201,7 +187,7 @@ String RIFF::Info::Tag::fieldText(const ByteVector &id) const
 void RIFF::Info::Tag::setFieldText(const ByteVector &id, const String &s)
 {
   // id must be four-byte long pure ascii string.
-  if(!isValidChunkID(id))
+  if(!RIFF::File::isValidChunkName(id))
     return;
 
   if(!s.isEmpty())
@@ -262,7 +248,7 @@ void RIFF::Info::Tag::parse(const ByteVector &data)
       break;
 
     const ByteVector id = data.mid(p, 4);
-    if(isValidChunkID(id)) {
+    if(RIFF::File::isValidChunkName(id)) {
       const String text = TagPrivate::stringHandler->parse(data.mid(p + 8, size));
       d->fieldListMap[id] = text;
     }

--- a/tests/test_riff.cpp
+++ b/tests/test_riff.cpp
@@ -41,6 +41,7 @@ class TestRIFF : public CppUnit::TestFixture
   CPPUNIT_TEST(testLastChunkAtEvenPosition2);
   CPPUNIT_TEST(testLastChunkAtEvenPosition3);
   CPPUNIT_TEST(testChunkOffset);
+  CPPUNIT_TEST(testChunkName);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -258,6 +259,14 @@ public:
     delete f;
   }
 
+  void testChunkName()
+  {
+    CPPUNIT_ASSERT(RIFF::File::isValidChunkName("WAVE"));
+    CPPUNIT_ASSERT(RIFF::File::isValidChunkName("SND "));
+    CPPUNIT_ASSERT(!RIFF::File::isValidChunkName("WWAVE"));
+    CPPUNIT_ASSERT(!RIFF::File::isValidChunkName("XY\x83Z"));
+    CPPUNIT_ASSERT(!RIFF::File::isValidChunkName("SND\r"));
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestRIFF);

--- a/tests/test_riff.cpp
+++ b/tests/test_riff.cpp
@@ -3,6 +3,7 @@
 #include <tag.h>
 #include <tbytevectorlist.h>
 #include <rifffile.h>
+#include <riffutils.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -261,11 +262,11 @@ public:
 
   void testChunkName()
   {
-    CPPUNIT_ASSERT(RIFF::File::isValidChunkName("WAVE"));
-    CPPUNIT_ASSERT(RIFF::File::isValidChunkName("SND "));
-    CPPUNIT_ASSERT(!RIFF::File::isValidChunkName("WWAVE"));
-    CPPUNIT_ASSERT(!RIFF::File::isValidChunkName("XY\x83Z"));
-    CPPUNIT_ASSERT(!RIFF::File::isValidChunkName("SND\r"));
+    CPPUNIT_ASSERT(RIFF::isValidChunkName("WAVE"));
+    CPPUNIT_ASSERT(RIFF::isValidChunkName("SND "));
+    CPPUNIT_ASSERT(!RIFF::isValidChunkName("WWAVE"));
+    CPPUNIT_ASSERT(!RIFF::isValidChunkName("XY\x83Z"));
+    CPPUNIT_ASSERT(!RIFF::isValidChunkName("SND\r"));
   }
 };
 

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -22,6 +22,7 @@ class TestWAV : public CppUnit::TestFixture
   CPPUNIT_TEST(testDuplicateTags);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testInvalidChunk);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -166,6 +167,26 @@ public:
   {
     RIFF::WAV::File f2(TEST_FILE_PATH_C("segfault.wav"));
     CPPUNIT_ASSERT(f2.isValid());
+  }
+
+  void testInvalidChunk()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      f.seek(12);
+      CPPUNIT_ASSERT_EQUAL(ByteVector("fmt "), f.readBlock(4));
+      f.insert(ByteVector("f\x10t\x90"), 12, 4);
+    }
+
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.isValid());
+
+      f.seek(12);
+      CPPUNIT_ASSERT_EQUAL(ByteVector("f\x10t\x90"), f.readBlock(4));
+    }
   }
 
 };


### PR DESCRIPTION
The check overlooks characters larger than 0x7f when char is signed.
I already fixed this one in ```taglib2``` branch but forgot to do it in ```master```.
 
The test log below implies that this bug actually occurs on OSX. I expect this PR fixes those warnings as well.
http://build.oxygene.sk/job/taglib-osx/58/console