### PR TITLE
Remove some unused private function prototypes.

### DIFF
--- a/taglib/ape/apefile.h
+++ b/taglib/ape/apefile.h
@@ -216,7 +216,6 @@ namespace TagLib {
       File &operator=(const File &);
 
       void read(bool readProperties, Properties::ReadStyle propertiesStyle);
-      void scan();
       long findID3v1();
       long findAPE();
 

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -295,7 +295,6 @@ namespace TagLib {
       long findID3v2();
       long findID3v1();
       ByteVector xiphCommentData() const;
-      long findPaddingBreak(long nextPageOffset, long targetOffset, bool *isLast);
 
       class FilePrivate;
       FilePrivate *d;

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -53,7 +53,6 @@ public:
     ID3v2Location(-1),
     ID3v2Size(0),
     properties(0),
-    scanned(false),
     hasAPE(false),
     hasID3v1(false),
     hasID3v2(false) {}
@@ -76,7 +75,6 @@ public:
   TagUnion tag;
 
   Properties *properties;
-  bool scanned;
 
   // These indicate whether the file *on disk* has these tags, not if
   // this data structure does.  This is used in computing offsets.

--- a/taglib/mpc/mpcfile.h
+++ b/taglib/mpc/mpcfile.h
@@ -217,7 +217,6 @@ namespace TagLib {
       File &operator=(const File &);
 
       void read(bool readProperties, Properties::ReadStyle propertiesStyle);
-      void scan();
       long findAPE();
       long findID3v1();
       long findID3v2();

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -240,7 +240,6 @@ namespace TagLib {
       File &operator=(const File &);
 
       void read(bool readProperties, Properties::ReadStyle propertiesStyle);
-      void scan();
       long findID3v1();
       long findID3v2();
 

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -203,7 +203,6 @@ namespace TagLib {
       File &operator=(const File &);
 
       void read(bool readProperties, Properties::ReadStyle propertiesStyle);
-      void scan();
       long findID3v1();
       long findAPE();
 


### PR DESCRIPTION
Just a small refactoring. Removing private functions doesn't affect the ABI compatibility.