### PR TITLE
Fixes #743 by not overwriting existing Xiph comment in FLAC::File::save

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -168,8 +168,9 @@ bool FLAC::File::save()
   }
 
   // Create new vorbis comments
-
-  Tag::duplicate(&d->tag, xiphComment(true), false);
+  if (!hasXiphComment())
+    Tag::duplicate(&d->tag, xiphComment(true), false);
+  
 
   d->xiphCommentData = xiphComment()->render(false);
 


### PR DESCRIPTION
IMHO this fix is okay but I'd like someone with better understanding of the `FLAC::File` internals to review it before merging.

Thanks,
Michael