### PR TITLE
Avoid overwriting the audio stream when adding an ID3v1 tag to a FLAC…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,7 @@ TagLib 1.10 (??? ??, 2015)
  * New API for the audio length in milliseconds.
  * Marked FLAC::File::streamInfoData() deprecated. It returns an empty ByteVector.
  * Marked FLAC::File::streamLength() deprecated. It returns zero.
+ * Fixed possible file corruptions when adding an ID3v1 tag to FLAC files.
  * Many smaller bug fixes and performance improvements.
 
 TagLib 1.9.1 (Oct 8, 2013)

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -258,8 +258,16 @@ bool FLAC::File::save()
   }
 
   if(ID3v1Tag()) {
-    seek(-128, End);
+    if(d->hasID3v1) {
+      seek(d->ID3v1Location);
+    }
+    else {
+      seek(0, End);
+      d->ID3v1Location = tell();
+    }
+
     writeBlock(ID3v1Tag()->render());
+    d->hasID3v1 = true;
   }
 
   return true;


### PR DESCRIPTION
… file.

```FLAC::File``` overwrites the last 128 bytes of the audio stream when creating an ID3v1 tag.
Actually, this is part of #600, but I think it's an urgent bug, so I created a small PR to make it able to be reviewed and merged quickly.  