### PR TITLE
Fix Typo

### DIFF
--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -198,7 +198,7 @@ String ChapterFrame::toString() const
     s += ", start offset: " + String::number(d->startOffset);
 
   if(d->endOffset != 0xFFFFFFFF)
-    s += ", start offset: " + String::number(d->endOffset);
+    s += ", end offset: " + String::number(d->endOffset);
 
   if(!d->embeddedFrameList.isEmpty()) {
     StringList frameIDs;


### PR DESCRIPTION
# Fix Typo

## The Problem
When outputting chapter information within the toString() call, there was a typo meaning "start offset" was printed for both the start and end offsets.

## The Solution
I've changed it to "end offset" where appropriate.