### PR TITLE
Fix XiphComment::setComment() for the case that a Vorbis comment has …

### DIFF
--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -137,7 +137,14 @@ void Ogg::XiphComment::setAlbum(const String &s)
 
 void Ogg::XiphComment::setComment(const String &s)
 {
-  addField(d->commentField.isEmpty() ? "DESCRIPTION" : d->commentField, s);
+  if(d->commentField.isEmpty()) {
+    if(!d->fieldListMap["DESCRIPTION"].isEmpty())
+      d->commentField = "DESCRIPTION";
+    else
+      d->commentField = "COMMENT";
+  }
+
+  addField(d->commentField, s);
 }
 
 void Ogg::XiphComment::setGenre(const String &s)

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -36,6 +36,7 @@ class Ogg::XiphComment::XiphCommentPrivate
 public:
   FieldListMap fieldListMap;
   String vendorID;
+  String commentField;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -81,10 +82,16 @@ String Ogg::XiphComment::album() const
 
 String Ogg::XiphComment::comment() const
 {
-  if(!d->fieldListMap["COMMENT"].isEmpty())
-    return d->fieldListMap["COMMENT"].toString();
-  if(!d->fieldListMap["DESCRIPTION"].isEmpty())
+  if(!d->fieldListMap["DESCRIPTION"].isEmpty()) {
+    d->commentField = "DESCRIPTION";
     return d->fieldListMap["DESCRIPTION"].toString();
+  }
+
+  if(!d->fieldListMap["COMMENT"].isEmpty()) {
+    d->commentField = "COMMENT";
+    return d->fieldListMap["COMMENT"].toString();
+  }
+
   return String::null;
 }
 
@@ -130,8 +137,14 @@ void Ogg::XiphComment::setAlbum(const String &s)
 
 void Ogg::XiphComment::setComment(const String &s)
 {
-  removeField("DESCRIPTION");
-  addField("COMMENT", s);
+  if(d->commentField.isEmpty()) {
+    if(!d->fieldListMap["DESCRIPTION"].isEmpty())
+      d->commentField = "DESCRIPTION";
+    else
+      d->commentField = "COMMENT";
+  }
+
+  addField(d->commentField, s);
 }
 
 void Ogg::XiphComment::setGenre(const String &s)

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -36,7 +36,6 @@ class Ogg::XiphComment::XiphCommentPrivate
 public:
   FieldListMap fieldListMap;
   String vendorID;
-  String commentField;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,16 +81,10 @@ String Ogg::XiphComment::album() const
 
 String Ogg::XiphComment::comment() const
 {
-  if(!d->fieldListMap["DESCRIPTION"].isEmpty()) {
-    d->commentField = "DESCRIPTION";
-    return d->fieldListMap["DESCRIPTION"].toString();
-  }
-
-  if(!d->fieldListMap["COMMENT"].isEmpty()) {
-    d->commentField = "COMMENT";
+  if(!d->fieldListMap["COMMENT"].isEmpty())
     return d->fieldListMap["COMMENT"].toString();
-  }
-
+  if(!d->fieldListMap["DESCRIPTION"].isEmpty())
+    return d->fieldListMap["DESCRIPTION"].toString();
   return String::null;
 }
 
@@ -137,14 +130,8 @@ void Ogg::XiphComment::setAlbum(const String &s)
 
 void Ogg::XiphComment::setComment(const String &s)
 {
-  if(d->commentField.isEmpty()) {
-    if(!d->fieldListMap["DESCRIPTION"].isEmpty())
-      d->commentField = "DESCRIPTION";
-    else
-      d->commentField = "COMMENT";
-  }
-
-  addField(d->commentField, s);
+  removeField("DESCRIPTION");
+  addField("COMMENT", s);
 }
 
 void Ogg::XiphComment::setGenre(const String &s)

--- a/tests/test_xiphcomment.cpp
+++ b/tests/test_xiphcomment.cpp
@@ -17,6 +17,7 @@ class TestXiphComment : public CppUnit::TestFixture
   CPPUNIT_TEST(testSetYear);
   CPPUNIT_TEST(testTrack);
   CPPUNIT_TEST(testSetTrack);
