### PR TITLE
Add XiphComment::removeFields() functions to avoid a linkage error ca…

### DIFF
--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -257,17 +257,31 @@ void Ogg::XiphComment::addField(const String &key, const String &value, bool rep
 
 void Ogg::XiphComment::removeField(const String &key, const String &value)
 {
-  if(!value.isNull()) {
-    StringList::Iterator it = d->fieldListMap[key].begin();
-    while(it != d->fieldListMap[key].end()) {
-      if(value == *it)
-        it = d->fieldListMap[key].erase(it);
-      else
-        it++;
-    }
-  }
+  if(!value.isNull())
+    removeFields(key, value);
   else
-    d->fieldListMap.erase(key);
+    removeFields(key);
+}
+
+void Ogg::XiphComment::removeFields(const String &key)
+{
+  d->fieldListMap.erase(key);
+}
+
+void Ogg::XiphComment::removeFields(const String &key, const String &value)
+{
+  StringList::Iterator it = d->fieldListMap[key].begin();
+  while(it != d->fieldListMap[key].end()) {
+    if(value == *it)
+      it = d->fieldListMap[key].erase(it);
+    else
+      it++;
+  }
+}
+
+void Ogg::XiphComment::removeAllFields()
+{
+  d->fieldListMap.clear();
 }
 
 bool Ogg::XiphComment::contains(const String &key) const

--- a/taglib/ogg/xiphcomment.h
+++ b/taglib/ogg/xiphcomment.h
@@ -181,8 +181,28 @@ namespace TagLib {
       /*!
        * Remove the field specified by \a key with the data \a value.  If
        * \a value is null, all of the fields with the given key will be removed.
+       *
+       * \see removeFields()
+       *
+       * \deprecated May cause a linkage error depending on the situation.  Use
+       * removeFields() instead.
        */
       void removeField(const String &key, const String &value = String::null);
+
+      /*!
+       * Remove all the fields specified by \a key.
+       */
+      void removeFields(const String &key);
+
+      /*!
+       * Remove the fields specified by \a key with the data \a value.
+       */
+      void removeFields(const String &key, const String &value);
+
+      /*!
+       * Remove all the fields in the XiphComment.  Vendor ID will be preserved.
+       */
+      void removeAllFields();
 
       /*!
        * Returns true if the field is contained within the comment.


### PR DESCRIPTION
…used by removeField().
Fixes the bug reported at #651. I'd like to ask someone if it's worth it to merge immediately.