### PR TITLE
Avoid corrupting a file or segfault when calling Ogg::File::save() tw…

### DIFF
--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -198,8 +198,11 @@ bool Ogg::File::save()
       pageGroup.append(*it);
   }
   writePageGroup(pageGroup);
-  d->dirtyPages.clear();
-  d->dirtyPackets.clear();
+
+  // Reset all the internal structures for subsequent operations.
+
+  delete d;
+  d = new FilePrivate();
 
   return true;
 }
@@ -208,14 +211,16 @@ bool Ogg::File::save()
 // protected members
 ////////////////////////////////////////////////////////////////////////////////
 
-Ogg::File::File(FileName file) : TagLib::File(file)
+Ogg::File::File(FileName file) :
+  TagLib::File(file),
+  d(new FilePrivate())
 {
-  d = new FilePrivate;
 }
 
-Ogg::File::File(IOStream *stream) : TagLib::File(stream)
+Ogg::File::File(IOStream *stream) :
+  TagLib::File(stream),
+  d(new FilePrivate())
 {
-  d = new FilePrivate;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -199,7 +199,10 @@ bool Ogg::File::save()
   }
   writePageGroup(pageGroup);
 
-  // Reset all the internal structures for subsequent operations.
+  // Reset all the internal data, since the actual file has been updated.
+
+  // It's required to keep the consistency between this class and the actual
+  // file and avoid corrupting them by subsequent operations.
 
   *d = FilePrivate();
 

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -201,8 +201,7 @@ bool Ogg::File::save()
 
   // Reset all the internal structures for subsequent operations.
 
-  delete d;
-  d = new FilePrivate();
+  *d = FilePrivate();
 
   return true;
 }
@@ -284,7 +283,6 @@ void Ogg::File::writePageGroup(const List<int> &thePageGroup)
 {
   if(thePageGroup.isEmpty())
     return;
-
 
   // pages in the pageGroup and packets must be equivalent
   // (originalSize and size of packets would not work together),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ SET(test_runner_SRCS
   test_xm.cpp
   test_mpc.cpp
   test_opus.cpp
+  test_speex.cpp
 )
 
 INCLUDE_DIRECTORIES(${CPPUNIT_INCLUDE_DIR})

--- a/tests/test_ogg.cpp
+++ b/tests/test_ogg.cpp
@@ -20,6 +20,7 @@ class TestOGG : public CppUnit::TestFixture
   CPPUNIT_TEST(testSplitPackets);
   CPPUNIT_TEST(testDictInterface1);
   CPPUNIT_TEST(testDictInterface2);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -102,6 +103,29 @@ public:
     CPPUNIT_ASSERT_EQUAL(false, f->tag()->properties().contains("UNUSUALTAG"));
 
     delete f;
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("empty", ".ogg");
+    ScopedFileCopy copy2("empty", ".ogg");
+
+    {
+      Vorbis::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4328, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)4361, f.length());
+    }
+
+    {
+      Vorbis::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)4361, f.length());
+    }
   }
 
 };

--- a/tests/test_ogg.cpp
+++ b/tests/test_ogg.cpp
@@ -45,14 +45,30 @@ public:
     ScopedFileCopy copy("empty", ".ogg");
     string newname = copy.fileName();
 
-    Vorbis::File *f = new Vorbis::File(newname.c_str());
-    f->tag()->addField("test", ByteVector(128 * 1024, 'x') + ByteVector(1, '\0'));
-    f->save();
-    delete f;
+    String text(std::string(128 * 1024, ' '));
+    for (size_t i = 0; i < text.size(); ++i)
+      text[i] = static_cast<char>('A' + i % 26);
 
-    f = new Vorbis::File(newname.c_str());
-    CPPUNIT_ASSERT_EQUAL(19, f->lastPageHeader()->pageSequenceNumber());
-    delete f;
+    {
+      Ogg::Vorbis::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(2, f.lastPageHeader()->pageSequenceNumber());
+      f.tag()->setTitle(text);
+      f.save();
+    }
+
+    {
+      Ogg::Vorbis::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(19, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(text, f.tag()->title());
+      f.tag()->setTitle("");
+      f.save();
+    }
+
+    {
+      Ogg::Vorbis::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(3, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(String(), f.tag()->title());
+    }
   }
 
   void testDictInterface1()
@@ -110,13 +126,20 @@ public:
     ScopedFileCopy copy1("empty", ".ogg");
     ScopedFileCopy copy2("empty", ".ogg");
 
+    ByteVector audioStream;
     {
       Vorbis::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)4328, f.length());
 
