### PR TITLE
Add support for M4V tag parsing

### DIFF
--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -155,6 +155,7 @@ StringList FileRef::defaultFileExtensions()
   l.append("m4p");
   l.append("3g2");
   l.append("mp4");
+  l.append("m4v");
   l.append("wma");
   l.append("asf");
   l.append("aif");
@@ -261,7 +262,7 @@ File *FileRef::create(FileName fileName, bool readAudioProperties,
       return new Ogg::Opus::File(fileName, readAudioProperties, audioPropertiesStyle);
     if(ext == "TTA")
       return new TrueAudio::File(fileName, readAudioProperties, audioPropertiesStyle);
-    if(ext == "M4A" || ext == "M4R" || ext == "M4B" || ext == "M4P" || ext == "MP4" || ext == "3G2")
+    if(ext == "M4A" || ext == "M4R" || ext == "M4B" || ext == "M4P" || ext == "MP4" || ext == "3G2" || ext == "M4V")
       return new MP4::File(fileName, readAudioProperties, audioPropertiesStyle);
     if(ext == "WMA" || ext == "ASF")
       return new ASF::File(fileName, readAudioProperties, audioPropertiesStyle);


### PR DESCRIPTION
In VLC we use taglib a lot to get title/author/etc of audio and video files. M4V is among the common file formats that taglib can parse easily.