### PR TITLE
Avoid writing duplicate tags when saving ASF files.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
  * Better handling of duplicate ID3v2 tags in all kinds of files.
  * Better handling of duplicate tags in WAV files.
  * Fixed crash when calling File::properties() after strip().
+ * Fixed possible file corruptions when saving ASF files.
  * Marked ByteVector::null and ByteVector::isNull() deprecated.
  * Marked String::null and ByteVector::isNull() deprecated.
  * Many smaller bug fixes and performance improvements.

--- a/taglib/asf/asffile.h
+++ b/taglib/asf/asffile.h
@@ -112,9 +112,6 @@ namespace TagLib {
        * Save the file.
        *
        * This returns true if the save was successful.
-       *
-       * \warning In the current implementation, it's dangerous to call save()
-       * repeatedly.  At worst it will corrupt the file.
        */
       virtual bool save();
 

--- a/tests/test_asf.cpp
+++ b/tests/test_asf.cpp
@@ -25,6 +25,7 @@ class TestASF : public CppUnit::TestFixture
   CPPUNIT_TEST(testSavePicture);
   CPPUNIT_TEST(testSaveMultiplePictures);
   CPPUNIT_TEST(testProperties);
+  CPPUNIT_TEST(testRepeatedSave);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -268,6 +269,21 @@ public:
     CPPUNIT_ASSERT_EQUAL(1u, f.tag()->attributeListMap()["WM/PartOfSet"].size());
     CPPUNIT_ASSERT_EQUAL(String("3"), f.tag()->attribute("WM/PartOfSet").front().toString());
     CPPUNIT_ASSERT_EQUAL(StringList("3"), tags["DISCNUMBER"]);
+  }
+
+  void testRepeatedSave()
+  {
+    ScopedFileCopy copy("silence-1", ".wma");
+
+    {
+      ASF::File f(copy.fileName().c_str());
+      f.tag()->setTitle(std::string(128 * 1024, 'X').c_str());
+      f.save();
+      CPPUNIT_ASSERT_EQUAL(297578L, f.length());
+      f.tag()->setTitle(std::string(16 * 1024, 'X').c_str());
+      f.save();
+      CPPUNIT_ASSERT_EQUAL(68202L, f.length());
+    }
   }
 
 };


### PR DESCRIPTION
This fix #621.
I reported several similar bugs, but this one is relatively easy to fix. I think we can merge it to v1.10.

The points of this fix are:
* Clear all ```attributeData```s before adding things to them.
* Update ```d->headerSize``` after writing a tag.
 
This also reduces memory reallocations and copies when saving ASF files.