+      f.seek(0x0093);
+      audioStream = f.readBlock(4096);
+
       f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT_EQUAL((long)4361, f.length());
+
+      f.seek(0x00B4);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4096));
     }
 
     {
@@ -125,6 +148,15 @@ public:
       f.save();
       f.save();
       CPPUNIT_ASSERT_EQUAL((long)4361, f.length());
+
+      f.seek(0x00B4);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4096));
+
+      f.tag()->setTitle("");
+      f.save();
+
+      f.seek(0x0093);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4096));
     }
   }
 

--- a/tests/test_oggflac.cpp
+++ b/tests/test_oggflac.cpp
@@ -16,6 +16,7 @@ class TestOggFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestOggFLAC);
   CPPUNIT_TEST(testFramingBit);
   CPPUNIT_TEST(testFuzzedFile);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -44,6 +45,32 @@ public:
   {
     Ogg::FLAC::File f(TEST_FILE_PATH_C("segfault.oga"));
     CPPUNIT_ASSERT(!f.isValid());
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("empty_flac", ".oga");
+    ScopedFileCopy copy2("empty_flac", ".oga");
+
+    {
+      Ogg::FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)9113, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
+    }
+
+    {
+      Ogg::FLAC::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
+    }
   }
 
 };

--- a/tests/test_oggflac.cpp
+++ b/tests/test_oggflac.cpp
@@ -5,6 +5,7 @@
 #include <tbytevectorlist.h>
 #include <oggfile.h>
 #include <oggflacfile.h>
+#include <oggpageheader.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -16,6 +17,7 @@ class TestOggFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestOggFLAC);
   CPPUNIT_TEST(testFramingBit);
   CPPUNIT_TEST(testFuzzedFile);
+  CPPUNIT_TEST(testSplitPackets);
   CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
@@ -47,20 +49,58 @@ public:
     CPPUNIT_ASSERT(!f.isValid());
   }
 
+  void testSplitPackets()
+  {
+    ScopedFileCopy copy("empty_flac", ".oga");
+    string newname = copy.fileName();
+
+    String text(std::string(128 * 1024, ' '));
+    for (size_t i = 0; i < text.size(); ++i)
+      text[i] = static_cast<char>('A' + i % 26);
+
+    {
+      Ogg::FLAC::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(5, f.lastPageHeader()->pageSequenceNumber());
+      f.tag()->setTitle(text);
+      f.save();
+    }
+
+    {
+      Ogg::FLAC::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(21, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(text, f.tag()->title());
+      f.tag()->setTitle("");
+      f.save();
+    }
+
+    {
+      Ogg::FLAC::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(5, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(String(), f.tag()->title());
+    }
+  }
+
   void testSaveTagTwice()
   {
     ScopedFileCopy copy1("empty_flac", ".oga");
     ScopedFileCopy copy2("empty_flac", ".oga");
 
+    ByteVector audioStream;
     {
       Ogg::FLAC::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)9113, f.length());
 
+      f.seek(0x0097);
+      audioStream = f.readBlock(8192);
+
       f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
+
+      f.seek(0x00B8);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
     }
 
     {
@@ -70,6 +110,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)9146, f.length());
+
+      f.seek(0x00B8);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
+
+      f.tag()->setTitle("");
+      f.save();
+
+      f.seek(0x0097);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
     }
   }
 

--- a/tests/test_opus.cpp
+++ b/tests/test_opus.cpp
@@ -15,6 +15,7 @@ class TestOpus : public CppUnit::TestFixture
   CPPUNIT_TEST(testProperties);
   CPPUNIT_TEST(testReadComments);
   CPPUNIT_TEST(testWriteComments);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -54,6 +55,29 @@ public:
     CPPUNIT_ASSERT_EQUAL(StringList("Your Tester"), f->tag()->fieldListMap()["ARTIST"]);
     CPPUNIT_ASSERT_EQUAL(String("libopus 0.9.11-66-g64c2dd7"), f->tag()->vendorID());
     delete f;
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("correctness_gain_silent_output", ".opus");
+    ScopedFileCopy copy2("correctness_gain_silent_output", ".opus");
+
+    {
+      Ogg::Opus::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)35506, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
+    }
+
+    {
+      Ogg::Opus::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
+    }
   }
 
 };

--- a/tests/test_opus.cpp
+++ b/tests/test_opus.cpp
@@ -3,6 +3,7 @@
 #include <tag.h>
 #include <tbytevectorlist.h>
 #include <opusfile.h>
+#include <oggpageheader.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -15,6 +16,7 @@ class TestOpus : public CppUnit::TestFixture
   CPPUNIT_TEST(testProperties);
   CPPUNIT_TEST(testReadComments);
   CPPUNIT_TEST(testWriteComments);
