### PR TITLE
Add Matroska support to file type resolver

### DIFF
--- a/taglib/ebml/matroska/ebmlmatroskafile.cpp
+++ b/taglib/ebml/matroska/ebmlmatroskafile.cpp
@@ -134,7 +134,7 @@ EBML::Matroska::File::~File()
   }
 }
 
-EBML::Matroska::File::File(FileName file) : EBML::File(file), d(0)
+EBML::Matroska::File::File(FileName file, bool, AudioProperties::ReadStyle) : EBML::File(file), d(0)
 {
   if(isValid() && isOpen()) {
     d = FilePrivate::checkAndCreate(this);
@@ -145,7 +145,7 @@ EBML::Matroska::File::File(FileName file) : EBML::File(file), d(0)
   }
 }
 
-EBML::Matroska::File::File(IOStream *stream) : EBML::File(stream), d(0)
+EBML::Matroska::File::File(IOStream *stream, bool, AudioProperties::ReadStyle) : EBML::File(stream), d(0)
 {
   if(isValid() && isOpen()) {
     d = FilePrivate::checkAndCreate(this);

--- a/taglib/ebml/matroska/ebmlmatroskafile.h
+++ b/taglib/ebml/matroska/ebmlmatroskafile.h
@@ -28,6 +28,7 @@
 #define TAGLIB_EBMLMATROSKAFILE_H
 
 #include "ebmlelement.h"
+#include "audioproperties.h"
 
 namespace TagLib {
 
@@ -47,14 +48,28 @@ namespace TagLib {
         virtual ~File();
 
         /*!
-         * Constructs a Matroska File from a file name.
+         * Constructs a Matroska file from \a file.  If \a readProperties is true the
+         * file's audio properties will also be read using \a propertiesStyle.  If
+         * false, \a propertiesStyle is ignored.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.  The audio properties are always
+         * read.
          */
-        explicit File(FileName file);
+        explicit File(FileName file, bool readProperties = true,
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
-         *  Constructs a Matroska File from a stream.
+         * Constructs a Matroska file from \a stream.  If \a readProperties is true the
+         * file's audio properties will also be read using \a propertiesStyle.  If
+         * false, \a propertiesStyle is ignored.
+         *
+         * \note In the current implementation, both \a readProperties and
+         * \a propertiesStyle are ignored.  The audio properties are always
+         * read.
          */
-        explicit File(IOStream *stream);
+        explicit File(IOStream *stream, bool readproperties = true,
+             AudioProperties::ReadStyle propertiesStyle = AudioProperties::Average);
 
         /*!
          * Returns the pointer to a tag that allow access on common tags.

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -53,6 +53,7 @@
 #include "itfile.h"
 #include "xmfile.h"
 #include "dsffile.h"
+#include "ebmlmatroskafile.h"
 
 using namespace TagLib;
 
@@ -136,6 +137,9 @@ namespace
       return new IT::File(stream, readAudioProperties, audioPropertiesStyle);
     if(ext == "XM")
       return new XM::File(stream, readAudioProperties, audioPropertiesStyle);
+    if (ext == "MKA" || ext == "MKV") {
+      return new EBML::Matroska::File(stream, readAudioProperties, audioPropertiesStyle);
+    }
 
     return 0;
   }
@@ -352,6 +356,8 @@ StringList FileRef::defaultFileExtensions()
   l.append("it");
   l.append("xm");
   l.append("dsf");
+  l.append("mka");
+  l.append("mkv");
 
   return l;
 }


### PR DESCRIPTION
Updated the constructors to match the other file types, and added .mka and .mkv as recognized file types.
