### PR TITLE
Avoid corrupting files when saving them twice.

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -274,10 +274,14 @@ bool FLAC::File::save()
   }
 
   if(ID3v1Tag()) {
-    if(!d->hasID3v1)
-      d->ID3v1Location = length();
+    if(d->hasID3v1) {
+      seek(d->ID3v1Location);
+    }
+    else {
+      seek(0, End);
+      d->ID3v1Location = tell();
+    }
 
-    seek(d->ID3v1Location);
     writeBlock(ID3v1Tag()->render());
     d->hasID3v1 = true;
   }

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -149,6 +149,23 @@ MP4::File::save()
     return false;
   }
 
-  return d->tag->save();
+  const bool success = d->tag->save();
+  if(success) {
+    // Rebuild the internal structure for subsequent operations.
+    // This doesn't seem efficient, so may will be improved in the future.
+
+    FilePrivate *tmpD = new FilePrivate();
+
+    tmpD->atoms = new MP4::Atoms(this);
+    tmpD->tag = new Tag(this, tmpD->atoms);
+    if(d->properties) {
+      tmpD->properties = new Properties(this, tmpD->atoms, AudioProperties::Average);
+    }
+
+    std::swap(d, tmpD);
+    delete tmpD;
+  }
+
+  return success;
 }
 

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -232,7 +232,7 @@ bool MPEG::File::save(int tags, bool stripOthers, int id3v2Version, bool duplica
         d->ID3v2Location = 0;
 
       insert(ID3v2Tag()->render(id3v2Version), d->ID3v2Location, d->ID3v2OriginalSize);
-
+      d->ID3v2OriginalSize = ID3v2Tag()->header()->completeTagSize();
       d->hasID3v2 = true;
 
       // v1 tag location has changed, update if it exists

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -198,8 +198,12 @@ bool Ogg::File::save()
       pageGroup.append(*it);
   }
   writePageGroup(pageGroup);
-  d->dirtyPages.clear();
-  d->dirtyPackets.clear();
+
+  // Reset all the internal properties for subsequent operations.
+
+  FilePrivate *tmpD = new FilePrivate();
+  std::swap(d, tmpD);
+  delete tmpD;
 
   return true;
 }
@@ -279,7 +283,6 @@ void Ogg::File::writePageGroup(const List<int> &thePageGroup)
 {
   if(thePageGroup.isEmpty())
     return;
-
 
   // pages in the pageGroup and packets must be equivalent
   // (originalSize and size of packets would not work together),

--- a/tests/test_ape.cpp
+++ b/tests/test_ape.cpp
@@ -4,6 +4,8 @@
 #include <tstringlist.h>
 #include <tbytevectorlist.h>
 #include <apefile.h>
+#include <apetag.h>
+#include <id3v1tag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -18,6 +20,8 @@ class TestAPE : public CppUnit::TestFixture
   CPPUNIT_TEST(testProperties390);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveAPETagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -59,6 +63,58 @@ public:
   {
     APE::File f(TEST_FILE_PATH_C("zerodiv.ape"));
     CPPUNIT_ASSERT(f.isValid());
+  }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("mac-399", ".ape");
+    ScopedFileCopy copy2("mac-399", ".ape");
+
+    {
+      APE::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)172, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)364, f.length());
+    }
+
+    {
+      APE::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)364, f.length());
+    }
+  }
+
+  void testSaveAPETagTwice()
+  {
+    ScopedFileCopy copy1("mac-399", ".ape");
+    ScopedFileCopy copy2("mac-399", ".ape");
+
+    {
+      APE::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)172, f.length());
+
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)273, f.length());
+    }
+
+    {
+      APE::File f(copy2.fileName().c_str());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)273, f.length());
+    }
   }
 
 };

--- a/tests/test_asf.cpp
+++ b/tests/test_asf.cpp
@@ -5,6 +5,7 @@
 #include <tbytevectorlist.h>
 #include <tpropertymap.h>
 #include <asffile.h>
