### PR TITLE
fix pkgconfig file for cross compiling

### DIFF
--- a/taglib.pc.cmake
+++ b/taglib.pc.cmake
@@ -7,5 +7,5 @@ Name: TagLib
 Description: Audio meta-data library
 Requires: 
 Version: ${TAGLIB_LIB_VERSION_STRING}
-Libs: -L${LIB_INSTALL_DIR} -ltag
-Cflags: -I${INCLUDE_INSTALL_DIR}/taglib 
+Libs: -L${dollar}{libdir} -ltag
+Cflags: -I${dollar}{includedir}/taglib


### PR DESCRIPTION
as title says. libdir / includedir shall never be hardcoded in generated pkgconfig file.