### PR TITLE
Add tests calling WavPack::File::save() twice.

### DIFF
--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -149,61 +149,63 @@ bool WavPack::File::save()
   if(ID3v1Tag()) {
     if(d->hasID3v1) {
       seek(d->ID3v1Location);
-      writeBlock(ID3v1Tag()->render());
     }
     else {
       seek(0, End);
       d->ID3v1Location = tell();
-      writeBlock(ID3v1Tag()->render());
-      d->hasID3v1 = true;
     }
+
+    writeBlock(ID3v1Tag()->render());
+    d->hasID3v1 = true;
   }
   else {
     if(d->hasID3v1) {
       removeBlock(d->ID3v1Location, 128);
+
+      d->ID3v1Location = -1;
       d->hasID3v1 = false;
-      if(d->hasAPE) {
-        if(d->APELocation > d->ID3v1Location)
-          d->APELocation -= 128;
-      }
     }
   }
 
   // Update APE tag
 
   if(APETag()) {
-    if(d->hasAPE)
-      insert(APETag()->render(), d->APELocation, d->APESize);
-    else {
-      if(d->hasID3v1)  {
-        insert(APETag()->render(), d->ID3v1Location, 0);
-        d->APESize = APETag()->footer()->completeTagSize();
-        d->hasAPE = true;
+    if(!d->hasAPE) {
+      if(d->hasID3v1) {
         d->APELocation = d->ID3v1Location;
-        d->ID3v1Location += d->APESize;
       }
       else {
         seek(0, End);
         d->APELocation = tell();
-        writeBlock(APETag()->render());
-        d->APESize = APETag()->footer()->completeTagSize();
-        d->hasAPE = true;
       }
     }
+
+    insert(APETag()->render(), d->APELocation, d->APESize);
+
+    const long prevAPESize = d->APESize;
+    d->APESize = APETag()->footer()->completeTagSize();
+    d->hasAPE = true;
+
+    // v1 tag location has changed, update if it exists
+
+    if(d->ID3v1Location >= 0)
+      d->ID3v1Location += (d->APESize - prevAPESize);
   }
   else {
     if(d->hasAPE) {
       removeBlock(d->APELocation, d->APESize);
+
+      const long removedSize = d->APESize;
+      d->APELocation = -1;
+      d->APESize = 0;
       d->hasAPE = false;
-      if(d->hasID3v1) {
-        if(d->ID3v1Location > d->APELocation) {
-          d->ID3v1Location -= d->APESize;
-        }
-      }
+
+      if(d->ID3v1Location >= 0)
+        d->ID3v1Location -= removedSize;
     }
   }
 
-   return true;
+  return true;
 }
 
 ID3v1::Tag *WavPack::File::ID3v1Tag(bool create)

--- a/tests/test_wavpack.cpp
+++ b/tests/test_wavpack.cpp
@@ -54,15 +54,22 @@ public:
     ScopedFileCopy copy1("click", ".wv");
     ScopedFileCopy copy2("click", ".wv");
 
+    ByteVector audioStream;
     {
       WavPack::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)3176, f.length());
 
+      f.seek(0x0000);
+      audioStream = f.readBlock(3176);
+
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)3368, f.length());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
 
     {
@@ -72,6 +79,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT_EQUAL((long)3368, f.length());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
+
+      f.ID3v1Tag(true)->setTitle("");
+      f.save();
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
   }
 
@@ -80,15 +96,22 @@ public:
     ScopedFileCopy copy1("click", ".wv");
     ScopedFileCopy copy2("click", ".wv");
 
+    ByteVector audioStream;
     {
       WavPack::File f(copy1.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasAPETag());
       CPPUNIT_ASSERT_EQUAL((long)3176, f.length());
 
+      f.seek(0x0000);
+      audioStream = f.readBlock(3176);
+
       f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
       f.save();
       CPPUNIT_ASSERT(f.hasAPETag());
       CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
 
     {
@@ -98,6 +121,15 @@ public:
       f.save();
       CPPUNIT_ASSERT(f.hasAPETag());
       CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
+
+      f.APETag(true)->setTitle("");
+      f.save();
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
   }
 
@@ -105,8 +137,12 @@ public:
   {
     ScopedFileCopy copy("click", ".wv");
 
+    ByteVector audioStream;
     {
       WavPack::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(3176);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasAPETag());
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -129,6 +165,9 @@ public:
 
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.APETag()->title());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
   }
 
@@ -136,8 +175,12 @@ public:
   {
     ScopedFileCopy copy("click", ".wv");
 
+    ByteVector audioStream;
     {
       WavPack::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(3176);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasAPETag());
       f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -160,6 +203,9 @@ public:
 
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.APETag()->title());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
   }
 
@@ -167,8 +213,12 @@ public:
   {
     ScopedFileCopy copy("click", ".wv");
 
+    ByteVector audioStream;
     {
       WavPack::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(3176);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasAPETag());
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -205,6 +255,9 @@ public:
       CPPUNIT_ASSERT_EQUAL((long)3240, f.length());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasAPETag());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
   }
 
@@ -212,8 +265,12 @@ public:
   {
     ScopedFileCopy copy("click", ".wv");
 
+    ByteVector audioStream;
     {
       WavPack::File f(copy.fileName().c_str());
+      f.seek(0x0000);
+      audioStream = f.readBlock(3176);
+
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasAPETag());
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -250,6 +307,9 @@ public:
       CPPUNIT_ASSERT_EQUAL((long)3240, f.length());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasAPETag());
+
+      f.seek(0x0000);
+      CPPUNIT_ASSERT_EQUAL(audioStream, f.readBlock(3176));
     }
   }
 

