### PR TITLE
Hide private things from a public header.

### DIFF
--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -515,37 +515,6 @@ namespace TagLib {
     void detach();
 
   private:
-    /*!
-     * Converts a \e Latin-1 string into \e UTF-16(without BOM/CPU byte order)
-     * and copies it to the internal buffer.
-     */
-    void copyFromLatin1(const char *s, size_t length);
-
-    /*!
-     * Converts a \e UTF-8 string into \e UTF-16(without BOM/CPU byte order)
-     * and copies it to the internal buffer.
-     */
-    void copyFromUTF8(const char *s, size_t length);
-
-    /*!
-     * Converts a \e UTF-16 (with BOM), UTF-16LE or UTF16-BE string into
-     * \e UTF-16(without BOM/CPU byte order) and copies it to the internal buffer.
-     */
-    void copyFromUTF16(const wchar_t *s, size_t length, Type t);
-
-    /*!
-     * Converts a \e UTF-16 (with BOM), UTF-16LE or UTF16-BE string into
-     * \e UTF-16(without BOM/CPU byte order) and copies it to the internal buffer.
-     */
-    void copyFromUTF16(const char *s, size_t length, Type t);
-
-    /*!
-     * Indicates which byte order of UTF-16 is used to store strings internally.
-     *
-     * \note \e String::UTF16BE or \e String::UTF16LE
-     */
-    static const Type WCharByteOrder;
-
     class StringPrivate;
     StringPrivate *d;
   };

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -495,6 +495,11 @@ namespace TagLib {
     String &operator=(const ByteVector &v);
 
     /*!
+     * Exchanges the content of the String by the content of \a s.
+     */
+    void swap(String &s);
+
+    /*!
      * To be able to use this class in a Map, this operator needed to be
      * implemented.  Returns true if \a s is less than this string in a byte-wise
      * comparison.

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -241,6 +241,12 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("-123").toInt(), -123);
     CPPUNIT_ASSERT_EQUAL(String("123aa").toInt(), 123);
     CPPUNIT_ASSERT_EQUAL(String("-123aa").toInt(), -123);
+
+    String("2147483648").toInt(&ok);
+    CPPUNIT_ASSERT_EQUAL(ok, false);
+
+    String("-2147483649").toInt(&ok);
+    CPPUNIT_ASSERT_EQUAL(ok, false);
   }
 
   void testSubstr()


### PR DESCRIPTION
Some functions and a variable in ```tstring.h``` are not needed to be exposed in a public header.
Basically the same idea as fbd3b71690cedd70b9175d55a1e089aaca748046, but hides more things.