### PR TITLE
Add a method to check if an MP4 file on disk actually has a tag.

### DIFF
--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -118,7 +118,8 @@ namespace TagLib {
       bool save();
 
       /*!
-       * Returns whether or not the file on disk actually has an MP4 tag.
+       * Returns whether or not the file on disk actually has an MP4 tag, or the
+       * file has a Metadata Item List (ilst) atom.
        */
       bool hasMP4Tag() const;
 

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -117,6 +117,11 @@ namespace TagLib {
        */
       bool save();
 
+      /*!
+       * Returns whether or not the file on disk actually has an MP4 tag.
+       */
+      bool hasMP4Tag() const;
+
     private:
       void read(bool readProperties);
 

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -69,6 +69,10 @@ public:
     CPPUNIT_ASSERT(!f.isValid());
     MP4::File f2(TEST_FILE_PATH_C("has-tags.m4a"));
     CPPUNIT_ASSERT(f2.isValid());
+    CPPUNIT_ASSERT(f2.hasMP4Tag());
+    MP4::File f3(TEST_FILE_PATH_C("no-tags.m4a"));
+    CPPUNIT_ASSERT(f3.isValid());
+    CPPUNIT_ASSERT(!f3.hasMP4Tag());
   }
 
   void testIsEmpty()

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -19,6 +19,7 @@ class TestMP4 : public CppUnit::TestFixture
   CPPUNIT_TEST(testPropertiesALAC);
   CPPUNIT_TEST(testFreeForm);
   CPPUNIT_TEST(testCheckValid);
+  CPPUNIT_TEST(testHasTag);
   CPPUNIT_TEST(testIsEmpty);
   CPPUNIT_TEST(testUpdateStco);
   CPPUNIT_TEST(testSaveExisingWhenIlstIsLast);
@@ -67,12 +68,30 @@ public:
   {
     MP4::File f(TEST_FILE_PATH_C("empty.aiff"));
     CPPUNIT_ASSERT(!f.isValid());
-    MP4::File f2(TEST_FILE_PATH_C("has-tags.m4a"));
-    CPPUNIT_ASSERT(f2.isValid());
-    CPPUNIT_ASSERT(f2.hasMP4Tag());
-    MP4::File f3(TEST_FILE_PATH_C("no-tags.m4a"));
-    CPPUNIT_ASSERT(f3.isValid());
-    CPPUNIT_ASSERT(!f3.hasMP4Tag());
+  }
+
+  void testHasTag()
+  {
+    {
+      MP4::File f(TEST_FILE_PATH_C("has-tags.m4a"));
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.hasMP4Tag());
+    }
+
+    ScopedFileCopy copy("no-tags", ".m4a");
+
+    {
+      MP4::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasMP4Tag());
+      f.tag()->setTitle("TITLE");
+      f.save();
+    }
+    {
+      MP4::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.hasMP4Tag());
+    }
   }
 
   void testIsEmpty()


### PR DESCRIPTION
We can check if an MP4 file on disk actually has a tag. I was totally wrong in #252. Sorry @joelverhagen!