+  CPPUNIT_TEST(testSplitPackets);
   CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
@@ -57,18 +59,56 @@ public:
     delete f;
   }
 
+  void testSplitPackets()
+  {
+    ScopedFileCopy copy("correctness_gain_silent_output", ".opus");
+    string newname = copy.fileName();
+
+    String text(std::string(128 * 1024, ' '));
+    for (size_t i = 0; i < text.size(); ++i)
+      text[i] = static_cast<char>('A' + i % 26);
+
+    {
+      Ogg::Opus::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(11, f.lastPageHeader()->pageSequenceNumber());
+      f.tag()->setTitle(text);
+      f.save();
+    }
+
+    {
+      Ogg::Opus::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(27, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(text, f.tag()->title());
+      f.tag()->setTitle("");
+      f.save();
+    }
+
+    {
+      Ogg::Opus::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(11, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(String(), f.tag()->title());
+    }
+  }
+
   void testSaveTagTwice()
   {
     ScopedFileCopy copy1("correctness_gain_silent_output", ".opus");
     ScopedFileCopy copy2("correctness_gain_silent_output", ".opus");
 
+    ByteVector audioStream;
     {
       Ogg::Opus::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)35506, f.length());
 
+      f.seek(0x0176);
+      audioStream = f.readBlock(8192);
+
       f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
+
+      f.seek(0x0197);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
     }
 
     {
@@ -77,6 +117,15 @@ public:
       f.save();
       f.save();
       CPPUNIT_ASSERT_EQUAL((long)35539, f.length());
+
+      f.seek(0x0197);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
+
+      f.tag()->setTitle("");
+      f.save();
+
+      f.seek(0x0176);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
     }
   }
 

--- a/tests/test_speex.cpp
+++ b/tests/test_speex.cpp
@@ -1,0 +1,102 @@
+#include <speexfile.h>
+#include <oggpageheader.h>
+#include <xiphcomment.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include "utils.h"
+
+using namespace std;
+using namespace TagLib;
+
+class TestSpeex : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestSpeex);
+  CPPUNIT_TEST(testAudioProperties);
+  CPPUNIT_TEST(testSplitPackets);
+  CPPUNIT_TEST(testSaveTagTwice);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void testAudioProperties()
+  {
+    Ogg::Speex::File f(TEST_FILE_PATH_C("empty.spx"));
+    CPPUNIT_ASSERT(f.audioProperties());
+    CPPUNIT_ASSERT_EQUAL(3, f.audioProperties()->length());
+    CPPUNIT_ASSERT_EQUAL(0, f.audioProperties()->bitrate());
+    CPPUNIT_ASSERT_EQUAL(2, f.audioProperties()->channels());
+    CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
+  }
+
+  void testSplitPackets()
+  {
+    ScopedFileCopy copy("empty", ".spx");
+    string newname = copy.fileName();
+
+    String text(std::string(128 * 1024, ' '));
+    for(size_t i = 0; i < text.size(); ++i)
+      text[i] = static_cast<char>('A' + i % 26);
+
+    {
+      Ogg::Speex::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(7, f.lastPageHeader()->pageSequenceNumber());
+      f.tag()->setTitle(text);
+      f.save();
+    }
+
+    {
+      Ogg::Speex::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(23, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(text, f.tag()->title());
+      f.tag()->setTitle("");
+      f.save();
+    }
+
+    {
+      Ogg::Speex::File f(newname.c_str());
+      CPPUNIT_ASSERT_EQUAL(7, f.lastPageHeader()->pageSequenceNumber());
+      CPPUNIT_ASSERT_EQUAL(String(), f.tag()->title());
+    }
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("empty", ".spx");
+    ScopedFileCopy copy2("empty", ".spx");
+
+    ByteVector audioStream;
+    {
+      Ogg::Speex::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)24301, f.length());
+
+      f.seek(0x00A9);
+      audioStream = f.readBlock(8192);
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)24335, f.length());
+
+      f.seek(0x00CB);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
+    }
+
+    {
+      Ogg::Speex::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)24335, f.length());
+
+      f.seek(0x00CB);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
+
+      f.tag()->setTitle("");
+      f.save();
+
+      f.seek(0x00AA);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(8192));
+    }
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestSpeex);


### PR DESCRIPTION
…ice without closing it.

As I reported at #596, ```Ogg::File::save()``` corrupts a file and/or cause a segfault when called twice.
This PR fixes it by simply resetting all the internal properties of ```Ogg::File```.