+#include <asftag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -24,6 +25,7 @@ class TestASF : public CppUnit::TestFixture
   CPPUNIT_TEST(testSavePicture);
   CPPUNIT_TEST(testSaveMultiplePictures);
   CPPUNIT_TEST(testProperties);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -242,6 +244,29 @@ public:
     CPPUNIT_ASSERT_EQUAL(1u, f.tag()->attributeListMap()["WM/PartOfSet"].size());
     CPPUNIT_ASSERT_EQUAL(String("3"), f.tag()->attribute("WM/PartOfSet").front().toString());
     CPPUNIT_ASSERT_EQUAL(StringList("3"), tags["DISCNUMBER"]);
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("silence-1", ".wma");
+    ScopedFileCopy copy2("silence-1", ".wma");
+
+    {
+      ASF::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)35416, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)35480, f.length());
+    }
+
+    {
+      ASF::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)35480, f.length());
+    }
   }
 
 };

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -6,6 +6,8 @@
 #include <tpropertymap.h>
 #include <flacfile.h>
 #include <xiphcomment.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -25,6 +27,9 @@ class TestFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST(testSaveMultipleValues);
   CPPUNIT_TEST(testDict);
   CPPUNIT_TEST(testInvalid);
+  CPPUNIT_TEST(testSaveXiphTwice);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveID3v2Twice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -253,6 +258,84 @@ public:
     PropertyMap invalid = f.setProperties(map);
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(1), invalid.size());
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(0), f.properties().size());
+  }
+
+  void testSaveXiphTwice()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+    }
+  }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+    }
+  }
+
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+    }
   }
 
 };

--- a/tests/test_it.cpp
+++ b/tests/test_it.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include <itfile.h>
+#include <modtag.h>
 #include <tstringlist.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -69,6 +70,7 @@ class TestIT : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestIT);
   CPPUNIT_TEST(testReadTags);
   CPPUNIT_TEST(testWriteTags);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -89,6 +91,29 @@ public:
       CPPUNIT_ASSERT(file.save());
     }
     testRead(copy.fileName().c_str(), titleAfter, commentAfter);
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("test", ".it");
+    ScopedFileCopy copy2("test", ".it");
+
+    {
+      IT::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)644, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)645, f.length());
+    }
+
+    {
+      IT::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)645, f.length());
+    }
   }
 
 private:

--- a/tests/test_mod.cpp
+++ b/tests/test_mod.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include <modfile.h>
+#include <modtag.h>
 #include <tpropertymap.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -53,6 +54,7 @@ class TestMod : public CppUnit::TestFixture
   CPPUNIT_TEST(testReadTags);
   CPPUNIT_TEST(testWriteTags);
   CPPUNIT_TEST(testPropertyInterface);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -91,6 +93,29 @@ public:
     CPPUNIT_ASSERT(unsupported.contains("ARTIST"));
     CPPUNIT_ASSERT_EQUAL(properties["ARTIST"], unsupported["ARTIST"]);
     CPPUNIT_ASSERT(!unsupported.contains("TITLE"));
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("test", ".mod");
+    ScopedFileCopy copy2("test", ".mod");
+
+    {
+      Mod::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3132, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)3132, f.length());
+    }
+
+    {
+      Mod::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)3132, f.length());
+    }
   }
 
 private:

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -29,6 +29,7 @@ class TestMP4 : public CppUnit::TestFixture
   CPPUNIT_TEST(testCovrRead2);
   CPPUNIT_TEST(testProperties);
   CPPUNIT_TEST(testFuzzedFile);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -303,6 +304,29 @@ public:
   {
     MP4::File f(TEST_FILE_PATH_C("infloop.m4a"));
     CPPUNIT_ASSERT(f.isValid());
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("no-tags", ".m4a");
+    ScopedFileCopy copy2("no-tags", ".m4a");
+
+    {
+      MP4::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)2898, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)3975, f.length());
+    }
+
+    {
+      MP4::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)3975, f.length());
+    }
   }
 
 };

--- a/tests/test_mpc.cpp
+++ b/tests/test_mpc.cpp
@@ -4,6 +4,8 @@
 #include <tstringlist.h>
 #include <tbytevectorlist.h>
 #include <mpcfile.h>
