### PR TITLE
Avoid corrupting a FLAC file when saving.

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -267,8 +267,16 @@ bool FLAC::File::save()
   }
 
   if(ID3v1Tag()) {
-    seek(-128, End);
+    if(d->hasID3v1) {
+      seek(d->ID3v1Location);
+    }
+    else {
+      seek(0, End);
+      d->ID3v1Location = tell();
+    }
+
     writeBlock(ID3v1Tag()->render());
+    d->hasID3v1 = true;
   }
 
   return true;

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -252,6 +252,9 @@ bool FLAC::File::save()
   insert(data, d->flacStart, originalLength);
   d->hasXiphComment = true;
 
+  if(d->ID3v1Location >= 0)
+    d->ID3v1Location += (data.size() - originalLength);
+
   // Update ID3 tags
 
   if(ID3v2Tag()) {
@@ -267,10 +270,14 @@ bool FLAC::File::save()
 
       insert(ID3v2Tag()->render(), d->ID3v2Location, d->ID3v2OriginalSize);
 
+      const long prevOriginalSize = d->ID3v2OriginalSize;
       d->ID3v2OriginalSize = ID3v2Tag()->header()->completeTagSize();
       d->hasID3v2 = true;
 
-      d->flacStart = find("fLaC", d->ID3v2Location + d->ID3v2OriginalSize) + 4;
+      d->flacStart += (d->ID3v2OriginalSize - prevOriginalSize);
+
+      if(d->ID3v1Location >= 0)
+        d->ID3v1Location += (d->ID3v2OriginalSize - prevOriginalSize);
     }
   }
 

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -275,7 +275,8 @@ bool FLAC::File::save()
 
     // FLAC metadata location has changed, update.
 
-    d->flacStart += (d->ID3v2OriginalSize - prevOriginalSize);
+    d->flacStart   += (d->ID3v2OriginalSize - prevOriginalSize);
+    d->streamStart += (d->ID3v2OriginalSize - prevOriginalSize);
 
     // v1 tag location has changed, update if it exists.
 
@@ -293,7 +294,8 @@ bool FLAC::File::save()
 
       // FLAC metadata location has changed, update.
 
