### PR TITLE
check SUNPRO_CC version before using Map workaround

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -23,7 +23,7 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#ifdef __SUNPRO_CC
+#if __SUNPRO_CC < 0x5130
 // Sun Studio finds multiple specializations of Map because
 // it considers specializations with and without class types
 // to be different; this define forces Map to use only the

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -23,7 +23,7 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#if __SUNPRO_CC < 0x5130
+#if defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5130)
 // Sun Studio finds multiple specializations of Map because
 // it considers specializations with and without class types
 // to be different; this define forces Map to use only the


### PR DESCRIPTION
The workaround for the old Solaris Studio compiler causes compilation errors on the newer version