+  CPPUNIT_TEST(testSetComment);
   CPPUNIT_TEST(testInvalidKeys);
   CPPUNIT_TEST(testClearComment);
   CPPUNIT_TEST_SUITE_END();
@@ -61,6 +62,16 @@ public:
     cmt.setTrack(3);
     CPPUNIT_ASSERT(cmt.fieldListMap()["TRACKNUM"].isEmpty());
     CPPUNIT_ASSERT_EQUAL(String("3"), cmt.fieldListMap()["TRACKNUMBER"].front());
+  }
+
+  void testSetComment()
+  {
+    Ogg::XiphComment cmt;
+    cmt.addField("DESCRIPTION", "Test Comment 1");
+    cmt.addField("COMMENT", "Test Comment 2");
+    cmt.setComment("Test Comment 3");
+    CPPUNIT_ASSERT(cmt.fieldListMap()["DESCRIPTION"].isEmpty());
+    CPPUNIT_ASSERT_EQUAL(String("Test Comment 3"), cmt.fieldListMap()["COMMENT"].front());
   }
 
   void testInvalidKeys()

--- a/tests/test_xiphcomment.cpp
+++ b/tests/test_xiphcomment.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <stdio.h>
+#include <flacfile.h>
 #include <xiphcomment.h>
 #include <tpropertymap.h>
 #include <tdebug.h>
@@ -17,6 +18,7 @@ class TestXiphComment : public CppUnit::TestFixture
   CPPUNIT_TEST(testTrack);
   CPPUNIT_TEST(testSetTrack);
   CPPUNIT_TEST(testInvalidKeys);
+  CPPUNIT_TEST(testClearComment);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -72,6 +74,22 @@ public:
     PropertyMap unsuccessful = cmt.setProperties(map);
     CPPUNIT_ASSERT_EQUAL(TagLib::uint(3), unsuccessful.size());
     CPPUNIT_ASSERT(cmt.properties().isEmpty());
+  }
+
+  void testClearComment()
+  {
+    ScopedFileCopy copy("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy.fileName().c_str());
+      f.xiphComment()->addField("COMMENT", "Comment1");
+      f.save();
+    }
+    {
+      FLAC::File f(copy.fileName().c_str());
+      f.xiphComment()->setComment("");
+      CPPUNIT_ASSERT_EQUAL(String(""), f.xiphComment()->comment());
+    }
   }
 
 };

--- a/tests/test_xiphcomment.cpp
+++ b/tests/test_xiphcomment.cpp
@@ -17,7 +17,6 @@ class TestXiphComment : public CppUnit::TestFixture
   CPPUNIT_TEST(testSetYear);
   CPPUNIT_TEST(testTrack);
   CPPUNIT_TEST(testSetTrack);
-  CPPUNIT_TEST(testSetComment);
   CPPUNIT_TEST(testInvalidKeys);
   CPPUNIT_TEST(testClearComment);
   CPPUNIT_TEST_SUITE_END();
@@ -62,16 +61,6 @@ public:
     cmt.setTrack(3);
     CPPUNIT_ASSERT(cmt.fieldListMap()["TRACKNUM"].isEmpty());
     CPPUNIT_ASSERT_EQUAL(String("3"), cmt.fieldListMap()["TRACKNUMBER"].front());
-  }
-
-  void testSetComment()
-  {
-    Ogg::XiphComment cmt;
-    cmt.addField("DESCRIPTION", "Test Comment 1");
-    cmt.addField("COMMENT", "Test Comment 2");
-    cmt.setComment("Test Comment 3");
-    CPPUNIT_ASSERT(cmt.fieldListMap()["DESCRIPTION"].isEmpty());
-    CPPUNIT_ASSERT_EQUAL(String("Test Comment 3"), cmt.fieldListMap()["COMMENT"].front());
   }
 
   void testInvalidKeys()


### PR DESCRIPTION
…the "COMMENT" field.

This fixes #653. 
Cause: ```d->commentField``` is not initialized until ```comment()``` is called, and ```setComment()``` updates the "DESCRIPTION" field even if the tag has the "COMMENT" field.