-      d->flacStart -= removedSize;
+      d->flacStart   -= removedSize;
+      d->streamStart -= removedSize;
 
       // v1 tag location has changed, update if it exists
 

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -67,6 +67,23 @@ namespace TagLib {
     {
     public:
       /*!
+       * This set of flags is used for various operations and is suitable for
+       * being OR-ed together.
+       */
+      enum TagTypes {
+        //! Empty set.  Matches no tag types.
+        NoTags      = 0x0000,
+        //! Matches Xiph comments.
+        XiphComment = 0x0001,
+        //! Matches ID3v1 tags.
+        ID3v1       = 0x0002,
+        //! Matches ID3v2 tags.
+        ID3v2       = 0x0004,
+        //! Matches all tag types.
+        AllTags     = 0xffff
+      };
+
+      /*!
        * Constructs a FLAC file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
@@ -264,6 +281,17 @@ namespace TagLib {
        * \note The file will be saved only after calling save().
        */
       void addPicture(Picture *picture);
+
+      /*!
+       * This will remove the tags that match the OR-ed together TagTypes from
+       * the file.  By default it removes all tags.
+       *
+       * \note This will also invalidate pointers to the tags as their memory
+       * will be freed.
+       * \note In order to make the removal permanent save() still needs to be
+       * called.
+       */
+      void strip(int tags = AllTags);
 
       /*!
        * Returns whether or not the file on disk actually has a XiphComment.

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -6,6 +6,8 @@
 #include <tpropertymap.h>
 #include <flacfile.h>
 #include <xiphcomment.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -26,6 +28,9 @@ class TestFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST(testDict);
   CPPUNIT_TEST(testInvalid);
   CPPUNIT_TEST(testShrinkPadding);
+  CPPUNIT_TEST(testSaveXiphTwice);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveID3v2Twice);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -285,6 +290,84 @@ public:
       f.removePictures();
       f.save();
       CPPUNIT_ASSERT(f.length() < 100 * 1024);
+    }
+  }
+
+  void testSaveXiphTwice()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+    }
+  }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+    }
+  }
+
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
     }
   }
 

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -31,6 +31,7 @@ class TestFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST(testSaveXiphTwice);
   CPPUNIT_TEST(testSaveID3v1Twice);
   CPPUNIT_TEST(testSaveID3v2Twice);
+  CPPUNIT_TEST(testSaveTagCombination);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -368,6 +369,126 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+    }
+  }
+
+  void testSaveTagCombination()
+  {
+    ScopedFileCopy copy1("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+    }
+
+    {
+      FLAC::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
+    }
+
+    ScopedFileCopy copy2("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+    }
+
+    {
+      FLAC::File f(copy2.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
+    }
+
+    ScopedFileCopy copy3("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy3.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+    }
+
+    {
+      FLAC::File f(copy3.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
     }
   }
 

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -31,8 +31,12 @@ class TestFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST(testSaveXiphTwice);
   CPPUNIT_TEST(testSaveID3v1Twice);
   CPPUNIT_TEST(testSaveID3v2Twice);
-  CPPUNIT_TEST(testSaveTagCombination);
-  CPPUNIT_TEST(testStripTags);
+  CPPUNIT_TEST(testSaveTags1);
+  CPPUNIT_TEST(testSaveTags2);
+  CPPUNIT_TEST(testSaveTags3);
+  CPPUNIT_TEST(testStripTags1);
+  CPPUNIT_TEST(testStripTags2);
+  CPPUNIT_TEST(testStripTags3);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -373,115 +377,43 @@ public:
     }
   }
 
-  void testSaveTagCombination()
+  void testSaveTags1()
   {
-    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy("no-tags", ".flac");
 
     {
-      FLAC::File f(copy1.fileName().c_str());
+      FLAC::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(!f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
     }
 
     {
-      FLAC::File f(copy1.fileName().c_str());
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasXiphComment());
 
-      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
-      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
-      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
-    }
-
-    ScopedFileCopy copy2("no-tags", ".flac");
-
-    {
-      FLAC::File f(copy2.fileName().c_str());
-      CPPUNIT_ASSERT(!f.hasID3v1Tag());
-      CPPUNIT_ASSERT(!f.hasID3v2Tag());
-      CPPUNIT_ASSERT(!f.hasXiphComment());
-      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(!f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
       f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
     }
 
     {
-      FLAC::File f(copy2.fileName().c_str());
-      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-
-      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
-      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
-      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
-    }
-
-    ScopedFileCopy copy3("no-tags", ".flac");
-
-    {
-      FLAC::File f(copy3.fileName().c_str());
-      CPPUNIT_ASSERT(!f.hasID3v1Tag());
-      CPPUNIT_ASSERT(!f.hasID3v2Tag());
-      CPPUNIT_ASSERT(!f.hasXiphComment());
-      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(!f.hasID3v1Tag());
-      CPPUNIT_ASSERT(!f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(!f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.save();
-
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
-      CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasXiphComment());
-    }
-
-    {
-      FLAC::File f(copy3.fileName().c_str());
+      FLAC::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
@@ -493,35 +425,278 @@ public:
     }
   }
 
-  void testStripTags()
+  void testSaveTags2()
   {
-    ScopedFileCopy copy1("no-tags", ".flac");
+    ScopedFileCopy copy("no-tags", ".flac");
 
     {
-      FLAC::File f(copy1.fileName().c_str());
-      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
-      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+
       f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
     }
 
     {
-      FLAC::File f(copy1.fileName().c_str());
-      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasXiphComment());
-      f.strip(FLAC::File::ID3v1 | FLAC::File::ID3v2);
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
     }
 
     {
-      FLAC::File f(copy1.fileName().c_str());
-      CPPUNIT_ASSERT(!f.hasID3v1Tag());
-      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
     }
   }
+
+  void testSaveTags3()
+  {
+    ScopedFileCopy copy("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
+    }
+  }
+
+  void testStripTags1()
+  {
+    ScopedFileCopy copy("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::ID3v1);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::ID3v2);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::XiphComment);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4660, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+    }
+  }
+
+  void testStripTags2()
+  {
+    ScopedFileCopy copy("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::ID3v2);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::ID3v1);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::XiphComment);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4660, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+    }
+  }
+
+  void testStripTags3()
+  {
+    ScopedFileCopy copy("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasXiphComment());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::XiphComment);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5888, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::ID3v1);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.strip(FLAC::File::ID3v2);
+      f.save();
+    }
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasXiphComment());
+    }
+  }
+
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestFLAC);

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -25,6 +25,7 @@ class TestFLAC : public CppUnit::TestFixture
   CPPUNIT_TEST(testSaveMultipleValues);
   CPPUNIT_TEST(testDict);
   CPPUNIT_TEST(testInvalid);
+  CPPUNIT_TEST(testShrinkPadding);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -118,6 +119,18 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("image/jpeg"), pic->mimeType());
     CPPUNIT_ASSERT_EQUAL(String("new image"), pic->description());
     CPPUNIT_ASSERT_EQUAL(ByteVector("JPEG data"), pic->data());
+
+    newpic = new FLAC::Picture();
+    newpic->setType(FLAC::Picture::Artist);
+    newpic->setWidth(5);
+    newpic->setHeight(6);
+    newpic->setColorDepth(16);
+    newpic->setNumColors(7);
+    newpic->setMimeType("image/jpeg");
+    newpic->setDescription("new image");
+    newpic->setData(ByteVector(16777216, '\x55'));
+    f->addPicture(newpic);
+    CPPUNIT_ASSERT(!f->save());
     delete f;
   }
 
@@ -253,6 +266,26 @@ public:
     PropertyMap invalid = f.setProperties(map);
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(1), invalid.size());
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(0), f.properties().size());
+  }
+
+  void testShrinkPadding()
+  {
+    ScopedFileCopy copy("silence-44-s", ".flac");
+    string newname = copy.fileName();
+
+    {
+      FLAC::File f(newname.c_str());
+      f.addPicture(new FLAC::Picture(ByteVector(1000 * 1024, '\xff')));
+      f.save();
+      CPPUNIT_ASSERT(f.length() > 1000 * 1024);
+    }
+
+    {
+      FLAC::File f(newname.c_str());
+      f.removePictures();
+      f.save();
+      CPPUNIT_ASSERT(f.length() < 100 * 1024);
+    }
   }
 
 };

--- a/tests/test_flac.cpp
+++ b/tests/test_flac.cpp
@@ -304,15 +304,22 @@ public:
     ScopedFileCopy copy1("no-tags", ".flac");
     ScopedFileCopy copy2("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
 
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       f.xiphComment(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
 
     {
@@ -322,6 +329,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasXiphComment());
       CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
+
+      f.xiphComment(true)->setTitle("");
+      f.save();
+
+      f.seek(0x00E0);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -330,15 +346,22 @@ public:
     ScopedFileCopy copy1("no-tags", ".flac");
     ScopedFileCopy copy2("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
 
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
 
     {
@@ -348,6 +371,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)4820, f.length());
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
+
+      f.ID3v1Tag(true)->setTitle("");
+      f.save();
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -356,15 +388,22 @@ public:
     ScopedFileCopy copy1("no-tags", ".flac");
     ScopedFileCopy copy2("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)4692, f.length());
 
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+
+      f.seek(0x052C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
 
     {
@@ -374,6 +413,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)5760, f.length());
+
+      f.seek(0x052C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
+
+      f.ID3v2Tag(true)->setTitle("");
+      f.save();
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -381,8 +429,12 @@ public:
   {
     ScopedFileCopy copy("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy.fileName().c_str());
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
@@ -422,6 +474,9 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
+
+      f.seek(0x052C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -429,8 +484,12 @@ public:
   {
     ScopedFileCopy copy("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy.fileName().c_str());
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
@@ -471,6 +530,9 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
+
+      f.seek(0x052C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -478,8 +540,12 @@ public:
   {
     ScopedFileCopy copy("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy.fileName().c_str());
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
@@ -520,6 +586,9 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.xiphComment()->title());
+
+      f.seek(0x052C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -527,8 +596,12 @@ public:
   {
     ScopedFileCopy copy("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy.fileName().c_str());
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
@@ -578,6 +651,9 @@ public:
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.seek(0x00E0);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -585,8 +661,12 @@ public:
   {
     ScopedFileCopy copy("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy.fileName().c_str());
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
@@ -636,6 +716,9 @@ public:
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.seek(0x00E0);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 
@@ -643,8 +726,12 @@ public:
   {
     ScopedFileCopy copy("no-tags", ".flac");
 
+    ByteVector audioStream;
     {
       FLAC::File f(copy.fileName().c_str());
+      f.seek(0x0100);
+      audioStream = f.readBlock(4436);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(!f.hasXiphComment());
@@ -694,6 +781,9 @@ public:
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasXiphComment());
+
+      f.seek(0x0100);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(4436));
     }
   }
 


### PR DESCRIPTION
This PR fixes file corruption in following cases:
* Too huge metadata block is added.
* An ID3v1 tag is newly created.
* Saved twice without closing it.

Additionally, this includes the changes in #586.
