### PR TITLE
return const correct reverse iterator for newer Sun compiler

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -746,6 +746,7 @@ ByteVector::ReverseIterator ByteVector::rbegin()
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
+  // we need a const reference to the data vector so we can ensure the const version of rbegin() is called
   const std::vector<char> &v = d->data->data;
   return v.rbegin() + (v.size() - (d->offset + d->length));
 }
@@ -758,6 +759,7 @@ ByteVector::ReverseIterator ByteVector::rend()
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
+  // we need a const reference to the data vector so we can ensure the const version of rbegin() is called
   const std::vector<char> &v = d->data->data;
   return v.rbegin() + (v.size() - d->offset);
 }

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -746,7 +746,11 @@ ByteVector::ReverseIterator ByteVector::rbegin()
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
+#if __SUNPRO_CC >= 0x5130
   return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length)))));
+#else
+  return d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length));
+#endif
 }
 
 ByteVector::ReverseIterator ByteVector::rend()
@@ -757,7 +761,11 @@ ByteVector::ReverseIterator ByteVector::rend()
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
+#if __SUNPRO_CC >= 0x5130
   return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - d->offset))));
+#else
+  return d->data->data.rbegin() + (d->data->data.size() - d->offset);
+#endif
 }
 
 bool ByteVector::isNull() const

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -746,7 +746,7 @@ ByteVector::ReverseIterator ByteVector::rbegin()
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
-  return d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length));
+  return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length)))));
 }
 
 ByteVector::ReverseIterator ByteVector::rend()
@@ -757,7 +757,7 @@ ByteVector::ReverseIterator ByteVector::rend()
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
-  return d->data->data.rbegin() + (d->data->data.size() - d->offset);
+  return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - d->offset))));
 }
 
 bool ByteVector::isNull() const

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -746,7 +746,7 @@ ByteVector::ReverseIterator ByteVector::rbegin()
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
-#if __SUNPRO_CC >= 0x5130
+#if defined(__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
   return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length)))));
 #else
   return d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length));
@@ -761,7 +761,7 @@ ByteVector::ReverseIterator ByteVector::rend()
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
-#if __SUNPRO_CC >= 0x5130
+#if defined(__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
   return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - d->offset))));
 #else
   return d->data->data.rbegin() + (d->data->data.size() - d->offset);

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -746,11 +746,8 @@ ByteVector::ReverseIterator ByteVector::rbegin()
 
 ByteVector::ConstReverseIterator ByteVector::rbegin() const
 {
-#if defined(__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
-  return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length)))));
-#else
-  return d->data->data.rbegin() + (d->data->data.size() - (d->offset + d->length));
-#endif
+  const std::vector<char> &v = d->data->data;
+  return v.rbegin() + (v.size() - (d->offset + d->length));
 }
 
 ByteVector::ReverseIterator ByteVector::rend()
@@ -761,11 +758,8 @@ ByteVector::ReverseIterator ByteVector::rend()
 
 ByteVector::ConstReverseIterator ByteVector::rend() const
 {
-#if defined(__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130)
-  return ConstReverseIterator(static_cast<const char*>(&*(d->data->data.rbegin() + (d->data->data.size() - d->offset))));
-#else
-  return d->data->data.rbegin() + (d->data->data.size() - d->offset);
-#endif
+  const std::vector<char> &v = d->data->data;
+  return v.rbegin() + (v.size() - d->offset);
 }
 
 bool ByteVector::isNull() const


### PR DESCRIPTION
The Solaris Studio 12.4 compiler chokes on const conversion for ByteVector::rbegin() and ByteVector::rend() with the following errors:

"taglib/toolkit/tbytevector.cpp", line 749: Error: Cannot return std::reverse_iterator<char*, std::random_access_iterator_tag, char, char&, char*, int> from a function that should return std::reverse_iterator<const char*, std::random_access_iterator_tag, char, const char&, const char*, int>.
"taglib/toolkit/tbytevector.cpp", line 760: Error: Cannot return std::reverse_iterator<char*, std::random_access_iterator_tag, char, char&, char*, int> from a function that should return std::reverse_iterator<const char*, std::random_access_iterator_tag, char, const char&, const char*, int>.

The following patch corrects the constness of the reverse iterators to help Solaris Studio out
