### PR TITLE
Avoid corrupting a file when calling MP4::File::save() twice without …

### DIFF
--- a/taglib/mp4/mp4atom.cpp
+++ b/taglib/mp4/mp4atom.cpp
@@ -41,6 +41,8 @@ const char *MP4::Atom::containers[11] = {
 
 MP4::Atom::Atom(File *file)
 {
+  children.setAutoDelete(true);
+
   offset = file->tell();
   ByteVector header = file->readBlock(8);
   if (header.size() != 8) {
@@ -104,10 +106,6 @@ MP4::Atom::Atom(File *file)
 
 MP4::Atom::~Atom()
 {
-  for(unsigned int i = 0; i < children.size(); i++) {
-    delete children[i];
-  }
-  children.clear();
 }
 
 MP4::Atom *
@@ -116,9 +114,9 @@ MP4::Atom::find(const char *name1, const char *name2, const char *name3, const c
   if(name1 == 0) {
     return this;
   }
-  for(unsigned int i = 0; i < children.size(); i++) {
-    if(children[i]->name == name1) {
-      return children[i]->find(name2, name3, name4);
+  for(MP4::AtomList::ConstIterator it = children.begin(); it != children.end(); ++it) {
+    if((*it)->name == name1) {
+      return (*it)->find(name2, name3, name4);
     }
   }
   return 0;
@@ -128,12 +126,12 @@ MP4::AtomList
 MP4::Atom::findall(const char *name, bool recursive)
 {
   MP4::AtomList result;
-  for(unsigned int i = 0; i < children.size(); i++) {
-    if(children[i]->name == name) {
-      result.append(children[i]);
+  for(MP4::AtomList::ConstIterator it = children.begin(); it != children.end(); ++it) {
+    if((*it)->name == name) {
+      result.append((*it));
     }
     if(recursive) {
-      result.append(children[i]->findall(name, recursive));
+      result.append((*it)->findall(name, recursive));
     }
   }
   return result;
@@ -146,9 +144,9 @@ MP4::Atom::path(MP4::AtomList &path, const char *name1, const char *name2, const
   if(name1 == 0) {
     return true;
   }
-  for(unsigned int i = 0; i < children.size(); i++) {
-    if(children[i]->name == name1) {
-      return children[i]->path(path, name2, name3);
+  for(MP4::AtomList::ConstIterator it = children.begin(); it != children.end(); ++it) {
+    if((*it)->name == name1) {
+      return (*it)->path(path, name2, name3);
     }
   }
   return false;
@@ -156,31 +154,29 @@ MP4::Atom::path(MP4::AtomList &path, const char *name1, const char *name2, const
 
 MP4::Atoms::Atoms(File *file)
 {
+  atoms.setAutoDelete(true);
+
   file->seek(0, File::End);
   long end = file->tell();
   file->seek(0);
   while(file->tell() + 8 <= end) {
     MP4::Atom *atom = new MP4::Atom(file);
     atoms.append(atom);
-    if (atom->length == 0)
+    if(atom->length == 0)
       break;
   }
 }
 
 MP4::Atoms::~Atoms()
 {
-  for(unsigned int i = 0; i < atoms.size(); i++) {
-    delete atoms[i];
-  }
-  atoms.clear();
 }
 
 MP4::Atom *
 MP4::Atoms::find(const char *name1, const char *name2, const char *name3, const char *name4)
 {
-  for(unsigned int i = 0; i < atoms.size(); i++) {
-    if(atoms[i]->name == name1) {
-      return atoms[i]->find(name2, name3, name4);
+  for(MP4::AtomList::ConstIterator it = atoms.begin(); it != atoms.end(); ++it) {
+    if((*it)->name == name1) {
+      return (*it)->find(name2, name3, name4);
     }
   }
   return 0;
@@ -189,15 +185,15 @@ MP4::Atoms::find(const char *name1, const char *name2, const char *name3, const 
 MP4::AtomList
 MP4::Atoms::path(const char *name1, const char *name2, const char *name3, const char *name4)
 {
-  MP4::AtomList path;
-  for(unsigned int i = 0; i < atoms.size(); i++) {
-    if(atoms[i]->name == name1) {
-      if(!atoms[i]->path(path, name2, name3, name4)) {
-        path.clear();
-      }
-      return path;
+  for(MP4::AtomList::ConstIterator it = atoms.begin(); it != atoms.end(); ++it) {
+    if((*it)->name == name1) {
+      MP4::AtomList path;
+      if((*it)->path(path, name2, name3, name4))
+        return path;
+      else
+        return MP4::AtomList();
     }
   }
-  return path;
+  return MP4::AtomList();
 }
 

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -35,9 +35,10 @@ using namespace TagLib;
 class MP4::File::FilePrivate
 {
 public:
-  FilePrivate() : tag(0), atoms(0), properties(0)
-  {
-  }
+  FilePrivate() :
+    tag(0),
+    atoms(0),
+    properties(0) {}
 
   ~FilePrivate()
   {
@@ -51,18 +52,18 @@ public:
   MP4::Properties *properties;
 };
 
-MP4::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
-    : TagLib::File(file)
+MP4::File::File(FileName file, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle) :
+  TagLib::File(file),
+  d(new FilePrivate())
 {
-  d = new FilePrivate;
   if(isOpen())
     read(readProperties, audioPropertiesStyle);
 }
 
-MP4::File::File(IOStream *stream, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle)
-    : TagLib::File(stream)
+MP4::File::File(IOStream *stream, bool readProperties, AudioProperties::ReadStyle audioPropertiesStyle) :
+  TagLib::File(stream),
+  d(new FilePrivate())
 {
-  d = new FilePrivate;
   if(isOpen())
     read(readProperties, audioPropertiesStyle);
 }
@@ -102,10 +103,10 @@ MP4::File::audioProperties() const
 bool
 MP4::File::checkValid(const MP4::AtomList &list)
 {
-  for(uint i = 0; i < list.size(); i++) {
-    if(list[i]->length == 0)
+  for(MP4::AtomList::ConstIterator it = list.begin(); it != list.end(); ++it) {
+    if((*it)->length == 0)
       return false;
-    if(!checkValid(list[i]->children))
+    if(!checkValid((*it)->children))
       return false;
   }
   return true;
@@ -118,7 +119,7 @@ MP4::File::read(bool readProperties, Properties::ReadStyle audioPropertiesStyle)
     return;
 
   d->atoms = new Atoms(this);
-  if (!checkValid(d->atoms->atoms)) {
+  if(!checkValid(d->atoms->atoms)) {
     setValid(false);
     return;
   }

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -609,11 +609,16 @@ MP4::Tag::saveNew(ByteVector data)
     data = renderAtom("udta", data);
   }
 
-  long offset = path[path.size() - 1]->offset + 8;
+  const long offset = path.back()->offset + 8;
   d->file->insert(data, offset, 0);
 
   updateParents(path, data.size());
   updateOffsets(data.size(), offset);
+
+  // Insert newly created atoms to keep the data structure up-to-date.
+
+  d->file->seek(offset);
+  path.back()->children.prepend(new Atom(d->file));
 }
 
 void

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -311,13 +311,20 @@ public:
     ScopedFileCopy copy1("no-tags", ".m4a");
     ScopedFileCopy copy2("no-tags", ".m4a");
 
+    ByteVector audioStream;
     {
       MP4::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)2898, f.length());
 
+      f.seek(0x001C);
+      audioStream = f.readBlock(1465);
+
       f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT_EQUAL((long)3975, f.length());
+
+      f.seek(0x001C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(1465));
     }
 
     {
@@ -326,6 +333,12 @@ public:
       f.save();
       f.save();
       CPPUNIT_ASSERT_EQUAL((long)3975, f.length());
+
+      f.tag()->setTitle("");
+      f.save();
+
+      f.seek(0x001C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(1465));
     }
   }
 

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -29,6 +29,7 @@ class TestMP4 : public CppUnit::TestFixture
   CPPUNIT_TEST(testCovrRead2);
   CPPUNIT_TEST(testProperties);
   CPPUNIT_TEST(testFuzzedFile);
+  CPPUNIT_TEST(testSaveTagTwice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -303,6 +304,29 @@ public:
   {
     MP4::File f(TEST_FILE_PATH_C("infloop.m4a"));
     CPPUNIT_ASSERT(f.isValid());
+  }
+
+  void testSaveTagTwice()
+  {
+    ScopedFileCopy copy1("no-tags", ".m4a");
+    ScopedFileCopy copy2("no-tags", ".m4a");
+
+    {
+      MP4::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)2898, f.length());
+
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)3975, f.length());
+    }
+
+    {
+      MP4::File f(copy2.fileName().c_str());
+      f.tag()->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT_EQUAL((long)3975, f.length());
+    }
   }
 
 };


### PR DESCRIPTION
…closing it.

This tries to keep the data structure of ```MP4::Tag``` up-to-date to avoid creating the same atom twice.