### PR TITLE
Install target should be checked to avoid conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,5 +127,7 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
   IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
+if (NOT TARGET uninstall)
+  add_custom_target(uninstall
   COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+endif()


### PR DESCRIPTION
While using this library as Subproject there could be conflicts with 'uninstall' target with other libs. Cmake error like this:

```CMake Error at libraryY/CMakeLists.txt:63 (add_custom_target):
  add_custom_target cannot create target "doc" because another target with
  the same name already exists.  The existing target is a custom target
  created in source directory
  "/path/to/libraryX".  See
  documentation for policy CMP0002 for more details.```

And current support of CMP0002 policy is buggy on stable cmake package.