### PR TITLE
Skip duplicate ID3v2 tags and treat them as an extra blank of the first one.

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -446,23 +446,8 @@ long MPEG::File::firstFrameOffset()
 {
   long position = 0;
 
-  if(hasID3v2Tag()) {
+  if(hasID3v2Tag())
     position = d->ID3v2Location + ID3v2Tag()->header()->completeTagSize();
-
-    // Skip duplicate ID3v2 tags.
-
-    // Workaround for some faulty files that have duplicate ID3v2 tags.
-    // Combination of EAC and LAME creates such files when configured incorrectly.
-
-    long location;
-    while((location = findID3v2(position)) >= 0) {
-      seek(location);
-      const ID3v2::Header header(readBlock(ID3v2::Header::size()));
-      position = location + header.completeTagSize();
-
-      debug("MPEG::File::firstFrameOffset() - Duplicate ID3v2 tag found.");
-    }
-  }
 
   return nextFrameOffset(position);
 }

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -390,7 +390,7 @@ namespace TagLib {
       File &operator=(const File &);
 
       void read(bool readProperties);
-      long findID3v2(long offset);
+      long findID3v2();
       long findID3v1();
       void findAPE();
 

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -93,6 +93,7 @@ class TestID3v2 : public CppUnit::TestFixture
   CPPUNIT_TEST(testRenderTableOfContentsFrame);
   CPPUNIT_TEST(testShrinkPadding);
   CPPUNIT_TEST(testEmptyFrame);
+  CPPUNIT_TEST(testDuplicateTags);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -1114,6 +1115,41 @@ public:
       ID3v2::Tag *tag = f.ID3v2Tag();
       CPPUNIT_ASSERT_EQUAL(String("Title"), tag->title());
       CPPUNIT_ASSERT_EQUAL(true, tag->frameListMap()["WOAF"].isEmpty());
+    }
+  }
+
+  void testDuplicateTags()
+  {
+    ScopedFileCopy copy("duplicate_id3v2", ".mp3");
+
+    ByteVector audioStream;
+    {
+      MPEG::File f(copy.fileName().c_str());
+      f.seek(f.ID3v2Tag()->header()->completeTagSize());
+      audioStream = f.readBlock(2089);
+
+      // duplicate_id3v2.mp3 has duplicate ID3v2 tags.
+      // Sample rate will be 32000 if we can't skip the second tag.
+
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((TagLib::uint)8049, f.ID3v2Tag()->header()->completeTagSize());
+
+      CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
+
+      f.ID3v2Tag()->setArtist("Artist A");
+      f.save(MPEG::File::ID3v2, true);
+    }
+    {
+      MPEG::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT_EQUAL((long)3594, f.length());
+      CPPUNIT_ASSERT_EQUAL((TagLib::uint)1505, f.ID3v2Tag()->header()->completeTagSize());
+      CPPUNIT_ASSERT_EQUAL(String("Artist A"), f.ID3v2Tag()->artist());
+      CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
+
+      f.seek(f.ID3v2Tag()->header()->completeTagSize());
+      CPPUNIT_ASSERT_EQUAL(f.readBlock(2089), audioStream);
+
     }
   }
 


### PR DESCRIPTION
(same as #616, sorry for re-creating this one.)

This moves the code I added at #454 from ```MPEG::File``` to ```MPEG::ID3v2::Tag``` because of these points:

* Enable other File classes to treat duplicate ID3v2 tags properly.
* Enable ```MPEG::ID3v2::Tag``` to erase duplicate tags.

Additionally, it will help me fix some of the bugs I reported in #606.