### PR TITLE
Remove an useless function call.

### DIFF
--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -281,8 +281,6 @@ void MPC::File::read(bool readProperties, Properties::ReadStyle /* propertiesSty
 
   // Look for an APE tag
 
-  findAPE();
-
   d->APELocation = findAPE();
 
   if(d->APELocation >= 0) {


### PR DESCRIPTION
Just a small refactoring. That's definitely useless since ```MPC::File::findAPE()``` doesn't touch any internal data members.