### PR TITLE
Fix defect in ByteVectorStream::seek when Position==End.

### DIFF
--- a/taglib/toolkit/tbytevectorstream.cpp
+++ b/taglib/toolkit/tbytevectorstream.cpp
@@ -137,7 +137,7 @@ void ByteVectorStream::seek(long offset, Position p)
     d->position += offset;
     break;
   case End:
-    d->position = length() - offset;
+    d->position = length() + offset; // offset is expected to be negative
     break;
   }
 }

--- a/tests/test_bytevectorstream.cpp
+++ b/tests/test_bytevectorstream.cpp
@@ -38,6 +38,7 @@ class TestByteVectorStream : public CppUnit::TestFixture
   CPPUNIT_TEST(testReadBlock);
   CPPUNIT_TEST(testRemoveBlock);
   CPPUNIT_TEST(testInsert);
+  CPPUNIT_TEST(testSeekEnd);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -110,6 +111,19 @@ public:
     CPPUNIT_ASSERT_EQUAL(ByteVector("yyxfoa"), *stream.data());
     stream.insert(ByteVector("123"), 3, 0);
     CPPUNIT_ASSERT_EQUAL(ByteVector("yyx123foa"), *stream.data());
+  }
+
+  void testSeekEnd()
+  {
+    ByteVector v("abcdefghijklmnopqrstuvwxyz");
+    ByteVectorStream stream(v);
+    CPPUNIT_ASSERT_EQUAL(26L, stream.length());
+
+    stream.seek(-4, IOStream::End);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("w"), stream.readBlock(1));
+
+    stream.seek(-25, IOStream::End);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("b"), stream.readBlock(1));
   }
 
 };


### PR DESCRIPTION
This fixes the problem described in my e-mail to the development list ("Possible bug in MPEG::File::strip"). The bug in ByteVectorStream::seek() caused MPEG::File to not detect any present ID3v1 tag whenever it was using a ByteVectorStream as input. So strip() wasn't even aware of the tag's existence.