### PR TITLE
CMake check for vsprintf_s/vsnprintf rather than sprintf_s/snprintf.

### DIFF
--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -209,22 +209,22 @@ check_cxx_source_compiles("
   int main() {
     char buf[20];
     va_list args;
-    vsprintf_s(buf, \"%d\", args);
+    vsnprintf(buf, 20, \"%d\", args);
     return 0;
   }
-" HAVE_VSPRINTF_S)
+" HAVE_VSNPRINTF)
 
-if(NOT HAVE_VSPRINTF_S)
+if(NOT HAVE_VSNPRINTF)
   check_cxx_source_compiles("
     #include <cstdio>
     #include <cstdarg>
     int main() {
       char buf[20];
       va_list args;
-      vsnprintf(buf, 20, \"%d\", args);
+      vsprintf_s(buf, \"%d\", args);
       return 0;
     }
-  " HAVE_VSNPRINTF)
+  " HAVE_VSPRINTF_S)
 endif()
 
 # Check for libz using the cmake supplied FindZLIB.cmake

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -201,26 +201,30 @@ if(NOT HAVE_GCC_BYTESWAP_16 OR NOT HAVE_GCC_BYTESWAP_32 OR NOT HAVE_GCC_BYTESWAP
   endif()
 endif()
 
-# Determine whether your compiler supports some safer version of sprintf.
+# Determine whether your compiler supports some safer version of vsprintf.
 
 check_cxx_source_compiles("
   #include <cstdio>
+  #include <cstdarg>
   int main() {
     char buf[20];
-    snprintf(buf, 20, \"%d\", 1);
+    va_list args;
+    vsprintf_s(buf, \"%d\", args);
     return 0;
   }
-" HAVE_SNPRINTF)
+" HAVE_VSPRINTF_S)
 
-if(NOT HAVE_SNPRINTF)
+if(NOT HAVE_VSPRINTF_S)
   check_cxx_source_compiles("
     #include <cstdio>
+    #include <cstdarg>
     int main() {
       char buf[20];
-      sprintf_s(buf, \"%d\", 1);
+      va_list args;
+      vsnprintf(buf, 20, \"%d\", args);
       return 0;
     }
-  " HAVE_SPRINTF_S)
+  " HAVE_VSNPRINTF)
 endif()
 
 # Check for libz using the cmake supplied FindZLIB.cmake

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -25,9 +25,9 @@
 #cmakedefine   HAVE_WIN_ATOMIC 1
 #cmakedefine   HAVE_IA64_ATOMIC 1
 
-/* Defined if your compiler supports some safer version of sprintf */
-#cmakedefine   HAVE_SNPRINTF 1
-#cmakedefine   HAVE_SPRINTF_S 1
+/* Defined if your compiler supports some safer version of vsprintf */
+#cmakedefine   HAVE_VSNPRINTF 1
+#cmakedefine   HAVE_VSPRINTF_S 1
 
 /* Defined if you have libz */
 #cmakedefine   HAVE_ZLIB 1

--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -177,11 +177,11 @@ namespace TagLib
       char buf[BufferSize];
       int length;
 
-#if defined(HAVE_SNPRINTF)
+#if defined(HAVE_VSNPRINTF)
 
       length = vsnprintf(buf, BufferSize, format, args);
 
-#elif defined(HAVE_SPRINTF_S)
+#elif defined(HAVE_VSPRINTF_S)
 
       length = vsprintf_s(buf, format, args);
 


### PR DESCRIPTION
I become aware of the fact that some systems lacks ```vsnprintf``` despite that they have ```snprintf```.
So I'd like to change the CMake tests to check ```vsnprintf``` directly rather than ```snprintf```.