### PR TITLE
Add tests calling TrueAudio::File::save() twice.

### DIFF
--- a/tests/test_trueaudio.cpp
+++ b/tests/test_trueaudio.cpp
@@ -15,7 +15,10 @@ class TestTrueAudio : public CppUnit::TestFixture
   CPPUNIT_TEST(testReadPropertiesWithoutID3v2);
   CPPUNIT_TEST(testSaveID3v1Twice);
   CPPUNIT_TEST(testSaveID3v2Twice);
-  CPPUNIT_TEST(testSaveTagCombination);
+  CPPUNIT_TEST(testSaveTags1);
+  CPPUNIT_TEST(testSaveTags2);
+  CPPUNIT_TEST(testStripTags1);
+  CPPUNIT_TEST(testStripTags2);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -32,15 +35,22 @@ public:
     ScopedFileCopy copy1("empty", ".tta");
     ScopedFileCopy copy2("empty", ".tta");
 
+    ByteVector audioStream;
     {
       TrueAudio::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
 
+      f.seek(0x0000);
+      audioStream = f.readBlock(79538);
+
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
     }
 
     {
@@ -50,6 +60,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
+
+      f.ID3v1Tag(true)->setTitle("");
+      f.save();
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
     }
   }
 
@@ -58,15 +77,22 @@ public:
     ScopedFileCopy copy1("empty", ".tta");
     ScopedFileCopy copy2("empty", ".tta");
 
+    ByteVector audioStream;
     {
       TrueAudio::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
 
+      f.seek(0x0000);
+      audioStream = f.readBlock(79538);
+
       f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+
+      f.seek(0x042C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
     }
 
     {
@@ -76,15 +102,28 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+
+      f.seek(0x042C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
+
+      f.ID3v2Tag(true)->setTitle("");
+      f.save();
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
     }
   }
 
-  void testSaveTagCombination()
+  void testSaveTags1()
   {
-    ScopedFileCopy copy1("empty", ".tta");
+    ScopedFileCopy copy("empty", ".tta");
 
+    ByteVector audioStream;
     {
-      TrueAudio::File f(copy1.fileName().c_str());
+      TrueAudio::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(79538);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -100,19 +139,29 @@ public:
     }
 
     {
-      TrueAudio::File f(copy1.fileName().c_str());
+      TrueAudio::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)80734, f.length());
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
 
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+
+      f.seek(0x042C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
     }
+  }
 
-    ScopedFileCopy copy2("empty", ".tta");
+  void testSaveTags2()
+  {
+    ScopedFileCopy copy("empty", ".tta");
 
+    ByteVector audioStream;
     {
-      TrueAudio::File f(copy2.fileName().c_str());
+      TrueAudio::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(79538);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasID3v2Tag());
       f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -128,13 +177,120 @@ public:
     }
 
     {
-      TrueAudio::File f(copy2.fileName().c_str());
+      TrueAudio::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)80734, f.length());
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
 
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+
+      f.seek(0x042C);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
+    }
+  }
+
+  void testStripTags1()
+  {
+    ScopedFileCopy copy("empty", ".tta");
+
+    ByteVector audioStream;
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(79538);
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)80734, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      f.strip(TrueAudio::File::ID3v1);
+      f.save();
+    }
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      f.strip(TrueAudio::File::ID3v2);
+      f.save();
+    }
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
+    }
+  }
+
+  void testStripTags2()
+  {
+    ScopedFileCopy copy("empty", ".tta");
+
+    ByteVector audioStream;
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(79538);
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)80734, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      f.strip(TrueAudio::File::ID3v2);
+      f.save();
+    }
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+
+      f.strip(TrueAudio::File::ID3v1);
+      f.save();
+    }
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(79538));
     }
   }
 

--- a/tests/test_trueaudio.cpp
+++ b/tests/test_trueaudio.cpp
@@ -1,7 +1,9 @@
-#include <cppunit/extensions/HelperMacros.h>
 #include <string>
 #include <stdio.h>
 #include <trueaudiofile.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
+#include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
 using namespace std;
@@ -11,6 +13,9 @@ class TestTrueAudio : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestTrueAudio);
   CPPUNIT_TEST(testReadPropertiesWithoutID3v2);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveID3v2Twice);
+  CPPUNIT_TEST(testSaveTagCombination);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -20,6 +25,117 @@ public:
     TrueAudio::File f(TEST_FILE_PATH_C("empty.tta"));
     CPPUNIT_ASSERT(f.audioProperties());
     CPPUNIT_ASSERT_EQUAL(3, f.audioProperties()->length());
+  }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("empty", ".tta");
+    ScopedFileCopy copy2("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+    }
+
+    {
+      TrueAudio::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79666, f.length());
+    }
+  }
+
+  void testSaveID3v2Twice()
+  {
+    ScopedFileCopy copy1("empty", ".tta");
+    ScopedFileCopy copy2("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)79538, f.length());
+
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+    }
+
+    {
+      TrueAudio::File f(copy2.fileName().c_str());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)80606, f.length());
+    }
+  }
+
+  void testSaveTagCombination()
+  {
+    ScopedFileCopy copy1("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+    }
+
+    {
+      TrueAudio::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)80734, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+    }
+
+    ScopedFileCopy copy2("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy2.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      f.ID3v2Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+    }
+
+    {
+      TrueAudio::File f(copy2.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)80734, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v2Tag()->title());
+    }
   }
 
 };


### PR DESCRIPTION
```TrueAudio::File``` doesn't corrupt a file when calling ```save()``` twice.
Added some tests.