### PR TITLE
Fix mismatched file I/O buffer sizes.

### DIFF
--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -66,15 +66,6 @@
 
 using namespace TagLib;
 
-namespace
-{
-#ifdef _WIN32
-  const TagLib::uint BufferSize = 8192;
-#else
-  const TagLib::uint BufferSize = 1024;
-#endif
-}
-
 class File::FilePrivate
 {
 public:
@@ -499,7 +490,7 @@ bool File::isWritable(const char *file)
 
 TagLib::uint File::bufferSize()
 {
-  return BufferSize;
+  return 1024;
 }
 
 void File::setValid(bool valid)

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -45,7 +45,6 @@ namespace
   typedef FileName FileNameHandle;
   typedef HANDLE FileHandle;
 
-  const TagLib::uint BufferSize = 8192;
   const FileHandle InvalidFileHandle = INVALID_HANDLE_VALUE;
 
   inline FileHandle openFile(const FileName &path, bool readOnly)
@@ -93,7 +92,6 @@ namespace
 
   typedef FILE* FileHandle;
 
-  const TagLib::uint BufferSize = 8192;
   const FileHandle InvalidFileHandle = 0;
 
   inline FileHandle openFile(const FileName &path, bool readOnly)
@@ -497,5 +495,5 @@ void FileStream::truncate(long length)
 
 TagLib::uint FileStream::bufferSize()
 {
-  return BufferSize;
+  return 1024;
 }


### PR DESCRIPTION
Mismatched buffer size between ```File``` and ```FileStream``` sometimes may cause useless memory reallocation.
Additionally, I realized that different buffer size between Linux and Windows doesn't help improve the performance.