--- a/tests/test_wavpack.cpp
+++ b/tests/test_wavpack.cpp
@@ -1,9 +1,11 @@
-#include <cppunit/extensions/HelperMacros.h>
 #include <string>
 #include <stdio.h>
 #include <tag.h>
 #include <tbytevectorlist.h>
 #include <wavpackfile.h>
+#include <apetag.h>
+#include <id3v1tag.h>
+#include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
 using namespace std;
@@ -14,6 +16,9 @@ class TestWavPack : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestWavPack);
   CPPUNIT_TEST(testBasic);
   CPPUNIT_TEST(testLengthScan);
+  CPPUNIT_TEST(testSaveID3v1Twice);
+  CPPUNIT_TEST(testSaveAPETwice);
+  CPPUNIT_TEST(testSaveTagCombination);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -40,6 +45,118 @@ public:
     WavPack::File f(TEST_FILE_PATH_C("infloop.wv"));
     CPPUNIT_ASSERT(f.isValid());
   }
+
+  void testSaveID3v1Twice()
+  {
+    ScopedFileCopy copy1("click", ".wv");
+    ScopedFileCopy copy2("click", ".wv");
+
+    {
+      WavPack::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3176, f.length());
+
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3368, f.length());
+    }
+
+    {
+      WavPack::File f(copy2.fileName().c_str());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3368, f.length());
+    }
+  }
+
+  void testSaveAPETwice()
+  {
+    ScopedFileCopy copy1("click", ".wv");
+    ScopedFileCopy copy2("click", ".wv");
+
+    {
+      WavPack::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)3176, f.length());
+
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+    }
+
+    {
+      WavPack::File f(copy2.fileName().c_str());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+      f.save();
+      CPPUNIT_ASSERT(f.hasAPETag());
+      CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+    }
+  }
+
+  void testSaveTagCombination()
+  {
+    ScopedFileCopy copy1("click", ".wv");
+
+    {
+      WavPack::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+    }
+
+    {
+      WavPack::File f(copy1.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3405, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.APETag()->title());
+    }
+
+    ScopedFileCopy copy2("click", ".wv");
+
+    {
+      WavPack::File f(copy2.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+    }
+
+    {
+      WavPack::File f(copy2.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3405, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.APETag()->title());
+    }
+  }
+
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestWavPack);

--- a/tests/test_wavpack.cpp
+++ b/tests/test_wavpack.cpp
@@ -18,7 +18,10 @@ class TestWavPack : public CppUnit::TestFixture
   CPPUNIT_TEST(testLengthScan);
   CPPUNIT_TEST(testSaveID3v1Twice);
   CPPUNIT_TEST(testSaveAPETwice);
-  CPPUNIT_TEST(testSaveTagCombination);
+  CPPUNIT_TEST(testSaveTags1);
+  CPPUNIT_TEST(testSaveTags2);
+  CPPUNIT_TEST(testStripTags1);
+  CPPUNIT_TEST(testStripTags2);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -98,12 +101,12 @@ public:
     }
   }
 
-  void testSaveTagCombination()
+  void testSaveTags1()
   {
-    ScopedFileCopy copy1("click", ".wv");
+    ScopedFileCopy copy("click", ".wv");
 
     {
-      WavPack::File f(copy1.fileName().c_str());
+      WavPack::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasAPETag());
       f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -119,7 +122,7 @@ public:
     }
 
     {
-      WavPack::File f(copy1.fileName().c_str());
+      WavPack::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)3405, f.length());
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasAPETag());
@@ -127,11 +130,14 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.APETag()->title());
     }
+  }
 
-    ScopedFileCopy copy2("click", ".wv");
+  void testSaveTags2()
+  {
+    ScopedFileCopy copy("click", ".wv");
 
     {
-      WavPack::File f(copy2.fileName().c_str());
+      WavPack::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT(!f.hasID3v1Tag());
       CPPUNIT_ASSERT(!f.hasAPETag());
       f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
@@ -147,13 +153,103 @@ public:
     }
 
     {
-      WavPack::File f(copy2.fileName().c_str());
+      WavPack::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT_EQUAL((long)3405, f.length());
       CPPUNIT_ASSERT(f.hasID3v1Tag());
       CPPUNIT_ASSERT(f.hasAPETag());
 
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.ID3v1Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("01234 56789 ABCDE FGHIJ"), f.APETag()->title());
+    }
+  }
+
+  void testStripTags1()
+  {
+    ScopedFileCopy copy("click", ".wv");
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3405, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+
+      f.strip(WavPack::File::ID3v1);
+      f.save();
+    }
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3277, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+
+      f.strip(WavPack::File::APE);
+      f.save();
+    }
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3240, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+    }
+  }
+
+  void testStripTags2()
+  {
+    ScopedFileCopy copy("click", ".wv");
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+      f.ID3v1Tag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+      f.APETag(true)->setTitle("01234 56789 ABCDE FGHIJ");
+      f.save();
+    }
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3405, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
+
+      f.strip(WavPack::File::APE);
+      f.save();
+    }
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3304, f.length());
+      CPPUNIT_ASSERT(f.hasID3v1Tag());
+      CPPUNIT_ASSERT(!f.hasAPETag());
+
+      f.strip(WavPack::File::ID3v1);
+      f.save();
+    }
+
+    {
+      WavPack::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL((long)3240, f.length());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+      CPPUNIT_ASSERT(f.hasAPETag());
     }
   }
 


### PR DESCRIPTION
```WavPack::File``` doesn't corrupt a file when calling ```save()``` twice.
Added some tests and removed some redundant code.