### PR TITLE
Adds a function for dynamic version information retrieval

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -321,6 +321,7 @@ set(matroska_SRCS
 )
 
 set(toolkit_SRCS
+  toolkit/taglib.cpp
   toolkit/tstring.cpp
   toolkit/tstringlist.cpp
   toolkit/tstringhandler.cpp

--- a/taglib/toolkit/taglib.cpp
+++ b/taglib/toolkit/taglib.cpp
@@ -4,31 +4,34 @@
 
 using namespace TagLib;
 
-String TagLib::GetVersionString()
+
+String TagLib::Version::string()
 {
   return String::number(TAGLIB_MAJOR_VERSION)
       + "." + String::number(TAGLIB_MINOR_VERSION)
       + "." + String::number(TAGLIB_PATCH_VERSION);
 }
 
-unsigned int TagLib::GetMajorVersion()
-{
-  return TAGLIB_MAJOR_VERSION;
-}
-
-unsigned int TagLib::GetMinorVersion()
-{
-  return TAGLIB_MINOR_VERSION;
-}
-
-unsigned int TagLib::GetPatchVersion()
-{
-  return TAGLIB_PATCH_VERSION;
-}
-
-unsigned int TagLib::GetVersion()
+unsigned int TagLib::Version::combined()
 {
   return (TAGLIB_MAJOR_VERSION << 16)
           || (TAGLIB_MINOR_VERSION << 8)
           || (TAGLIB_PATCH_VERSION << 4);
 }
+
+
+unsigned int (TagLib::Version::major)()
+{
+  return TAGLIB_MAJOR_VERSION;
+}
+
+unsigned int (TagLib::Version::minor)()
+{
+  return TAGLIB_MINOR_VERSION;
+}
+
+unsigned int TagLib::Version::patch()
+{
+  return TAGLIB_PATCH_VERSION;
+}
+

--- a/taglib/toolkit/taglib.cpp
+++ b/taglib/toolkit/taglib.cpp
@@ -1,0 +1,34 @@
+#include "taglib.h"
+#include "tstring.h"
+#include <string>
+
+using namespace TagLib;
+
+String TagLib::GetVersionString()
+{
+  return String::number(TAGLIB_MAJOR_VERSION)
+      + "." + String::number(TAGLIB_MINOR_VERSION)
+      + "." + String::number(TAGLIB_PATCH_VERSION);
+}
+
+unsigned int TagLib::GetMajorVersion()
+{
+  return TAGLIB_MAJOR_VERSION;
+}
+
+unsigned int TagLib::GetMinorVersion()
+{
+  return TAGLIB_MINOR_VERSION;
+}
+
+unsigned int TagLib::GetPatchVersion()
+{
+  return TAGLIB_PATCH_VERSION;
+}
+
+unsigned int TagLib::GetVersion()
+{
+  return (TAGLIB_MAJOR_VERSION << 16)
+          || (TAGLIB_MINOR_VERSION << 8)
+          || (TAGLIB_PATCH_VERSION << 4);
+}

--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -46,8 +46,6 @@
  * \endcode
  */
 
-#include <tuple>
-
 namespace TagLib
 {
   enum ByteOrder
@@ -55,13 +53,35 @@ namespace TagLib
     LittleEndian,
     BigEndian
   };
+  class String;
   /*!
-   * Returns the library's version information as 3-tuple of ints (for major, minor, patch version).
+   * Returns the version as a string in the form
+   * (Major Version).(Minor Version).(Patch Version), e.g. "4.2.0".
    */
-  std::tuple<int, int, int> version()
-  {
-      return std::make_tuple(TAGLIB_MAJOR_VERSION, TAGLIB_MINOR_VERSION, TAGLIB_PATCH_VERSION);
-  }
+  String GetVersionString();
+
+  /*!
+   * Returns the version as an unsigned integer in the form
+   * (Major Version << 16) | (Minor Version << 8) | (Patch Version), e.g. 0x040200
+   * Use this for simple and consistent version comparison, e.g.
+   *     if (TagLib::GetVersion() <= ((1 << 16) | (11 << 8))) return false;
+   */
+  unsigned int GetVersion();
+
+  /*!
+   * Returns the major version, e.g. 4
+   */
+  unsigned int GetMajorVersion();
+
+  /*!
+   * Returns the minor version, e.g. 2
+   */
+  unsigned int GetMinorVersion();
+
+  /*!
+   * Returns the patch version, e.g. 0
+   */
+  unsigned int GetPatchVersion();
 }
 
 /*!

--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -54,34 +54,37 @@ namespace TagLib
     BigEndian
   };
   class String;
-  /*!
-   * Returns the version as a string in the form
-   * (Major Version).(Minor Version).(Patch Version), e.g. "4.2.0".
-   */
-  String GetVersionString();
+  namespace Version
+  {
+    /*!
+     * Returns the version as a string in the form
+     * (Major Version).(Minor Version).(Patch Version), e.g. "4.2.0".
+     */
+    String string();
 
-  /*!
-   * Returns the version as an unsigned integer in the form
-   * (Major Version << 16) | (Minor Version << 8) | (Patch Version), e.g. 0x040200
-   * Use this for simple and consistent version comparison, e.g.
-   *     if (TagLib::GetVersion() <= ((1 << 16) | (11 << 8))) return false;
-   */
-  unsigned int GetVersion();
+    /*!
+     * Returns the version as an unsigned integer in the form
+     * (Major Version << 16) | (Minor Version << 8) | (Patch Version), e.g. 0x040200
+     * Use this for simple and consistent version comparison, e.g.
+     *     if (TagLib::GetVersion() <= ((1 << 16) | (11 << 8))) return false;
+     */
+    unsigned int combined();
 
-  /*!
-   * Returns the major version, e.g. 4
-   */
-  unsigned int GetMajorVersion();
+    /*!
+     * Returns the major version, e.g. 4
+     */
+    unsigned int (major)();
 
-  /*!
-   * Returns the minor version, e.g. 2
-   */
-  unsigned int GetMinorVersion();
+    /*!
+     * Returns the minor version, e.g. 2
+     */
+    unsigned int (minor)();
 
-  /*!
-   * Returns the patch version, e.g. 0
-   */
-  unsigned int GetPatchVersion();
+    /*!
+     * Returns the patch version, e.g. 0
+     */
+    unsigned int patch();
+  }
 }
 
 /*!

--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -46,6 +46,8 @@
  * \endcode
  */
 
+#include <tuple>
+
 namespace TagLib
 {
   enum ByteOrder
@@ -53,6 +55,13 @@ namespace TagLib
     LittleEndian,
     BigEndian
   };
+  /*!
+   * Returns the library's version information as 3-tuple of ints (for major, minor, patch version).
+   */
+  std::tuple<int, int, int> version()
+  {
+      return std::make_tuple(TAGLIB_MAJOR_VERSION, TAGLIB_MINOR_VERSION, TAGLIB_PATCH_VERSION);
+  }
 }
 
 /*!


### PR DESCRIPTION
The current way of exposing TagLib's version only through #define's
makes it impossible for clients (e.g. language bindings) to reliably
determine the TagLib version that is currently in use: using the
define's in client code will statically copy the compile-time values
into the client's library, but if TagLib is dynamically bound the
version (at least minor and patch version) can change after building
client code.