### PR TITLE
Move cmake_minimum_required at the top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(taglib)
-
 cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
+
+project(taglib)
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 2.8.12)
   cmake_policy(SET CMP0022 OLD)


### PR DESCRIPTION
`cmake_minimum_required()` command must be at the beginning of the top-level CMakeLists.txt file even before calling the `project()` command, [proof](https://cmake.org/cmake/help/v3.3/command/cmake_minimum_required.html).