### PR TITLE
Enable FLAC::File to remove non-standard tags.

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -372,6 +372,20 @@ void FLAC::File::removePictures()
   }
 }
 
+void FLAC::File::strip(int tags)
+{
+  if(tags & ID3v1)
+    d->tag.set(FlacID3v1Index, 0);
+
+  if(tags & ID3v2)
+    d->tag.set(FlacID3v2Index, 0);
+
+  if(tags & XiphComment) {
+    xiphComment()->removeAllFields();
+    xiphComment()->removeAllPictures();
+  }
+}
+
 bool FLAC::File::hasXiphComment() const
 {
   return !d->xiphCommentData.isEmpty();

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -67,6 +67,23 @@ namespace TagLib {
     {
     public:
       /*!
+       * This set of flags is used for various operations and is suitable for
+       * being OR-ed together.
+       */
+      enum TagTypes {
+        //! Empty set.  Matches no tag types.
+        NoTags      = 0x0000,
+        //! Matches Vorbis comments.
+        XiphComment = 0x0001,
+        //! Matches ID3v1 tags.
+        ID3v1       = 0x0002,
+        //! Matches ID3v2 tags.
+        ID3v2       = 0x0004,
+        //! Matches all tag types.
+        AllTags     = 0xffff
+      };
+
+      /*!
        * Constructs a FLAC file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
@@ -264,6 +281,21 @@ namespace TagLib {
        * \note The file will be saved only after calling save().
        */
       void addPicture(Picture *picture);
+
+      /*!
+       * This will remove the tags that match the OR-ed together TagTypes from
+       * the file.  By default it removes all tags.
+       *
+       * \warning This will also invalidate pointers to the tags as their memory
+       * will be freed.
+       *
+       * \note In order to make the removal permanent save() still needs to be
+       * called.
+       *
+       * \note This won't remove the Vorbis comment block completely.  The
+       * vendor ID will be preserved.
+       */
+      void strip(int tags = AllTags);
 
       /*!
        * Returns whether or not the file on disk actually has a XiphComment.


### PR DESCRIPTION
This is related to #646. 
This adds a method named ```strip()``` to ```FLAC::File```. It works like other ```strip()``` methods, but it preserves the vendor ID instead of removing the Vorbis comment block completely.