### PR TITLE
Fix segfaults when calling File::properties() after strip().

### DIFF
--- a/taglib/ape/apefile.cpp
+++ b/taglib/ape/apefile.cpp
@@ -125,26 +125,20 @@ TagLib::Tag *APE::File::tag() const
 
 PropertyMap APE::File::properties() const
 {
-  if(d->hasAPE)
-    return d->tag.access<APE::Tag>(ApeAPEIndex, false)->properties();
-  if(d->hasID3v1)
-    return d->tag.access<ID3v1::Tag>(ApeID3v1Index, false)->properties();
-  return PropertyMap();
+  return d->tag.properties();
 }
 
 void APE::File::removeUnsupportedProperties(const StringList &properties)
 {
-  if(d->hasAPE)
-    d->tag.access<APE::Tag>(ApeAPEIndex, false)->removeUnsupportedProperties(properties);
-  if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(ApeID3v1Index, false)->removeUnsupportedProperties(properties);
+  d->tag.removeUnsupportedProperties(properties);
 }
 
 PropertyMap APE::File::setProperties(const PropertyMap &properties)
 {
-  if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(ApeID3v1Index, false)->setProperties(properties);
-  return d->tag.access<APE::Tag>(ApeAPEIndex, true)->setProperties(properties);
+  if(ID3v1Tag())
+    ID3v1Tag()->setProperties(properties);
+
+  return APETag(true)->setProperties(properties);
 }
 
 APE::Properties *APE::File::audioProperties() const

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -141,30 +141,17 @@ TagLib::Tag *FLAC::File::tag() const
 
 PropertyMap FLAC::File::properties() const
 {
-  // once Tag::properties() is virtual, this case distinction could actually be done
-  // within TagUnion.
-  if(d->hasXiphComment)
-    return d->tag.access<Ogg::XiphComment>(FlacXiphIndex, false)->properties();
-  if(d->hasID3v2)
-    return d->tag.access<ID3v2::Tag>(FlacID3v2Index, false)->properties();
-  if(d->hasID3v1)
-    return d->tag.access<ID3v1::Tag>(FlacID3v1Index, false)->properties();
-  return PropertyMap();
+  return d->tag.properties();
 }
 
 void FLAC::File::removeUnsupportedProperties(const StringList &unsupported)
 {
-  if(d->hasXiphComment)
-    d->tag.access<Ogg::XiphComment>(FlacXiphIndex, false)->removeUnsupportedProperties(unsupported);
-  if(d->hasID3v2)
-    d->tag.access<ID3v2::Tag>(FlacID3v2Index, false)->removeUnsupportedProperties(unsupported);
-  if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(FlacID3v1Index, false)->removeUnsupportedProperties(unsupported);
+  d->tag.removeUnsupportedProperties(unsupported);
 }
 
 PropertyMap FLAC::File::setProperties(const PropertyMap &properties)
 {
-  return d->tag.access<Ogg::XiphComment>(FlacXiphIndex, true)->setProperties(properties);
+  return xiphComment(true)->setProperties(properties);
 }
 
 FLAC::Properties *FLAC::File::audioProperties() const

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -116,26 +116,20 @@ TagLib::Tag *MPC::File::tag() const
 
 PropertyMap MPC::File::properties() const
 {
-  if(d->hasAPE)
-    return d->tag.access<APE::Tag>(MPCAPEIndex, false)->properties();
-  if(d->hasID3v1)
-    return d->tag.access<ID3v1::Tag>(MPCID3v1Index, false)->properties();
-  return PropertyMap();
+  return d->tag.properties();
 }
 
 void MPC::File::removeUnsupportedProperties(const StringList &properties)
 {
-  if(d->hasAPE)
-    d->tag.access<APE::Tag>(MPCAPEIndex, false)->removeUnsupportedProperties(properties);
-  if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(MPCID3v1Index, false)->removeUnsupportedProperties(properties);
+  d->tag.removeUnsupportedProperties(properties);
 }
 
 PropertyMap MPC::File::setProperties(const PropertyMap &properties)
 {
-  if(d->hasID3v1)
-    d->tag.access<APE::Tag>(MPCID3v1Index, false)->setProperties(properties);
-  return d->tag.access<APE::Tag>(MPCAPEIndex, true)->setProperties(properties);
+  if(ID3v1Tag())
+    ID3v1Tag()->setProperties(properties);
+
+  return APETag(true)->setProperties(properties);
 }
 
 MPC::Properties *MPC::File::audioProperties() const

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -149,33 +149,22 @@ TagLib::Tag *MPEG::File::tag() const
 
 PropertyMap MPEG::File::properties() const
 {
-  // once Tag::properties() is virtual, this case distinction could actually be done
-  // within TagUnion.
-  if(d->hasID3v2)
-    return d->tag.access<ID3v2::Tag>(ID3v2Index, false)->properties();
-  if(d->hasAPE)
-    return d->tag.access<APE::Tag>(APEIndex, false)->properties();
-  if(d->hasID3v1)
-    return d->tag.access<ID3v1::Tag>(ID3v1Index, false)->properties();
-  return PropertyMap();
+  return d->tag.properties();
 }
 
 void MPEG::File::removeUnsupportedProperties(const StringList &properties)
 {
-  if(d->hasID3v2)
-    d->tag.access<ID3v2::Tag>(ID3v2Index, false)->removeUnsupportedProperties(properties);
-  else if(d->hasAPE)
-    d->tag.access<APE::Tag>(APEIndex, false)->removeUnsupportedProperties(properties);
-  else if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(ID3v1Index, false)->removeUnsupportedProperties(properties);
+  d->tag.removeUnsupportedProperties(properties);
 }
 
 PropertyMap MPEG::File::setProperties(const PropertyMap &properties)
 {
-  if(d->hasID3v1)
-    // update ID3v1 tag if it exists, but ignore the return value
-    d->tag.access<ID3v1::Tag>(ID3v1Index, false)->setProperties(properties);
-  return d->tag.access<ID3v2::Tag>(ID3v2Index, true)->setProperties(properties);
+  // update ID3v1 tag if it exists, but ignore the return value
+
+  if(ID3v1Tag())
+    ID3v1Tag()->setProperties(properties);
+
+  return ID3v2Tag(true)->setProperties(properties);
 }
 
 MPEG::Properties *MPEG::File::audioProperties() const

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -45,11 +45,8 @@ class RIFF::WAV::File::FilePrivate
 public:
   FilePrivate() :
     properties(0),
