### PR TITLE
Allow create FileRef from an already opened IOStream

### DIFF
--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -128,6 +128,20 @@ namespace TagLib {
                      audioPropertiesStyle = AudioProperties::Average);
 
     /*!
+     * Create a FileRef from an opened \a IOStream.  If \a readAudioProperties is true then
+     * the audio properties will be read using \a audioPropertiesStyle.  If
+     * \a readAudioProperties is false then \a audioPropertiesStyle will be
+     * ignored.
+     *
+     * Also see the note in the class documentation about why you may not want to
+     * use this method in your application.
+     */
+    explicit FileRef(IOStream* stream,
+                     bool readAudioProperties = true,
+                     AudioProperties::ReadStyle
+                     audioPropertiesStyle = AudioProperties::Average);
+
+    /*!
      * Construct a FileRef using \a file.  The FileRef now takes ownership of the
      * pointer and will delete the File when it passes out of scope.
      */
@@ -252,6 +266,9 @@ namespace TagLib {
                         bool readAudioProperties = true,
                         AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
 
+    static File *create(IOStream* ioStream,
+                        bool readAudioProperties = true,
+                        AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
 
   private:
     class FileRefPrivate;


### PR DESCRIPTION
In Windows Store apps, it's not possible to access the files directly using the regular file operations. The only way to open files (asynchronously) is through managed code. Using the raw IOStream class it's possible to go over this limitation in taglib.