### PR TITLE
(minor, comment only) Add a supplementary comment to ByteVector::checksum().

### DIFF
--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -275,7 +275,10 @@ namespace TagLib {
 
     /*!
      * Returns a CRC checksum of the byte vector's data.
+     *
+     * \note This uses an uncommon variant of CRC32 specializes in Ogg.
      */
+    // BIC: Remove or make generic.
     uint checksum() const;
 
     /*!


### PR DESCRIPTION
Related to #615. Add a comment that ```ByteVector::checksum()``` is not generic.