-    tagChunkID("ID3 "),
     hasID3v2(false),
-    hasInfo(false)
-  {
-  }
+    hasInfo(false) {}
 
   ~FilePrivate()
   {
@@ -57,9 +54,6 @@ public:
   }
 
   Properties *properties;
-
-  ByteVector tagChunkID;
-
   TagUnion tag;
 
   bool hasID3v2;
@@ -162,7 +156,7 @@ bool RIFF::WAV::File::save(TagTypes tags, bool stripOthers, int id3v2Version)
     removeTagChunks(ID3v2);
 
     if(ID3v2Tag() && !ID3v2Tag()->isEmpty()) {
-      setChunkData(d->tagChunkID, ID3v2Tag()->render(id3v2Version));
+      setChunkData("ID3 ", ID3v2Tag()->render(id3v2Version));
       d->hasID3v2 = true;
     }
   }
@@ -199,7 +193,6 @@ void RIFF::WAV::File::read(bool readProperties)
     const ByteVector name = chunkName(i);
     if(name == "ID3 " || name == "id3 ") {
       if(!d->tag[ID3v2Index]) {
-        d->tagChunkID = name;
         d->tag.set(ID3v2Index, new ID3v2::Tag(this, chunkOffset(i)));
         d->hasID3v2 = true;
       }

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -106,6 +106,17 @@ RIFF::Info::Tag *RIFF::WAV::File::InfoTag() const
   return d->tag.access<RIFF::Info::Tag>(InfoIndex, false);
 }
 