+#include <id3v1tag.h>
+#include <apetag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -21,6 +23,8 @@ class TestMPC : public CppUnit::TestFixture
   CPPUNIT_TEST(testFuzzedFile2);
   CPPUNIT_TEST(testFuzzedFile3);
   CPPUNIT_TEST(testFuzzedFile4);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveAPETwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -87,6 +91,58 @@ public:
   {
     MPC::File f(TEST_FILE_PATH_C("segfault2.mpc"));
     CPPUNIT_ASSERT(f.isValid());
+  }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("click", ".mpc");
+    ScopedFileCopy copy2("click", ".mpc");
+
+    {
+      MPC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)1588, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)1780, f.length());
+    }
+
+    {
+      MPC::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)1780, f.length());
+    }
+  }
+
+  void testSaveAPETwice()
+  {
+    ScopedFileCopy copy1("click", ".mpc");
+    ScopedFileCopy copy2("click", ".mpc");
+
+    {
+      MPC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)1588, f.length());
+
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)1689, f.length());
+    }
+
+    {
+      MPC::File f(copy2.fileName().c_str());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)1689, f.length());
+    }
   }
 
 };

--- a/tests/test_mpeg.cpp
+++ b/tests/test_mpeg.cpp
@@ -3,6 +3,7 @@
 #include <tstring.h>
 #include <mpegfile.h>
 #include <id3v2tag.h>
+#include <apetag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -19,6 +20,8 @@ class TestMPEG : public CppUnit::TestFixture
   CPPUNIT_TEST(testDuplicateID3v2);
   CPPUNIT_TEST(testFuzzedFile);
   CPPUNIT_TEST(testFrameOffset);
+  CPPUNIT_TEST(testSaveID3v2Twice);
+  CPPUNIT_TEST(testSaveAPETwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -134,6 +137,39 @@ public:
     }
   }
 
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+    string newname = copy.fileName();
+
+    {
+      MPEG::File f(newname.c_str());
+      f.ID3v2Tag()->setTitle(String(ByteVector(8192, 'X'), String::Latin1));
+      f.save(MPEG::File::AllTags, true, 4);
+      f.save(MPEG::File::AllTags, true, 4);
+    }
+    {
+      MPEG::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL((long)17573, f.length());
+    }
+  }
+
+  void testSaveAPETwice()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+    string newname = copy.fileName();
+
+    {
+      MPEG::File f(newname.c_str());
+      f.APETag(true)->setTitle(String(ByteVector(8192, 'X'), String::Latin1));
+      f.save(MPEG::File::AllTags, true, 4);
+      f.save(MPEG::File::AllTags, true, 4);
+    }
+    {
+      MPEG::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL((long)16478, f.length());
+    }
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestMPEG);

--- a/tests/test_ogg.cpp
+++ b/tests/test_ogg.cpp
@@ -6,6 +6,7 @@
 #include <tpropertymap.h>
 #include <oggfile.h>
 #include <vorbisfile.h>
+#include <xiphcomment.h>
 #include <oggpageheader.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -20,6 +21,7 @@ class TestOGG : public CppUnit::TestFixture
   CPPUNIT_TEST(testSplitPackets);
   CPPUNIT_TEST(testDictInterface1);
   CPPUNIT_TEST(testDictInterface2);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -102,6 +104,29 @@ public:
     CPPUNIT_ASSERT_EQUAL(false, f->tag()->properties().contains("UNUSUALTAG"));
 
     delete f;
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("empty", ".ogg");
+    ScopedFileCopy copy2("empty", ".ogg");
+
+    {
+      Vorbis::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4328, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)4361, f.length());
+    }
+
+    {
+      Vorbis::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)4361, f.length());
+    }
   }
 
 };

--- a/tests/test_oggflac.cpp
+++ b/tests/test_oggflac.cpp
@@ -68,7 +68,7 @@ public:
       Ogg::FLAC::File f(copy2.fileName().c_str());
       f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
-      //f.save(); // Causes segfault.
+      f.save();
       CPPUNIT_ASSERT(f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
     }

