### PR TITLE
Use volatile for TestFloatFormat

### DIFF
--- a/cmake/TestFloatFormat.c
+++ b/cmake/TestFloatFormat.c
@@ -2,16 +2,14 @@ int main(int argc, char **argv)
 {
   int ret = 0;
 
-  double bin1[] = {
+  volatile double bin1[] = {
     // "*TAGLIB*" encoded as a little-endian floating-point number
     (double)3.9865557444897601e-105, (double)0.0
   };
-  float bin2[] = {
+  volatile float bin2[] = {
     // "*TL*" encoded as a little-endian floating-point number
     (float)1.81480400e-013, (float)0.0
   };
-  ret += ((int*)bin1)[argc];
-  ret += ((int*)bin2)[argc];
-
+  ret += (int)(bin1[1]+bin2[1]);
   return ret;
 }


### PR DESCRIPTION
Just use `volatile` and it won't be optimized away. Current code will compile incorrectly on GCC 5.x and 6.0 with O2/O3 because of different pointer type typecast, see [GCC bug 67090](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67090) 

Tested PR with Clang 3.6.2, GCC 5.2 and 6.0, it compiles correctly with max optimizations.
