### PR TITLE
Fix some typos in comments.

### DIFF
--- a/taglib/ape/apefile.h
+++ b/taglib/ape/apefile.h
@@ -130,7 +130,7 @@ namespace TagLib {
 
       /*!
        * Implements the unified property interface -- import function.
-       * Creates an APEv2 tag if necessary. A pontentially existing ID3v1
+       * Creates an APEv2 tag if necessary. A potentially existing ID3v1
        * tag will be updated as well.
        */
       PropertyMap setProperties(const PropertyMap &);
@@ -156,8 +156,8 @@ namespace TagLib {
        * if there is no valid ID3v1 tag.  If \a create is true it will create
        * an ID3v1 tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file
        * on disk actually has an ID3v1 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -175,8 +175,8 @@ namespace TagLib {
        * if there is no valid APE tag.  If \a create is true it will create
        * an APE tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an APE tag.  Use hasAPETag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an APE tag.  Use hasAPETag() to check if the file
        * on disk actually has an APE tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be

--- a/taglib/ape/apefooter.h
+++ b/taglib/ape/apefooter.h
@@ -37,7 +37,7 @@ namespace TagLib {
 
     /*!
      * This class implements APE footers (and headers). It attempts to follow, both
-     * semantically and programatically, the structure specified in
+     * semantically and programmatically, the structure specified in
      * the APE v2.0 standard.  The API is based on the properties of APE footer and
      * headers specified there.
      */

--- a/taglib/ape/apeitem.h
+++ b/taglib/ape/apeitem.h
@@ -153,7 +153,7 @@ namespace TagLib {
 
       /*!
        * Returns the value as a single string.  In case of multiple strings,
-       * the first is returned.  If the data type is not \a Text, always returns 
+       * the first is returned.  If the data type is not \a Text, always returns
        * an empty String.
        */
       String toString() const;
@@ -164,7 +164,7 @@ namespace TagLib {
 #endif
 
       /*!
-       * Returns the list of text values.  If the data type is not \a Text, always 
+       * Returns the list of text values.  If the data type is not \a Text, always
        * returns an empty StringList.
        */
       StringList values() const;

--- a/taglib/ape/apetag.h
+++ b/taglib/ape/apetag.h
@@ -143,7 +143,7 @@ namespace TagLib {
        * Returns a reference to the item list map.  This is an ItemListMap of
        * all of the items in the tag.
        *
-       * This is the most powerfull structure for accessing the items of the tag.
+       * This is the most powerful structure for accessing the items of the tag.
        *
        * APE tags are case-insensitive, all keys in this map have been converted
        * to upper case.

--- a/taglib/asf/asffile.h
+++ b/taglib/asf/asffile.h
@@ -54,7 +54,7 @@ namespace TagLib {
        * \a propertiesStyle are ignored.  The audio properties are always
        * read.
        */
-      File(FileName file, bool readProperties = true, 
+      File(FileName file, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
@@ -67,7 +67,7 @@ namespace TagLib {
        * \note TagLib will *not* take ownership of the stream, the caller is
        * responsible for deleting it after the File object.
        */
-      File(IOStream *stream, bool readProperties = true, 
+      File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -128,7 +128,7 @@ namespace TagLib {
                      audioPropertiesStyle = AudioProperties::Average);
 
     /*!
-     * Contruct a FileRef using \a file.  The FileRef now takes ownership of the
+     * Construct a FileRef using \a file.  The FileRef now takes ownership of the
      * pointer and will delete the File when it passes out of scope.
      */
     explicit FileRef(File *file);
@@ -191,7 +191,7 @@ namespace TagLib {
      * is tried.
      *
      * Returns a pointer to the added resolver (the same one that's passed in --
-     * this is mostly so that static inialializers have something to use for
+     * this is mostly so that static initializers have something to use for
      * assignment).
      *
      * \see FileTypeResolver
@@ -209,7 +209,7 @@ namespace TagLib {
      * by TagLib for resolution is case-insensitive.
      *
      * \note This does not account for any additional file type resolvers that
-     * are plugged in.  Also note that this is not intended to replace a propper
+     * are plugged in.  Also note that this is not intended to replace a proper
      * mime-type resolution system, but is just here for reference.
      *
      * \see FileTypeResolver

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -46,7 +46,7 @@ namespace TagLib {
   /*!
    * This is implementation of FLAC metadata for non-Ogg FLAC files.  At some
    * point when Ogg / FLAC is more common there will be a similar implementation
-   * under the Ogg hiearchy.
+   * under the Ogg hierarchy.
    *
    * This supports ID3v1, ID3v2 and Xiph style comments as well as reading stream
    * properties from the file.
@@ -165,8 +165,8 @@ namespace TagLib {
        * if there is no valid ID3v2 tag.  If \a create is true it will create
        * an ID3v2 tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the file
        * on disk actually has an ID3v2 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -184,8 +184,8 @@ namespace TagLib {
        * if there is no valid APE tag.  If \a create is true it will create
        * an APE tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file
        * on disk actually has an ID3v1 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -203,10 +203,10 @@ namespace TagLib {
        * if there is no valid XiphComment.  If \a create is true it will create
        * a XiphComment if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has a XiphComment.  Use hasXiphComment() to check if the 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has a XiphComment.  Use hasXiphComment() to check if the
        * file on disk actually has a XiphComment.
-       * 
+       *
        * \note The Tag <b>is still</b> owned by the FLAC::File and should not be
        * deleted by the user.  It will be deleted when the file (object) is
        * destroyed.

--- a/taglib/flac/flacproperties.h
+++ b/taglib/flac/flacproperties.h
@@ -78,13 +78,13 @@ namespace TagLib {
       int sampleWidth() const;
 
       /*!
-       * Return the number of sample frames
+       * Return the number of sample frames.
        */
       unsigned long long sampleFrames() const;
 
       /*!
        * Returns the MD5 signature of the uncompressed audio stream as read
-       * from the stream info header header.
+       * from the stream info header.
        */
       ByteVector signature() const;
 

--- a/taglib/mod/modtag.h
+++ b/taglib/mod/modtag.h
@@ -97,7 +97,7 @@ namespace TagLib {
        * Sets the title to \a title.  If \a title is String::null then this
        * value will be cleared.
        *
-       * The length limits per file type are (1 characetr = 1 byte):
+       * The length limits per file type are (1 character = 1 byte):
        * Mod 20 characters, S3M 27 characters, IT 25 characters and XM 20
        * characters.
        */
@@ -126,7 +126,7 @@ namespace TagLib {
        * an thus the line length in comments are limited. Too big comments
        * will be truncated.
        *
-       * The line length limits per file type are (1 characetr = 1 byte):
+       * The line length limits per file type are (1 character = 1 byte):
        * Mod 22 characters, S3M 27 characters, IT 25 characters and XM 22
        * characters.
        */
@@ -169,7 +169,7 @@ namespace TagLib {
        * Implements the unified property interface -- import function.
        * Because of the limitations of the module file tag, any tags besides
        * COMMENT, TITLE and, if it is an XM file, TRACKERNAME, will be
-       * returened. Additionally, if the map contains tags with multiple values,
+       * returned. Additionally, if the map contains tags with multiple values,
        * all but the first will be contained in the returned map of unsupported
        * properties.
        */

--- a/taglib/mp4/mp4atom.h
+++ b/taglib/mp4/mp4atom.h
@@ -59,7 +59,7 @@ namespace TagLib {
       TypeDateTime  = 17, // in UTC, counting seconds since midnight, January 1, 1904; 32 or 64-bits
       TypeGenred    = 18, // a list of enumerated values
       TypeInteger   = 21, // a signed big-endian integer with length one of { 1,2,3,4,8 } bytes
-      TypeRIAAPA    = 24, // RIAA parental advisory; { -1=no, 1=yes, 0=unspecified }, 8-bit ingteger
+      TypeRIAAPA    = 24, // RIAA parental advisory; { -1=no, 1=yes, 0=unspecified }, 8-bit integer
       TypeUPC       = 25, // Universal Product Code, in text UTF-8 format (valid as an ID)
       TypeBMP       = 27, // Windows bitmap image
       TypeUndefined = 255 // undefined

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -54,7 +54,7 @@ namespace TagLib {
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      File(FileName file, bool readProperties = true, 
+      File(FileName file, bool readProperties = true,
            Properties::ReadStyle audioPropertiesStyle = Properties::Average);
 
       /*!
@@ -66,7 +66,7 @@ namespace TagLib {
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
        */
-      File(IOStream *stream, bool readProperties = true, 
+      File(IOStream *stream, bool readProperties = true,
            Properties::ReadStyle audioPropertiesStyle = Properties::Average);
 
       /*!

--- a/taglib/mpc/mpcfile.h
+++ b/taglib/mpc/mpcfile.h
@@ -149,8 +149,8 @@ namespace TagLib {
        * if there is no valid APE tag.  If \a create is true it will create
        * an APE tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file
        * on disk actually has an ID3v1 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -166,11 +166,11 @@ namespace TagLib {
        *
        * If \a create is false (the default) this may return a null pointer
        * if there is no valid APE tag.  If \a create is true it will create
-       * an APE tag if one does not exist and returns a valid pointer.  If 
+       * an APE tag if one does not exist and returns a valid pointer.  If
        * there already be an ID3v1 tag, the new APE tag will be placed before it.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an APE tag.  Use hasAPETag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an APE tag.  Use hasAPETag() to check if the file
        * on disk actually has an APE tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be

--- a/taglib/mpeg/id3v1/id3v1tag.h
+++ b/taglib/mpeg/id3v1/id3v1tag.h
@@ -85,7 +85,7 @@ namespace TagLib {
     //! The main class in the ID3v1 implementation
 
     /*!
-     * This is an implementation of the ID3v1 format.  ID3v1 is both the simplist
+     * This is an implementation of the ID3v1 format.  ID3v1 is both the simplest
      * and most common of tag formats but is rather limited.  Because of its
      * pervasiveness and the way that applications have been written around the
      * fields that it provides, the generic TagLib::Tag API is a mirror of what is

--- a/taglib/mpeg/id3v2/frames/chapterframe.h
+++ b/taglib/mpeg/id3v2/frames/chapterframe.h
@@ -55,7 +55,7 @@ namespace TagLib {
       /*!
        * Creates a chapter frame with the element ID \a elementID, start time
        * \a startTime, end time \a endTime, start offset \a startOffset,
-       * end offset \a endOffset and optionally a list of embeeded frames,
+       * end offset \a endOffset and optionally a list of embedded frames,
        * whose ownership will then be taken over by this Frame, in
        * \a embeededFrames;
        *
@@ -81,14 +81,14 @@ namespace TagLib {
       ByteVector elementID() const;
 
       /*!
-       * Returns time of chapter's start (in miliseconds).
+       * Returns time of chapter's start (in milliseconds).
        *
        * \see setStartTime()
        */
       uint startTime() const;
 
       /*!
-       * Returns time of chapter's end (in miliseconds).
+       * Returns time of chapter's end (in milliseconds).
        *
        * \see setEndTime()
        */
@@ -121,14 +121,14 @@ namespace TagLib {
       void setElementID(const ByteVector &eID);
 
       /*!
-       * Sets time of chapter's start (in miliseconds) to \a sT.
+       * Sets time of chapter's start (in milliseconds) to \a sT.
        *
        * \see startTime()
        */
       void setStartTime(const uint &sT);
 
       /*!
-       * Sets time of chapter's end (in miliseconds) to \a eT.
+       * Sets time of chapter's end (in milliseconds) to \a eT.
        *
        * \see endTime()
        */

--- a/taglib/mpeg/id3v2/frames/commentsframe.h
+++ b/taglib/mpeg/id3v2/frames/commentsframe.h
@@ -36,7 +36,7 @@ namespace TagLib {
     //! An implementation of ID3v2 comments
 
     /*!
-     * This implements the ID3v2 comment format.  An ID3v2 comment concists of
+     * This implements the ID3v2 comment format.  An ID3v2 comment consists of
      * a language encoding, a description and a single text field.
      */
 
@@ -106,7 +106,7 @@ namespace TagLib {
       /*!
        * Sets the description of the comment to \a s.
        *
-       * \see decription()
+       * \see description()
        */
       void setDescription(const String &s);
 
@@ -149,7 +149,7 @@ namespace TagLib {
 
       /*!
        * Comments each have a unique description.  This searches for a comment
-       * frame with the decription \a d and returns a pointer to it.  If no
+       * frame with the description \a d and returns a pointer to it.  If no
        * frame is found that matches the given description null is returned.
        *
        * \see description()

--- a/taglib/mpeg/id3v2/frames/ownershipframe.h
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.h
@@ -94,21 +94,21 @@ namespace TagLib {
        * \see pricePaid()
        */
       void setPricePaid(const String &pricePaid);
-      
+
       /*!
        * Returns the seller.
        *
        * \see setSeller()
        */
       String seller() const;
-      
+
       /*!
        * Set the seller.
        *
        * \see seller()
        */
       void setSeller(const String &seller);
-      
+
       /*!
        * Returns the text encoding that will be used in rendering this frame.
        * This defaults to the type that was either specified in the constructor
@@ -118,7 +118,7 @@ namespace TagLib {
        * \see render()
        */
       String::Type textEncoding() const;
-      
+
       /*!
        * Sets the text encoding to be used when rendering this frame to
        * \a encoding.

--- a/taglib/mpeg/id3v2/frames/popularimeterframe.h
+++ b/taglib/mpeg/id3v2/frames/popularimeterframe.h
@@ -36,7 +36,7 @@ namespace TagLib {
     //! An implementation of ID3v2 "popularimeter"
 
     /*!
-     * This implements the ID3v2 popularimeter (POPM frame).  It concists of
+     * This implements the ID3v2 popularimeter (POPM frame).  It consists of
      * an email, a rating and an optional counter.
      */
 

--- a/taglib/mpeg/id3v2/frames/relativevolumeframe.h
+++ b/taglib/mpeg/id3v2/frames/relativevolumeframe.h
@@ -140,7 +140,7 @@ namespace TagLib {
 
       /*
        * There was a terrible API goof here, and while this can't be changed to
-       * the way it appears below for binary compaibility reasons, let's at
+       * the way it appears below for binary compatibility reasons, let's at
        * least pretend that it looks clean.
        */
 
@@ -149,7 +149,7 @@ namespace TagLib {
       /*!
        * Returns the relative volume adjustment "index".  As indicated by the
        * ID3v2 standard this is a 16-bit signed integer that reflects the
-       * decibils of adjustment when divided by 512.
+       * decibels of adjustment when divided by 512.
        *
        * This defaults to returning the value for the master volume channel if
        * available and returns 0 if the specified channel does not exist.
@@ -161,7 +161,7 @@ namespace TagLib {
 
       /*!
        * Set the volume adjustment to \a index.  As indicated by the ID3v2
-       * standard this is a 16-bit signed integer that reflects the decibils of
+       * standard this is a 16-bit signed integer that reflects the decibels of
        * adjustment when divided by 512.
        *
        * By default this sets the value for the master volume.

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.h
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.h
@@ -197,7 +197,7 @@ namespace TagLib {
       /*!
        * Sets the description of the synchronized lyrics frame to \a s.
        *
-       * \see decription()
+       * \see description()
        */
       void setDescription(const String &s);
 

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.h
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.h
@@ -74,7 +74,7 @@ namespace TagLib {
       ByteVector elementID() const;
 
       /*!
-       * Returns true, if the frame is top-level (doen't have
+       * Returns true, if the frame is top-level (doesn't have
        * any parent CTOC frame).
        *
        * \see setIsTopLevel()
@@ -90,7 +90,7 @@ namespace TagLib {
       bool isOrdered() const;
 
       /*!
-       * Returns count of child elements of the frame. It allways
+       * Returns count of child elements of the frame. It always
        * corresponds to size of child elements list.
        *
        * \see childElements()
@@ -113,7 +113,7 @@ namespace TagLib {
       void setElementID(const ByteVector &eID);
 
       /*!
-       * Sets, if the frame is top-level (doen't have
+       * Sets, if the frame is top-level (doesn't have
        * any parent CTOC frame).
        *
        * \see isTopLevel()

--- a/taglib/mpeg/id3v2/frames/uniquefileidentifierframe.h
+++ b/taglib/mpeg/id3v2/frames/uniquefileidentifierframe.h
@@ -46,7 +46,7 @@ namespace TagLib {
 
     public:
       /*!
-       * Creates a uniqe file identifier frame based on \a data.
+       * Creates a unique file identifier frame based on \a data.
        */
       UniqueFileIdentifierFrame(const ByteVector &data);
 

--- a/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.h
+++ b/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.h
@@ -104,7 +104,7 @@ namespace TagLib {
       /*!
        * Sets the description of the unsynchronized lyrics frame to \a s.
        *
-       * \see decription()
+       * \see description()
        */
       void setDescription(const String &s);
 
@@ -149,7 +149,7 @@ namespace TagLib {
 
       /*!
        * LyricsFrames each have a unique description.  This searches for a lyrics
-       * frame with the decription \a d and returns a pointer to it.  If no
+       * frame with the description \a d and returns a pointer to it.  If no
        * frame is found that matches the given description null is returned.
        *
        * \see description()

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -165,7 +165,7 @@ namespace TagLib {
        * All other processing of \a data should be handled in a subclass.
        *
        * \note This need not contain anything more than a frame ID, but
-       * \e must constain at least that.
+       * \e must contain at least that.
        */
       explicit Frame(const ByteVector &data);
 
@@ -218,9 +218,9 @@ namespace TagLib {
       ByteVector fieldData(const ByteVector &frameData) const;
 
       /*!
-       * Reads a String of type \a encodiong from the ByteVector \a data.  If \a
+       * Reads a String of type \a encoding from the ByteVector \a data.  If \a
        * position is passed in it is used both as the starting point and is
-       * updated to replect the position just after the string that has been read.
+       * updated to return the position just after the string that has been read.
        * This is useful for reading strings sequentially.
        */
       String readStringField(const ByteVector &data, String::Type encoding,
@@ -460,7 +460,7 @@ namespace TagLib {
       bool readOnly() const;
 
       /*!
-       * Returns true if the flag for the grouping identifity is set.
+       * Returns true if the flag for the grouping identity is set.
        *
        * \note This flag is currently ignored internally in TagLib.
        */

--- a/taglib/mpeg/id3v2/id3v2framefactory.h
+++ b/taglib/mpeg/id3v2/id3v2framefactory.h
@@ -105,7 +105,7 @@ namespace TagLib {
        * Returns the default text encoding for text frames.  If setTextEncoding()
        * has not been explicitly called this will only be used for new text
        * frames.  However, if this value has been set explicitly all frames will be
-       * converted to this type (unless it's explitly set differently for the
+       * converted to this type (unless it's explicitly set differently for the
        * individual frame) when being rendered.
        *
        * \see setDefaultTextEncoding()

--- a/taglib/mpeg/id3v2/id3v2header.h
+++ b/taglib/mpeg/id3v2/id3v2header.h
@@ -37,7 +37,7 @@ namespace TagLib {
 
     /*!
      * This class implements ID3v2 headers.  It attempts to follow, both
-     * semantically and programatically, the structure specified in
+     * semantically and programmatically, the structure specified in
      * the ID3v2 standard.  The API is based on the properties of ID3v2 headers
      * specified there.  If any of the terms used in this documentation are
      * unclear please check the specification in the linked section.

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -60,13 +60,13 @@ namespace TagLib {
     //! An abstraction for the ISO-8859-1 string to data encoding in ID3v2 tags.
 
     /*!
-     * ID3v2 tag can store strings in ISO-8859-1 (Latin1), and TagLib only 
-     * supports genuine ISO-8859-1 by default.  However, in practice, non 
-     * ISO-8859-1 encodings are often used instead of ISO-8859-1, such as 
+     * ID3v2 tag can store strings in ISO-8859-1 (Latin1), and TagLib only
+     * supports genuine ISO-8859-1 by default.  However, in practice, non
+     * ISO-8859-1 encodings are often used instead of ISO-8859-1, such as
      * Windows-1252 for western languages, Shift_JIS for Japanese and so on.
      *
      * Here is an option to read such tags by subclassing this class,
-     * reimplementing parse() and setting your reimplementation as the default 
+     * reimplementing parse() and setting your reimplementation as the default
      * with ID3v2::Tag::setStringHandler().
      *
      * \note Writing non-ISO-8859-1 tags is not implemented intentionally.
@@ -98,7 +98,7 @@ namespace TagLib {
      * split into data components.
      *
      * ID3v2 tags have several parts, TagLib attempts to provide an interface
-     * for them all.  header(), footer() and extendedHeader() corespond to those
+     * for them all.  header(), footer() and extendedHeader() correspond to those
      * data structures in the ID3v2 standard and the APIs for the classes that
      * they return attempt to reflect this.
      *
@@ -115,7 +115,7 @@ namespace TagLib {
      * class.
      *
      * read() and parse() pass binary data to the other ID3v2 class structures,
-     * they do not handle parsing of flags or fields, for instace.  Those are
+     * they do not handle parsing of flags or fields, for instance.  Those are
      * handled by similar functions within those classes.
      *
      * \note All pointers to data structures within the tag will become invalid
@@ -126,7 +126,7 @@ namespace TagLib {
      * rather long, but if you're planning on messing with this class and others
      * that deal with the details of ID3v2 (rather than the nice, safe, abstract
      * TagLib::Tag and friends), it's worth your time to familiarize yourself
-     * with said spec (which is distrubuted with the TagLib sources).  TagLib
+     * with said spec (which is distributed with the TagLib sources).  TagLib
      * tries to do most of the work, but with a little luck, you can still
      * convince it to generate invalid ID3v2 tags.  The APIs for ID3v2 assume a
      * working knowledge of ID3v2 structure.  You're been warned.
@@ -150,7 +150,7 @@ namespace TagLib {
        * \note You should be able to ignore the \a factory parameter in almost
        * all situations.  You would want to specify your own FrameFactory
        * subclass in the case that you are extending TagLib to support additional
-       * frame types, which would be incorperated into your factory.
+       * frame types, which would be incorporated into your factory.
        *
        * \see FrameFactory
        */
@@ -353,9 +353,9 @@ namespace TagLib {
        */
       // BIC: combine with the above method
       ByteVector render(int version) const;
-      
+
       /*!
-       * Gets the current string handler that decides how the "Latin-1" data 
+       * Gets the current string handler that decides how the "Latin-1" data
        * will be converted to and from binary data.
        *
        * \see Latin1StringHandler
@@ -369,7 +369,7 @@ namespace TagLib {
        * released and default ISO-8859-1 handler is restored.
        *
        * \note The caller is responsible for deleting the previous handler
-       * as needed after it is released. 
+       * as needed after it is released.
        *
        * \see Latin1StringHandler
        */

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -173,7 +173,7 @@ namespace TagLib {
        * This is the same as calling save(AllTags);
        *
        * If you would like more granular control over the content of the tags,
-       * with the concession of generality, use paramaterized save call below.
+       * with the concession of generality, use parameterized save call below.
        *
        * \see save(int tags)
        */

--- a/taglib/ogg/flac/oggflacfile.h
+++ b/taglib/ogg/flac/oggflacfile.h
@@ -42,7 +42,7 @@ namespace TagLib {
 
   /*!
    * This is implementation of FLAC metadata for Ogg FLAC files.  For "pure"
-   * FLAC files look under the FLAC hiearchy.
+   * FLAC files look under the FLAC hierarchy.
    *
    * Unlike "pure" FLAC-files, Ogg FLAC only supports Xiph-comments,
    * while the audio-properties are the same.
@@ -64,7 +64,7 @@ namespace TagLib {
     {
     public:
       /*!
-       * Constructs an Ogg/FLAC file from \a file.  If \a readProperties is true 
+       * Constructs an Ogg/FLAC file from \a file.  If \a readProperties is true
        * the file's audio properties will also be read.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
@@ -73,7 +73,7 @@ namespace TagLib {
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Constructs an Ogg/FLAC file from \a stream.  If \a readProperties is true 
+       * Constructs an Ogg/FLAC file from \a stream.  If \a readProperties is true
        * the file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
@@ -92,10 +92,10 @@ namespace TagLib {
       /*!
        * Returns the Tag for this file.  This will always be a XiphComment.
        *
-       * \note This always returns a valid pointer regardless of whether or not 
-       * the file on disk has a XiphComment.  Use hasXiphComment() to check if 
+       * \note This always returns a valid pointer regardless of whether or not
+       * the file on disk has a XiphComment.  Use hasXiphComment() to check if
        * the file on disk actually has a XiphComment.
-       * 
+       *
        * \note The Tag <b>is still</b> owned by the FLAC::File and should not be
        * deleted by the user.  It will be deleted when the file (object) is
        * destroyed.
@@ -111,17 +111,17 @@ namespace TagLib {
       virtual Properties *audioProperties() const;
 
 
-      /*! 
+      /*!
        * Implements the unified property interface -- export function.
        * This forwards directly to XiphComment::properties().
        */
       PropertyMap properties() const;
 
-      /*! 
+      /*!
        * Implements the unified tag dictionary interface -- import function.
        * Like properties(), this is a forwarder to the file's XiphComment.
        */
-      PropertyMap setProperties(const PropertyMap &); 
+      PropertyMap setProperties(const PropertyMap &);
 
 
       /*!

--- a/taglib/ogg/oggpage.h
+++ b/taglib/ogg/oggpage.h
@@ -41,7 +41,7 @@ namespace TagLib {
     /*!
      * This is an implementation of the pages that make up an Ogg stream.
      * This handles parsing pages and breaking them down into packets and handles
-     * the details of packets spanning multiple pages and pages that contiain
+     * the details of packets spanning multiple pages and pages that contain
      * multiple packets.
      *
      * In most Xiph.org formats the comments are found in the first few packets,
@@ -162,7 +162,7 @@ namespace TagLib {
 
       /*!
        * Pack \a packets into Ogg pages using the \a strategy for pagination.
-       * The page number indicater inside of the rendered packets will start
+       * The page number indicator inside of the rendered packets will start
        * with \a firstPage and be incremented for each page rendered.
        * \a containsLastPacket should be set to true if \a packets contains the
        * last page in the stream and will set the appropriate flag in the last

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -86,8 +86,8 @@ namespace TagLib {
         /*!
          * Returns the Tag for this file.
          *
-         * \note This always returns a valid pointer regardless of whether or not 
-         * the file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the file 
+         * \note This always returns a valid pointer regardless of whether or not
+         * the file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the file
          * on disk actually has an ID3v2 tag.
          *
          * \see hasID3v2Tag()

--- a/taglib/riff/rifffile.h
+++ b/taglib/riff/rifffile.h
@@ -96,7 +96,7 @@ namespace TagLib {
       ByteVector chunkData(uint i);
 
       /*!
-       * Sets the data for the the specified chunk to \a data. 
+       * Sets the data for the specified chunk to \a data.
        *
        * \warning This will update the file immediately.
        */
@@ -116,9 +116,9 @@ namespace TagLib {
        * given name already exists it will be overwritten, otherwise it will be
        * created after the existing chunks.
        *
-       * \note If \a alwaysCreate is true, a new chunk is created regardless of 
-       * whether or not the chunk \a name exists. It should only be used for 
-       * "LIST" chunks. 
+       * \note If \a alwaysCreate is true, a new chunk is created regardless of
+       * whether or not the chunk \a name exists. It should only be used for
+       * "LIST" chunks.
        *
        * \warning This will update the file immediately.
        */

--- a/taglib/riff/wav/infotag.h
+++ b/taglib/riff/wav/infotag.h
@@ -37,7 +37,7 @@ namespace TagLib {
 
   class File;
 
-  //! A RIFF Info tag implementation. 
+  //! A RIFF Info tag implementation.
   namespace RIFF {
   namespace Info {
 
@@ -50,8 +50,8 @@ namespace TagLib {
      * In practice, local encoding of each system is largely used and UTF-8 is
      * popular too.
      *
-     * Here is an option to read and write tags in your preferrd encoding 
-     * by subclassing this class, reimplementing parse() and render() and setting 
+     * Here is an option to read and write tags in your preferrd encoding
+     * by subclassing this class, reimplementing parse() and render() and setting
      * your reimplementation as the default with Info::Tag::setStringHandler().
      *
      * \see ID3v1::Tag::setStringHandler()
@@ -71,7 +71,7 @@ namespace TagLib {
 
       /*!
        * Encode a ByteVector with the data from \a s.  The default implementation
-       * assumes that \a s is an UTF-8 string. 
+       * assumes that \a s is an UTF-8 string.
        */
       virtual ByteVector render(const String &s) const;
     };
@@ -79,10 +79,10 @@ namespace TagLib {
     //! The main class in the ID3v2 implementation
 
     /*!
-     * This is the main class in the INFO tag implementation.  RIFF INFO tag is a 
-     * metadata format found in WAV audio and AVI video files.  Though it is a part 
-     * of Microsoft/IBM's RIFF specification, the author could not find the official 
-     * documents about it.  So, this implementation is referring to unofficial documents 
+     * This is the main class in the INFO tag implementation.  RIFF INFO tag is a
+     * metadata format found in WAV audio and AVI video files.  Though it is a part
+     * of Microsoft/IBM's RIFF specification, the author could not find the official
+     * documents about it.  So, this implementation is referring to unofficial documents
      * online and some applications' behaviors especially Windows Explorer.
      */
     class TAGLIB_EXPORT Tag : public TagLib::Tag
@@ -121,7 +121,7 @@ namespace TagLib {
       virtual bool isEmpty() const;
 
       /*!
-       * Returns a copy of the internal fields of the tag.  The returned map directly 
+       * Returns a copy of the internal fields of the tag.  The returned map directly
        * reflects the contents of the "INFO" chunk.
        *
        * \note Modifying this map does not affect the tag's internal data.
@@ -136,13 +136,13 @@ namespace TagLib {
        * Gets the value of the field with the ID \a id.
        */
       String fieldText(const ByteVector &id) const;
-        
+
       /*
         * Sets the value of the field with the ID \a id to \a s.
         * If the field does not exist, it is created.
         * If \s is empty, the field is removed.
         *
-        * \note fieldId must be four-byte long pure ASCII string.  This function 
+        * \note fieldId must be four-byte long pure ASCII string.  This function
         * performs nothing if fieldId is invalid.
         */
       void setFieldText(const ByteVector &id, const String &s);
@@ -155,7 +155,7 @@ namespace TagLib {
       /*!
        * Render the tag back to binary data, suitable to be written to disk.
        *
-       * \note Returns empty ByteVector is the tag contains no fields. 
+       * \note Returns empty ByteVector is the tag contains no fields.
        */
       ByteVector render() const;
 
@@ -171,7 +171,7 @@ namespace TagLib {
        * \see StringHandler
        */
       static void setStringHandler(const StringHandler *handler);
-    
+
     protected:
       /*!
        * Pareses the body of the tag in \a data.

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -97,8 +97,8 @@ namespace TagLib {
 
         /*!
          * Returns the ID3v2 Tag for this file.
-         * 
-         * \note This method does not return all the tags for this file for 
+         *
+         * \note This method does not return all the tags for this file for
          * backward compatibility.  Will be fixed in TagLib 2.0.
          */
         ID3v2::Tag *tag() const;
@@ -106,8 +106,8 @@ namespace TagLib {
         /*!
          * Returns the ID3v2 Tag for this file.
          *
-         * \note This always returns a valid pointer regardless of whether or not 
-         * the file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the 
+         * \note This always returns a valid pointer regardless of whether or not
+         * the file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the
          * file on disk actually has an ID3v2 tag.
          *
          * \see hasID3v2Tag()
@@ -117,8 +117,8 @@ namespace TagLib {
         /*!
          * Returns the RIFF INFO Tag for this file.
          *
-         * \note This always returns a valid pointer regardless of whether or not 
-         * the file on disk has a RIFF INFO tag.  Use hasInfoTag() to check if the 
+         * \note This always returns a valid pointer regardless of whether or not
+         * the file on disk has a RIFF INFO tag.  Use hasInfoTag() to check if the
          * file on disk actually has a RIFF INFO tag.
          *
          * \see hasInfoTag()
@@ -151,7 +151,7 @@ namespace TagLib {
         virtual bool save();
 
         bool save(TagTypes tags, bool stripOthers = true, int id3v2Version = 4);
-        
+
         /*!
          * Returns whether or not the file on disk actually has an ID3v2 tag.
          *

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -48,7 +48,7 @@ namespace TagLib {
   public:
 
     /*!
-     * Detroys this Tag instance.
+     * Destroys this Tag instance.
      */
     virtual ~Tag();
 

--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -94,7 +94,7 @@ namespace TagLib {
  * - Full support for unicode and internationalized tags.
  * - Dual <a href="http://www.mozilla.org/MPL/MPL-1.1.html">MPL</a> and
  *   <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">LGPL</a> licenses.
- * - No external toolkit dependancies.
+ * - No external toolkit dependencies.
  *
  * \section why Why TagLib?
  *

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -144,7 +144,7 @@ namespace TagLib {
 
     /*!
      * Searches the char for \a c starting at \a offset and returns
-     * the offset.  Returns \a npos if the pattern was not found.  If \a byteAlign is
+     * the offset.  Returns \a -1 if the pattern was not found.  If \a byteAlign is
      * specified the pattern will only be matched if it starts on a byte divisible
      * by \a byteAlign (starting from \a offset).
      */

--- a/taglib/toolkit/tdebuglistener.h
+++ b/taglib/toolkit/tdebuglistener.h
@@ -29,17 +29,17 @@
 #include "taglib_export.h"
 #include "tstring.h"
 
-namespace TagLib 
+namespace TagLib
 {
   //! An abstraction for the listener to the debug messages.
 
   /*!
-   * This class enables you to handle the debug messages in your preferred 
-   * way by subclassing this class, reimplementing printMessage() and setting 
+   * This class enables you to handle the debug messages in your preferred
+   * way by subclassing this class, reimplementing printMessage() and setting
    * your reimplementation as the default with setDebugListener().
    *
    * \see setDebugListener()
-   */  
+   */
   class TAGLIB_EXPORT DebugListener
   {
   public:
@@ -60,8 +60,8 @@ namespace TagLib
 
   /*!
    * Sets the listener that decides how the debug messages are redirected.
-   * If the parameter \a listener is null, the previous listener is released 
-   * and default stderr listener is restored.   
+   * If the parameter \a listener is null, the previous listener is released
+   * and default stderr listener is restored.
    *
    * \note The caller is responsible for deleting the previous listener
    * as needed after it is released.

--- a/taglib/toolkit/tfile.h
+++ b/taglib/toolkit/tfile.h
@@ -83,7 +83,7 @@ namespace TagLib {
      * names (uppercase Strings) to StringLists of tag values. Calls the according
      * specialization in the File subclasses.
      * For each metadata object of the file that could not be parsed into the PropertyMap
-     * format, the returend map's unsupportedData() list will contain one entry identifying
+     * format, the returned map's unsupportedData() list will contain one entry identifying
      * that object (e.g. the frame type for ID3v2 tags). Use removeUnsupportedProperties()
      * to remove (a subset of) them.
      * For files that contain more than one tag (e.g. an MP3 with both an ID3v2 and an ID3v2
@@ -106,7 +106,7 @@ namespace TagLib {
      * into the format-specific details.
      * If some value(s) could not be written imported to the specific metadata format,
      * the returned PropertyMap will contain those value(s). Otherwise it will be empty,
-     * indicating that no problems occured.
+     * indicating that no problems occurred.
      * With file types that support several tag formats (for instance, MP3 files can have
      * ID3v1, ID3v2, and APEv2 tags), this function will create the most appropriate one
      * (ID3v2 for MP3 files). Older formats will be updated as well, if they exist, but won't
@@ -115,7 +115,7 @@ namespace TagLib {
      * BIC: will become pure virtual in the future
      */
     PropertyMap setProperties(const PropertyMap &properties);
-    
+
     /*!
      * Returns a pointer to this file's audio properties.  This should be
      * reimplemented in the concrete subclasses.  If no audio properties were
@@ -155,12 +155,12 @@ namespace TagLib {
      * Returns the offset in the file that \a pattern occurs at or -1 if it can
      * not be found.  If \a before is set, the search will only continue until the
      * pattern \a before is found.  This is useful for tagging purposes to search
-     * for a tag before the synch frame.
+     * for a tag before the sync frame.
      *
      * Searching starts at \a fromOffset, which defaults to the beginning of the
      * file.
      *
-     * \note This has the practial limitation that \a pattern can not be longer
+     * \note This has the practical limitation that \a pattern can not be longer
      * than the buffer size used by readBlock().  Currently this is 1024 bytes.
      */
     long find(const ByteVector &pattern,
@@ -171,12 +171,12 @@ namespace TagLib {
      * Returns the offset in the file that \a pattern occurs at or -1 if it can
      * not be found.  If \a before is set, the search will only continue until the
      * pattern \a before is found.  This is useful for tagging purposes to search
-     * for a tag before the synch frame.
+     * for a tag before the sync frame.
      *
      * Searching starts at \a fromOffset and proceeds from the that point to the
      * beginning of the file and defaults to the end of the file.
      *
-     * \note This has the practial limitation that \a pattern can not be longer
+     * \note This has the practical limitation that \a pattern can not be longer
      * than the buffer size used by readBlock().  Currently this is 1024 bytes.
      */
     long rfind(const ByteVector &pattern,

--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -45,7 +45,7 @@ namespace TagLib {
     operator const char *() const;
 
     const std::wstring &wstr() const;
-    const std::string  &str() const; 
+    const std::string  &str() const;
 
     String toString() const;
 

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -72,7 +72,7 @@ namespace TagLib {
 
     /*!
      * Destroys this List instance.  If auto deletion is enabled and this list
-     * contains a pointer type all of the memebers are also deleted.
+     * contains a pointer type all of the members are also deleted.
      */
     virtual ~List();
 

--- a/taglib/toolkit/tpropertymap.h
+++ b/taglib/toolkit/tpropertymap.h
@@ -34,13 +34,13 @@ namespace TagLib {
   /*!
    * This map implements a generic representation of textual audio metadata
    * ("tags") realized as pairs of a case-insensitive key
-   * and a nonempty list of corresponding values, each value being an an arbitrary
+   * and a nonempty list of corresponding values, each value being an arbitrary
    * unicode String.
    *
    * Note that most metadata formats pose additional conditions on the tag keys. The
    * most popular ones (Vorbis, APE, ID3v2) should support all ASCII only words of
    * length between 2 and 16.
-   * 
+   *
    * This class can contain any tags, but here is a list of "well-known" tags that
    * you might want to use:
    *
@@ -81,14 +81,14 @@ namespace TagLib {
    *  - COPYRIGHT
    *  - ENCODEDBY
    *  - MOOD
-   *  - COMMENT 
+   *  - COMMENT
    *  - MEDIA
    *  - LABEL
    *  - CATALOGNUMBER
    *  - BARCODE
    *
    * MusicBrainz identifiers:
-   * 
+   *
    *  - MUSICBRAINZ_TRACKID
    *  - MUSICBRAINZ_ALBUMID
    *  - MUSICBRAINZ_RELEASEGROUPID
@@ -123,7 +123,7 @@ namespace TagLib {
 
     /*!
      * Inserts \a values under \a key in the map.  If \a key already exists,
-     * then \values will be appended to the existing StringList.
+     * then \a values will be appended to the existing StringList.
      * The returned value indicates success, i.e. whether \a key is a
      * valid key.
      */

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -355,7 +355,7 @@ namespace TagLib {
     /*!
      * Convert the string to an integer.
      *
-     * If the conversion was successfull, it sets the value of \a *ok to
+     * If the conversion was successful, it sets the value of \a *ok to
      * true and returns the integer. Otherwise it sets \a *ok to false
      * and the result is undefined.
      */
@@ -495,7 +495,7 @@ namespace TagLib {
 
     /*!
      * To be able to use this class in a Map, this operator needed to be
-     * implemented.  Returns true if \a s is less than this string in a bytewise
+     * implemented.  Returns true if \a s is less than this string in a byte-wise
      * comparison.
      */
     bool operator<(const String &s) const;

--- a/taglib/toolkit/tstringlist.h
+++ b/taglib/toolkit/tstringlist.h
@@ -38,7 +38,7 @@ namespace TagLib {
   //! A list of strings
 
   /*!
-   * This is a spcialization of the List class with some members convention for
+   * This is a specialization of the List class with some members convention for
    * string operations.
    */
 

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -79,7 +79,7 @@ namespace TagLib {
       };
 
       /*!
-       * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
+       * Constructs a TrueAudio file from \a file.  If \a readProperties is true
        * the file's audio properties will also be read.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
@@ -88,7 +88,7 @@ namespace TagLib {
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Constructs a TrueAudio file from \a file.  If \a readProperties is true 
+       * Constructs a TrueAudio file from \a file.  If \a readProperties is true
        * the file's audio properties will also be read.
        *
        * If this file contains and ID3v2 tag the frames will be created using
@@ -113,7 +113,7 @@ namespace TagLib {
            Properties::ReadStyle propertiesStyle = Properties::Average);
 
       /*!
-       * Constructs a TrueAudio file from \a stream.  If \a readProperties is true 
+       * Constructs a TrueAudio file from \a stream.  If \a readProperties is true
        * the file's audio properties will also be read.
        *
        * \note TagLib will *not* take ownership of the stream, the caller is
@@ -180,8 +180,8 @@ namespace TagLib {
        * if there is no valid ID3v1 tag.  If \a create is true it will create
        * an ID3v1 tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file
        * on disk actually has an ID3v1 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -199,8 +199,8 @@ namespace TagLib {
        * if there is no valid ID3v2 tag.  If \a create is true it will create
        * an ID3v2 tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v2 tag.  Use hasID3v2Tag() to check if the file
        * on disk actually has an ID3v2 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -220,7 +220,7 @@ namespace TagLib {
        * \note In order to make the removal permanent save() still needs to be called
        */
       void strip(int tags = AllTags);
-      
+
       /*!
        * Returns whether or not the file on disk actually has an ID3v1 tag.
        *
@@ -234,7 +234,7 @@ namespace TagLib {
        * \see ID3v2Tag()
        */
       bool hasID3v2Tag() const;
-    
+
     private:
       File(const File &);
       File &operator=(const File &);

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -143,8 +143,8 @@ namespace TagLib {
        * if there is no valid ID3v1 tag.  If \a create is true it will create
        * an ID3v1 tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an ID3v1 tag.  Use hasID3v1Tag() to check if the file
        * on disk actually has an ID3v1 tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -162,8 +162,8 @@ namespace TagLib {
        * if there is no valid APE tag.  If \a create is true it will create
        * an APE tag if one does not exist and returns a valid pointer.
        *
-       * \note This may return a valid pointer regardless of whether or not the 
-       * file on disk has an APE tag.  Use hasAPETag() to check if the file 
+       * \note This may return a valid pointer regardless of whether or not the
+       * file on disk has an APE tag.  Use hasAPETag() to check if the file
        * on disk actually has an APE tag.
        *
        * \note The Tag <b>is still</b> owned by the MPEG::File and should not be
@@ -183,7 +183,7 @@ namespace TagLib {
        * \note In order to make the removal permanent save() still needs to be called
        */
       void strip(int tags = AllTags);
-      
+
       /*!
        * Returns whether or not the file on disk actually has an ID3v1 tag.
        *
@@ -197,7 +197,7 @@ namespace TagLib {
        * \see APETag()
        */
       bool hasAPETag() const;
-    
+
     private:
       File(const File &);
       File &operator=(const File &);

--- a/taglib/wavpack/wavpackproperties.h
+++ b/taglib/wavpack/wavpackproperties.h
@@ -80,7 +80,7 @@ namespace TagLib {
        * Returns the sample rate in Hz. 0 means unknown or custom.
        */
       virtual int sampleRate() const;
-      
+
       virtual int channels() const;
 
       /*!


### PR DESCRIPTION
This PR fixes dozens of misspelled comments. Doesn't touch any actual code.
It might be too strict, but such misspelled comments give a confusion to people not familiar with English like me.