--- a/tests/test_oggflac.cpp
+++ b/tests/test_oggflac.cpp
@@ -5,6 +5,7 @@
 #include <tbytevectorlist.h>
 #include <oggfile.h>
 #include <oggflacfile.h>
+#include <xiphcomment.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -16,6 +17,7 @@ class TestOggFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestOggFLAC);
   CPPUNIT_TEST(testFramingBit);
   CPPUNIT_TEST(testFuzzedFile);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -44,6 +46,32 @@ public:
   {
     Ogg::FLAC::File f(TEST_FILE_PATH_C("segfault.oga"));
     CPPUNIT_ASSERT(!f.isValid());
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("empty_flac", ".oga");
+    ScopedFileCopy copy2("empty_flac", ".oga");
+
+    {
+      Ogg::FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)9113, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
+    }
+
+    {
+      Ogg::FLAC::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      //f.save(); // Causes segfault.
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
+    }
   }
 
 };

--- a/tests/test_opus.cpp
+++ b/tests/test_opus.cpp
@@ -76,7 +76,7 @@ public:
       Ogg::Opus::File f(copy2.fileName().c_str());
       f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
-      //f.save(); // Causes segfault.
+      f.save();
       CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
     }
   }

--- a/tests/test_opus.cpp
+++ b/tests/test_opus.cpp
@@ -3,6 +3,7 @@
 #include <tag.h>
 #include <tbytevectorlist.h>
 #include <opusfile.h>
+#include <xiphcomment.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -15,6 +16,7 @@ class TestOpus : public CppUnit::TestFixture
   CPPUNIT_TEST(testProperties);
   CPPUNIT_TEST(testReadComments);
   CPPUNIT_TEST(testWriteComments);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -54,6 +56,29 @@ public:
     CPPUNIT_ASSERT_EQUAL(StringList("Your Tester"), f->tag()->fieldListMap()["ARTIST"]);
     CPPUNIT_ASSERT_EQUAL(String("libopus 0.9.11-66-g64c2dd7"), f->tag()->vendorID());
     delete f;
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("correctness_gain_silent_output", ".opus");
+    ScopedFileCopy copy2("correctness_gain_silent_output", ".opus");
+
+    {
+      Ogg::Opus::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)35506, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
+    }
+
+    {
+      Ogg::Opus::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      //f.save(); // Causes segfault.
+      CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
+    }
   }
 
 };

--- a/tests/test_s3m.cpp
+++ b/tests/test_s3m.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include <s3mfile.h>
+#include <modtag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -56,6 +57,7 @@ class TestS3M : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestS3M);
   CPPUNIT_TEST(testReadTags);
   CPPUNIT_TEST(testWriteTags);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -79,6 +81,29 @@ public:
     CPPUNIT_ASSERT(fileEqual(
       copy.fileName(),
       TEST_FILE_PATH_C("changed.s3m")));
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("test", ".s3m");
+    ScopedFileCopy copy2("test", ".s3m");
+
+    {
+      S3M::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)544, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)544, f.length());
+    }
+
+    {
+      S3M::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)544, f.length());
+    }
   }
 
 private:

--- a/tests/test_trueaudio.cpp
+++ b/tests/test_trueaudio.cpp
@@ -2,6 +2,8 @@
 #include <string>
 #include <stdio.h>
 #include <trueaudiofile.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
 #include "utils.h"
 
 using namespace std;
@@ -11,6 +13,8 @@ class TestTrueAudio : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestTrueAudio);
   CPPUNIT_TEST(testReadPropertiesWithoutID3v2);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveID3v2Twice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -20,6 +24,58 @@ public:
     TrueAudio::File f(TEST_FILE_PATH_C("empty.tta"));
     CPPUNIT_ASSERT(f.audioProperties());
     CPPUNIT_ASSERT_EQUAL(3, f.audioProperties()->length());
