### PR TITLE
String::substr optimization

### DIFF
--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -447,7 +447,10 @@ bool String::startsWith(const String &s) const
 
 String String::substr(unsigned int position, unsigned int n) const
 {
-  return String(d->data.substr(position, n));
+  if(position == 0 && n == size())
+    return *this;
+  else
+    return String(d->data.substr(position, n));
 }
 
 String &String::append(const String &s)

--- a/tests/test_string.cpp
+++ b/tests/test_string.cpp
@@ -112,6 +112,9 @@ public:
     CPPUNIT_ASSERT(String("  foo  ").stripWhiteSpace() == String("foo"));
     CPPUNIT_ASSERT(String("foo    ").stripWhiteSpace() == String("foo"));
     CPPUNIT_ASSERT(String("    foo").stripWhiteSpace() == String("foo"));
+    CPPUNIT_ASSERT(String("foo").stripWhiteSpace() == String("foo"));
+    CPPUNIT_ASSERT(String("f o o").stripWhiteSpace() == String("f o o"));
+    CPPUNIT_ASSERT(String(" f o o ").stripWhiteSpace() == String("f o o"));
 
     CPPUNIT_ASSERT(memcmp(String("foo").data(String::Latin1).data(), "foo", 3) == 0);
     CPPUNIT_ASSERT(memcmp(String("f").data(String::Latin1).data(), "f", 1) == 0);


### PR DESCRIPTION
Optimize `String::substr` when returning itself as a substring (i.e. returning whole string).

Use copy ctor to return in a case whole string is being returned.

The intention was to optimize `String::stripWhiteSpace` for no-strip case (without any leading or trailing white space removal).
`copyFromUTF16` was used in any case previously and allocated duplicate buffer for the same string - no implicit sharing.
