### PR TITLE
Fixes access violation

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -917,7 +917,7 @@ PropertyMap MP4::Tag::setProperties(const PropertyMap &props)
   for(; it != props.end(); ++it) {
     if(reverseKeyMap.contains(it->first)) {
       String name = reverseKeyMap[it->first];
-      if(it->first == "TRACKNUMBER" || it->first == "DISCNUMBER") {
+      if((it->first == "TRACKNUMBER" || it->first == "DISCNUMBER") && it->second.size() > 0) {
         int first = 0, second = 0;
         StringList parts = StringList::split(it->second.front(), "/");
         if(parts.size() > 0) {
@@ -928,11 +928,11 @@ PropertyMap MP4::Tag::setProperties(const PropertyMap &props)
           d->items[name] = MP4::Item(first, second);
         }
       }
-      else if(it->first == "BPM") {
+      else if(it->first == "BPM" && it->second.size() > 0) {
         int value = it->second.front().toInt();
         d->items[name] = MP4::Item(value);
       }
-      else if(it->first == "COMPILATION") {
+      else if(it->first == "COMPILATION" && it->second.size() > 0) {
         bool value = (it->second.front().toInt() != 0);
         d->items[name] = MP4::Item(value);
       }

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -305,6 +305,14 @@ public:
     CPPUNIT_ASSERT(f.tag()->contains("cpil"));
     CPPUNIT_ASSERT_EQUAL(false, f.tag()->item("cpil").toBool());
     CPPUNIT_ASSERT_EQUAL(StringList("0"), tags["COMPILATION"]);
+
+    // Empty properties do not result in access violations
+    // when converting integers
+    tags["TRACKNUMBER"] = StringList();
+    tags["DISCNUMBER"] = StringList();
+    tags["BPM"] = StringList();
+    tags["COMPILATION"] = StringList();
+    f.setProperties(tags);
   }
 
   void testFuzzedFile()


### PR DESCRIPTION
Fixes #670

- Fixes access violation when setting empty stringlist on integer
  properties in mp4 tag
- Add a unit test that validates the fix.