+  }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("empty", ".tta");
+    ScopedFileCopy copy2("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+    }
+
+    {
+      TrueAudio::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+    }
+  }
+
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy1("empty", ".tta");
+    ScopedFileCopy copy2("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
+
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+    }
+
+    {
+      TrueAudio::File f(copy2.fileName().c_str());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+    }
   }
 
 };

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -22,6 +22,8 @@ class TestWAV : public CppUnit::TestFixture
   CPPUNIT_TEST(testDuplicateTags);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testSaveID3v2Twice);
+  CPPUNIT_TEST(testSaveInfoTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -166,6 +168,58 @@ public:
   {
     RIFF::WAV::File f2(TEST_FILE_PATH_C("segfault.wav"));
     CPPUNIT_ASSERT(f2.isValid());
+  }
+
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy1("empty", ".wav");
+    ScopedFileCopy copy2("empty", ".wav");
+
+    {
+      RIFF::WAV::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)14744, f.length());
+
+      f.ID3v2Tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save(RIFF::WAV::File::ID3v2, true);
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)15820, f.length());
+    }
+
+    {
+      RIFF::WAV::File f(copy2.fileName().c_str());
+      f.ID3v2Tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save(RIFF::WAV::File::ID3v2, true);
+      f.save(RIFF::WAV::File::ID3v2, true);
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)15820, f.length());
+    }
+  }
+
+  void testSaveInfoTwice()
+  {
+    ScopedFileCopy copy1("empty", ".wav");
+    ScopedFileCopy copy2("empty", ".wav");
+
+    {
+      RIFF::WAV::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL((long)14744, f.length());
+
+      f.InfoTag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save(RIFF::WAV::File::Info, true);
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL((long)14788, f.length());
+    }
+
+    {
+      RIFF::WAV::File f(copy2.fileName().c_str());
+      f.InfoTag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save(RIFF::WAV::File::Info, true);
+      f.save(RIFF::WAV::File::Info, true);
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT_EQUAL((long)14788, f.length());
+    }
   }
 
 };

--- a/tests/test_wavpack.cpp
+++ b/tests/test_wavpack.cpp
@@ -1,9 +1,12 @@
-#include <cppunit/extensions/HelperMacros.h>
 #include <string>
 #include <stdio.h>
 #include <tag.h>
 #include <tbytevectorlist.h>
 #include <wavpackfile.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
+#include <apetag.h>
+#include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
 using namespace std;
@@ -14,6 +17,8 @@ class TestWavPack : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestWavPack);
   CPPUNIT_TEST(testBasic);
   CPPUNIT_TEST(testLengthScan);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveAPETwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -40,6 +45,60 @@ public:
     WavPack::File f(TEST_FILE_PATH_C("infloop.wv"));
     CPPUNIT_ASSERT(f.isValid());
   }
+
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("click", ".wv");
+    ScopedFileCopy copy2("click", ".wv");
+
+    {
+      WavPack::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3176, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3368, f.length());
+    }
+
+    {
+      WavPack::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3368, f.length());
+    }
+  }
+
+  void testSaveAPETwice()
+  {
+    ScopedFileCopy copy1("click", ".wv");
+    ScopedFileCopy copy2("click", ".wv");
+
+    {
+      WavPack::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)3176, f.length());
+
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+    }
+
+    {
+      WavPack::File f(copy2.fileName().c_str());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+    }
+  }
+
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestWavPack);

--- a/tests/test_xm.cpp
+++ b/tests/test_xm.cpp
@@ -106,6 +106,7 @@ class TestXM : public CppUnit::TestFixture
   CPPUNIT_TEST(testReadStrippedTags);
   CPPUNIT_TEST(testWriteTagsShort);
   CPPUNIT_TEST(testWriteTagsLong);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -156,6 +157,29 @@ public:
   void testWriteTagsLong()
   {
     testWriteTags(newCommentLong);
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("test", ".xm");
+    ScopedFileCopy copy2("test", ".xm");
+
+    {
+      XM::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5471, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)5471, f.length());
+    }
+
+    {
+      XM::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)5471, f.length());
+    }
   }
 
 private:


### PR DESCRIPTION
Oops! I realized that TagLib itself may write duplicate ID3v2 tags when saving an MPEG file.