### PR TITLE
TAGLIB_EXPORT on the class causes warnings for std::string

### DIFF
--- a/taglib/toolkit/tiostream.h
+++ b/taglib/toolkit/tiostream.h
@@ -33,21 +33,21 @@
 namespace TagLib {
 
 #ifdef _WIN32
-  class TAGLIB_EXPORT FileName
+  class FileName
   {
   public:
-    FileName(const wchar_t *name);
-    FileName(const char *name);
+    TAGLIB_EXPORT FileName(const wchar_t *name);
+    TAGLIB_EXPORT FileName(const char *name);
 
-    FileName(const FileName &name);
+    TAGLIB_EXPORT FileName(const FileName &name);
 
-    operator const wchar_t *() const;
-    operator const char *() const;
+    TAGLIB_EXPORT operator const wchar_t *() const;
+    TAGLIB_EXPORT operator const char *() const;
 
-    const std::wstring &wstr() const;
-    const std::string  &str() const;
+    TAGLIB_EXPORT const std::wstring &wstr() const;
+    TAGLIB_EXPORT const std::string  &str() const;
 
-    String toString() const;
+    TAGLIB_EXPORT String toString() const;
 
   private:
     const std::string  m_name;


### PR DESCRIPTION
Setting TAGLIB_EXPORT on the class instead of the individual functions generates compiler warnings for both std::string when trying to build taglib as a .dll. See [discussion here](http://stackoverflow.com/questions/4145605/stdvector-needs-to-have-dll-interface-to-be-used-by-clients-of-class-xt-war). Moving the TAGLIB_EXPORT to just the exported functions fixes this, even if it isn't as pretty. 