+void RIFF::WAV::File::strip(TagTypes tags)
+{
+  removeTagChunks(tags);
+
+  if(tags & ID3v2)
+    d->tag.set(ID3v2Index, new ID3v2::Tag());
+
+  if(tags & Info)
+    d->tag.set(InfoIndex, new RIFF::Info::Tag());
+}
+
 PropertyMap RIFF::WAV::File::properties() const
 {
   return tag()->properties();
@@ -146,28 +157,20 @@ bool RIFF::WAV::File::save(TagTypes tags, bool stripOthers, int id3v2Version)
   if(stripOthers)
     strip(static_cast<TagTypes>(AllTags & ~tags));
 
-  const ID3v2::Tag *id3v2tag = d->tag.access<ID3v2::Tag>(ID3v2Index, false);
   if(tags & ID3v2) {
-    if(d->hasID3v2) {
-      removeChunk(d->tagChunkID);
-      d->hasID3v2 = false;
-    }
+    removeTagChunks(ID3v2);
 
-    if(!id3v2tag->isEmpty()) {
-      setChunkData(d->tagChunkID, id3v2tag->render(id3v2Version));
+    if(ID3v2Tag() && !ID3v2Tag()->isEmpty()) {
+      setChunkData(d->tagChunkID, ID3v2Tag()->render(id3v2Version));
       d->hasID3v2 = true;
     }
   }
 
-  const Info::Tag *infotag = d->tag.access<Info::Tag>(InfoIndex, false);
   if(tags & Info) {
-    if(d->hasInfo) {
-      removeChunk(findInfoTagChunk());
-      d->hasInfo = false;
-    }
+    removeTagChunks(Info);
 
-    if(!infotag->isEmpty()) {
-      setChunkData("LIST", infotag->render(), true);
+    if(InfoTag() && !InfoTag()->isEmpty()) {
+      setChunkData("LIST", InfoTag()->render(), true);
       d->hasInfo = true;
     }
   }
@@ -227,29 +230,21 @@ void RIFF::WAV::File::read(bool readProperties)
     d->properties = new Properties(this, Properties::Average);
 }
 
-void RIFF::WAV::File::strip(TagTypes tags)
+void RIFF::WAV::File::removeTagChunks(TagTypes tags)
 {
-  if(tags & ID3v2) {
-    removeChunk(d->tagChunkID);
+  if((tags & ID3v2) && d->hasID3v2) {
+    removeChunk("ID3 ");
+    removeChunk("id3 ");
+
     d->hasID3v2 = false;
   }
 
-  if(tags & Info){
-    TagLib::uint chunkId = findInfoTagChunk();
-    if(chunkId != TagLib::uint(-1)) {
-      removeChunk(chunkId);
-      d->hasInfo = false;
+  if((tags & Info) && d->hasInfo) {
+    for(int i = static_cast<int>(chunkCount()) - 1; i >= 0; --i) {
+      if(chunkName(i) == "LIST" && chunkData(i).startsWith("INFO"))
+        removeChunk(i);
     }
-  }
-}
 
-TagLib::uint RIFF::WAV::File::findInfoTagChunk()
-{
-  for(uint i = 0; i < chunkCount(); ++i) {
-    if(chunkName(i) == "LIST" && chunkData(i).startsWith("INFO")) {
-      return i;
-    }
+    d->hasInfo = false;
   }
-
-  return TagLib::uint(-1);
 }

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -119,17 +119,18 @@ void RIFF::WAV::File::strip(TagTypes tags)
 
 PropertyMap RIFF::WAV::File::properties() const
 {
-  return tag()->properties();
+  return d->tag.properties();
 }
 
 void RIFF::WAV::File::removeUnsupportedProperties(const StringList &unsupported)
 {
-  tag()->removeUnsupportedProperties(unsupported);
+  d->tag.removeUnsupportedProperties(unsupported);
 }
 
 PropertyMap RIFF::WAV::File::setProperties(const PropertyMap &properties)
 {
-  return tag()->setProperties(properties);
+  InfoTag()->setProperties(properties);
+  return ID3v2Tag()->setProperties(properties);
 }
 
 RIFF::WAV::Properties *RIFF::WAV::File::audioProperties() const

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -126,6 +126,15 @@ namespace TagLib {
         Info::Tag *InfoTag() const;
 
         /*!
+         * This will strip the tags that match the OR-ed together TagTypes from the
+         * file.  By default it strips all tags.  It returns true if the tags are
+         * successfully stripped.
+         *
+         * \note This will update the file immediately.
+         */
+        void strip(TagTypes tags = AllTags);
+
+        /*!
          * Implements the unified property interface -- export function.
          * This method forwards to ID3v2::Tag::properties().
          */
@@ -171,13 +180,7 @@ namespace TagLib {
         File &operator=(const File &);
 
         void read(bool readProperties);
-
-        void strip(TagTypes tags);
-
-        /*!
-         * Returns the index of the chunk that its name is "LIST" and list type is "INFO".
-         */
-        uint findInfoTagChunk();
+        void removeTagChunks(TagTypes tags);
 
         friend class Properties;
 

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -23,8 +23,15 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#include "tagunion.h"
-#include "tstringlist.h"
+#include <tagunion.h>
+#include <tstringlist.h>
+#include <tpropertymap.h>
+
+#include "id3v1tag.h"
+#include "id3v2tag.h"
+#include "apetag.h"
+#include "xiphcomment.h"
+#include "infotag.h"
 
 using namespace TagLib;
 
@@ -100,6 +107,62 @@ void TagUnion::set(int index, Tag *tag)
 {
   delete d->tags[index];
   d->tags[index] = tag;
+}
+
+PropertyMap TagUnion::properties() const
+{
+  // This is an ugly workaround but we can't add a virtual function.
+  // Should be virtual in taglib2.
+
+  for(size_t i = 0; i < 3; ++i) {
+
+    if(d->tags[i] && !d->tags[i]->isEmpty()) {
+
+      if(dynamic_cast<const ID3v1::Tag *>(d->tags[i]))
+        return dynamic_cast<const ID3v1::Tag *>(d->tags[i])->properties();
+
+      else if(dynamic_cast<const ID3v2::Tag *>(d->tags[i]))
+        return dynamic_cast<const ID3v2::Tag *>(d->tags[i])->properties();
+
+      else if(dynamic_cast<const APE::Tag *>(d->tags[i]))
+        return dynamic_cast<const APE::Tag *>(d->tags[i])->properties();
+
+      else if(dynamic_cast<const Ogg::XiphComment *>(d->tags[i]))
+        return dynamic_cast<const Ogg::XiphComment *>(d->tags[i])->properties();
+
+      else if(dynamic_cast<const RIFF::Info::Tag *>(d->tags[i]))
+        return dynamic_cast<const RIFF::Info::Tag *>(d->tags[i])->properties();
+    }
+  }
+
+  return PropertyMap();
+}
+
+void TagUnion::removeUnsupportedProperties(const StringList &unsupported)
+{
+  // This is an ugly workaround but we can't add a virtual function.
+  // Should be virtual in taglib2.
+
+  for(size_t i = 0; i < 3; ++i) {
+
+    if(d->tags[i]) {
+
+      if(dynamic_cast<ID3v1::Tag *>(d->tags[i]))
+        dynamic_cast<ID3v1::Tag *>(d->tags[i])->removeUnsupportedProperties(unsupported);
+
+      else if(dynamic_cast<ID3v2::Tag *>(d->tags[i]))
+        dynamic_cast<ID3v2::Tag *>(d->tags[i])->removeUnsupportedProperties(unsupported);
+
+      else if(dynamic_cast<APE::Tag *>(d->tags[i]))
+        dynamic_cast<APE::Tag *>(d->tags[i])->removeUnsupportedProperties(unsupported);
+
+      else if(dynamic_cast<Ogg::XiphComment *>(d->tags[i]))
+        dynamic_cast<Ogg::XiphComment *>(d->tags[i])->removeUnsupportedProperties(unsupported);
+
+      else if(dynamic_cast<RIFF::Info::Tag *>(d->tags[i]))
+        dynamic_cast<RIFF::Info::Tag *>(d->tags[i])->removeUnsupportedProperties(unsupported);
+    }
+  }
 }
 
 String TagUnion::title() const

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -56,6 +56,9 @@ namespace TagLib {
 
     void set(int index, Tag *tag);
 
+    PropertyMap properties() const;
+    void removeUnsupportedProperties(const StringList &unsupported);
+
     virtual String title() const;
     virtual String artist() const;
     virtual String album() const;

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -130,26 +130,20 @@ TagLib::Tag *TrueAudio::File::tag() const
 
 PropertyMap TrueAudio::File::properties() const
 {
-  // once Tag::properties() is virtual, this case distinction could actually be done
-  // within TagUnion.
-  if(d->hasID3v2)
-    return d->tag.access<ID3v2::Tag>(TrueAudioID3v2Index, false)->properties();
-  if(d->hasID3v1)
-    return d->tag.access<ID3v1::Tag>(TrueAudioID3v1Index, false)->properties();
-  return PropertyMap();
+  return d->tag.properties();
 }
 
 void TrueAudio::File::removeUnsupportedProperties(const StringList &unsupported)
 {
-  if(d->hasID3v2)
-    d->tag.access<ID3v2::Tag>(TrueAudioID3v2Index, false)->removeUnsupportedProperties(unsupported);
+  d->tag.removeUnsupportedProperties(unsupported);
 }
 
 PropertyMap TrueAudio::File::setProperties(const PropertyMap &properties)
 {
-  if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(TrueAudioID3v1Index, false)->setProperties(properties);
-  return d->tag.access<ID3v2::Tag>(TrueAudioID3v2Index, true)->setProperties(properties);
+  if(ID3v1Tag())
+    ID3v1Tag()->setProperties(properties);
+
+  return ID3v2Tag(true)->setProperties(properties);
 }
 
 TrueAudio::Properties *TrueAudio::File::audioProperties() const

--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -110,26 +110,20 @@ TagLib::Tag *WavPack::File::tag() const
 
 PropertyMap WavPack::File::properties() const
 {
-  if(d->hasAPE)
-    return d->tag.access<APE::Tag>(WavAPEIndex, false)->properties();
-  if(d->hasID3v1)
-    return d->tag.access<ID3v1::Tag>(WavID3v1Index, false)->properties();
-  return PropertyMap();
+  return d->tag.properties();
 }
-
 
 void WavPack::File::removeUnsupportedProperties(const StringList &unsupported)
 {
-  if(d->hasAPE)
-    d->tag.access<APE::Tag>(WavAPEIndex, false)->removeUnsupportedProperties(unsupported);
+  d->tag.removeUnsupportedProperties(unsupported);
 }
-
 
 PropertyMap WavPack::File::setProperties(const PropertyMap &properties)
 {
-  if(d->hasID3v1)
-    d->tag.access<ID3v1::Tag>(WavID3v1Index, false)->setProperties(properties);
-  return d->tag.access<APE::Tag>(WavAPEIndex, true)->setProperties(properties);
+  if(ID3v1Tag())
+    ID3v1Tag()->setProperties(properties);
+
+  return APETag(true)->setProperties(properties);
 }
 
 WavPack::Properties *WavPack::File::audioProperties() const

--- a/tests/test_ape.cpp
+++ b/tests/test_ape.cpp
@@ -1,8 +1,10 @@
 #include <string>
 #include <stdio.h>
-#include <tag.h>
+#include <apetag.h>
+#include <id3v1tag.h>
 #include <tstringlist.h>
 #include <tbytevectorlist.h>
+#include <tpropertymap.h>
 #include <apefile.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -20,6 +22,7 @@ class TestAPE : public CppUnit::TestFixture
   CPPUNIT_TEST(testProperties390);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testStripAndProperties);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -109,6 +112,26 @@ public:
   {
     APE::File f(TEST_FILE_PATH_C("zerodiv.ape"));
     CPPUNIT_ASSERT(f.isValid());
+  }
+
+  void testStripAndProperties()
+  {
+    ScopedFileCopy copy("mac-399", ".ape");
+
+    {
+      APE::File f(copy.fileName().c_str());
+      f.APETag(true)->setTitle("APE");
+      f.ID3v1Tag(true)->setTitle("ID3v1");
+      f.save();
+    }
+    {
+      APE::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL(String("APE"), f.properties()["TITLE"].front());
+      f.strip(APE::File::APE);
+      CPPUNIT_ASSERT_EQUAL(String("ID3v1"), f.properties()["TITLE"].front());
+      f.strip(APE::File::ID3v1);
+      CPPUNIT_ASSERT(f.properties().isEmpty());
+    }
   }
 
 };

--- a/tests/test_mpc.cpp
+++ b/tests/test_mpc.cpp
@@ -1,8 +1,10 @@
 #include <string>
 #include <stdio.h>
-#include <tag.h>
+#include <apetag.h>
+#include <id3v1tag.h>
 #include <tstringlist.h>
 #include <tbytevectorlist.h>
+#include <tpropertymap.h>
 #include <mpcfile.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -21,6 +23,7 @@ class TestMPC : public CppUnit::TestFixture
   CPPUNIT_TEST(testFuzzedFile2);
   CPPUNIT_TEST(testFuzzedFile3);
   CPPUNIT_TEST(testFuzzedFile4);
+  CPPUNIT_TEST(testStripAndProperties);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -107,6 +110,26 @@ public:
   {
     MPC::File f(TEST_FILE_PATH_C("segfault2.mpc"));
     CPPUNIT_ASSERT(f.isValid());
+  }
+
+  void testStripAndProperties()
+  {
+    ScopedFileCopy copy("click", ".mpc");
+
+    {
+      MPC::File f(copy.fileName().c_str());
+      f.APETag(true)->setTitle("APE");
+      f.ID3v1Tag(true)->setTitle("ID3v1");
+      f.save();
+    }
+    {
+      MPC::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL(String("APE"), f.properties()["TITLE"].front());
+      f.strip(MPC::File::APE);
+      CPPUNIT_ASSERT_EQUAL(String("ID3v1"), f.properties()["TITLE"].front());
+      f.strip(MPC::File::ID3v1);
+      CPPUNIT_ASSERT(f.properties().isEmpty());
+    }
   }
 
 };

--- a/tests/test_mpeg.cpp
+++ b/tests/test_mpeg.cpp
@@ -1,8 +1,11 @@
 #include <string>
 #include <stdio.h>
 #include <tstring.h>
+#include <tpropertymap.h>
 #include <mpegfile.h>
 #include <id3v2tag.h>
+#include <id3v1tag.h>
+#include <apetag.h>
 #include <mpegproperties.h>
 #include <xingheader.h>
 #include <mpegheader.h>
@@ -26,6 +29,7 @@ class TestMPEG : public CppUnit::TestFixture
   CPPUNIT_TEST(testDuplicateID3v2);
   CPPUNIT_TEST(testFuzzedFile);
   CPPUNIT_TEST(testFrameOffset);
+  CPPUNIT_TEST(testStripAndProperties);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -209,6 +213,29 @@ public:
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT_EQUAL((long)0x041A, f.firstFrameOffset());
       CPPUNIT_ASSERT_EQUAL((long)0x23F0, f.lastFrameOffset());
+    }
+  }
+
+  void testStripAndProperties()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+
+    {
+      MPEG::File f(copy.fileName().c_str());
+      f.ID3v2Tag(true)->setTitle("ID3v2");
+      f.APETag(true)->setTitle("APE");
+      f.ID3v1Tag(true)->setTitle("ID3v1");
+      f.save();
+    }
+    {
+      MPEG::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL(String("ID3v2"), f.properties()["TITLE"].front());
+      f.strip(MPEG::File::ID3v2);
+      CPPUNIT_ASSERT_EQUAL(String("APE"), f.properties()["TITLE"].front());
+      f.strip(MPEG::File::APE);
+      CPPUNIT_ASSERT_EQUAL(String("ID3v1"), f.properties()["TITLE"].front());
+      f.strip(MPEG::File::ID3v1);
+      CPPUNIT_ASSERT(f.properties().isEmpty());
     }
   }
 

--- a/tests/test_trueaudio.cpp
+++ b/tests/test_trueaudio.cpp
@@ -1,5 +1,8 @@
 #include <string>
 #include <stdio.h>
+#include <id3v1tag.h>
+#include <id3v2tag.h>
+#include <tpropertymap.h>
 #include <trueaudiofile.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -12,6 +15,7 @@ class TestTrueAudio : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestTrueAudio);
   CPPUNIT_TEST(testReadPropertiesWithoutID3v2);
   CPPUNIT_TEST(testReadPropertiesWithTags);
+  CPPUNIT_TEST(testStripAndProperties);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -44,6 +48,26 @@ public:
     CPPUNIT_ASSERT_EQUAL(16, f.audioProperties()->bitsPerSample());
     CPPUNIT_ASSERT_EQUAL(162496U, f.audioProperties()->sampleFrames());
     CPPUNIT_ASSERT_EQUAL(1, f.audioProperties()->ttaVersion());
+  }
+
+  void testStripAndProperties()
+  {
+    ScopedFileCopy copy("empty", ".tta");
+
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      f.ID3v2Tag(true)->setTitle("ID3v2");
+      f.ID3v1Tag(true)->setTitle("ID3v1");
+      f.save();
+    }
+    {
+      TrueAudio::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL(String("ID3v2"), f.properties()["TITLE"].front());
+      f.strip(TrueAudio::File::ID3v2);
+      CPPUNIT_ASSERT_EQUAL(String("ID3v1"), f.properties()["TITLE"].front());
+      f.strip(TrueAudio::File::ID3v1);
+      CPPUNIT_ASSERT(f.properties().isEmpty());
+    }
   }
 
 };

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -188,7 +188,10 @@ public:
 
   void testDuplicateTags()
   {
-    RIFF::WAV::File f(TEST_FILE_PATH_C("duplicate_tags.wav"));
+    ScopedFileCopy copy("duplicate_tags", ".wav");
+
+    RIFF::WAV::File f(copy.fileName().c_str());
+    CPPUNIT_ASSERT_EQUAL(17052L, f.length());
 
     // duplicate_tags.wav has duplicate ID3v2/INFO tags.
     // title() returns "Title2" if can't skip the second tag.
@@ -198,6 +201,10 @@ public:
 
     CPPUNIT_ASSERT(f.hasInfoTag());
     CPPUNIT_ASSERT_EQUAL(String("Title1"), f.InfoTag()->title());
+
+    f.save();
+    CPPUNIT_ASSERT_EQUAL(15898L, f.length());
+    CPPUNIT_ASSERT_EQUAL(-1L, f.find("Title2"));
   }
 
   void testFuzzedFile1()

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -1,9 +1,9 @@
 #include <string>
 #include <stdio.h>
