### PR TITLE
Add alternative methods to XiphComment::removeField() that may cause …

### DIFF
--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -264,22 +264,36 @@ void Ogg::XiphComment::addField(const String &key, const String &value, bool rep
 
 void Ogg::XiphComment::removeField(const String &key, const String &value)
 {
-  if(!value.isNull()) {
-    StringList::Iterator it = d->fieldListMap[key].begin();
-    while(it != d->fieldListMap[key].end()) {
-      if(value == *it)
-        it = d->fieldListMap[key].erase(it);
-      else
-        it++;
-    }
-  }
+  if(!value.isNull())
+    removeFields(key, value);
   else
-    d->fieldListMap.erase(key);
+    removeFields(key);
+}
+
+void Ogg::XiphComment::removeFields(const String &key)
+{
+  d->fieldListMap.erase(key.upper());
+}
+
+void Ogg::XiphComment::removeFields(const String &key, const String &value)
+{
+  StringList &fields = d->fieldListMap[key.upper()];
+  for(StringList::Iterator it = fields.begin(); it != fields.end(); ) {
+    if(*it == value)
+      it = fields.erase(it);
+    else
+      ++it;
+  }
+}
+
+void Ogg::XiphComment::removeAllFields()
+{
+  d->fieldListMap.clear();
 }
 
 bool Ogg::XiphComment::contains(const String &key) const
 {
-  return d->fieldListMap.contains(key) && !d->fieldListMap[key].isEmpty();
+  return !d->fieldListMap[key.upper()].isEmpty();
 }
 
 ByteVector Ogg::XiphComment::render() const

--- a/taglib/ogg/xiphcomment.h
+++ b/taglib/ogg/xiphcomment.h
@@ -181,8 +181,32 @@ namespace TagLib {
       /*!
        * Remove the field specified by \a key with the data \a value.  If
        * \a value is null, all of the fields with the given key will be removed.
+       *
+       * \deprecated Using this method may lead to a linkage error.
        */
+      // BIC: remove and merge with below
       void removeField(const String &key, const String &value = String::null);
+
+      /*!
+       * Remove all the fields specified by \a key.
+       *
+       * \see removeAllFields()
+       */
+      void removeFields(const String &key);
+
+      /*!
+       * Remove all the fields specified by \a key with the data \a value.
+       *
+       * \see removeAllFields()
+       */
+      void removeFields(const String &key, const String &value);
+
+      /*!
+       * Remove all the fields in the comment.
+       *
+       * \see removeFields()
+       */
+      void removeAllFields();
 
       /*!
        * Returns true if the field is contained within the comment.


### PR DESCRIPTION
…a linkage error.

This fixes #651. Using ```String::null``` in a public header may lead to a linkage error, so we need alternative methods not depending on ```String::null```.