### PR TITLE
Solaris Studio 12.4 compile error: removed use of const key type for Map - key type must be CopyAssignable

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -349,7 +349,7 @@ ByteVector APE::Tag::render() const
   uint itemCount = 0;
 
   {
-    for(Map<const String, Item>::ConstIterator it = d->itemListMap.begin();
+    for(Map<String, Item>::ConstIterator it = d->itemListMap.begin();
         it != d->itemListMap.end(); ++it)
     {
       data.append(it->second.render());

--- a/taglib/ape/apetag.h
+++ b/taglib/ape/apetag.h
@@ -49,7 +49,7 @@ namespace TagLib {
      *
      * \see APE::Tag::itemListMap()
      */
-    typedef Map<const String, Item> ItemListMap;
+    typedef Map<String, Item> ItemListMap;
 
 
     //! An APE tag implementation


### PR DESCRIPTION
This pull request fixes an issue compiling on Solaris Studio 12.4 by removing const in Map's key type.

From section 23.2.4.7 of the current C++ draft:

" The associative containers meet all the requirements of Allocator-aware containers (23.2.1), except that for map and multimap, the requirements placed on value_type in Table 96 apply instead to key_type and mapped_type. [Note: For example, in some cases key_type and mapped_type are required to be CopyAssignable even though the associated value_type, pair<const key_type, mapped_type>, is not CopyAssignable. —endnote]"