-#include <tag.h>
 #include <id3v2tag.h>
 #include <infotag.h>
 #include <tbytevectorlist.h>
+#include <tpropertymap.h>
 #include <wavfile.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
@@ -24,6 +24,7 @@ class TestWAV : public CppUnit::TestFixture
   CPPUNIT_TEST(testDuplicateTags);
   CPPUNIT_TEST(testFuzzedFile1);
   CPPUNIT_TEST(testFuzzedFile2);
+  CPPUNIT_TEST(testStripAndProperties);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -209,6 +210,26 @@ public:
   {
     RIFF::WAV::File f2(TEST_FILE_PATH_C("segfault.wav"));
     CPPUNIT_ASSERT(f2.isValid());
+  }
+
+  void testStripAndProperties()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      f.ID3v2Tag()->setTitle("ID3v2");
+      f.InfoTag()->setTitle("INFO");
+      f.save();
+    }
+    {
+      RIFF::WAV::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT_EQUAL(String("ID3v2"), f.properties()["TITLE"].front());
+      f.strip(RIFF::WAV::File::ID3v2);
+      CPPUNIT_ASSERT_EQUAL(String("INFO"), f.properties()["TITLE"].front());
+      f.strip(RIFF::WAV::File::Info);
+      CPPUNIT_ASSERT(f.properties().isEmpty());
+    }
   }
 
 };


### PR DESCRIPTION
This fixes #626 by backporting ```TagUnion::properties()``` and ```TagUnion::removeUnsupportedProperties()``` from taglib2 with one of those ugly workarounds to emulate virtual functions.

This PR is too large to review soon. So I have no intention to merge it into v1.10 beta.
