### PR TITLE
Fixed incorrect handling of MP4 tags when using wstrings

### DIFF
--- a/taglib/mp4/mp4item.cpp
+++ b/taglib/mp4/mp4item.cpp
@@ -23,8 +23,6 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#include "config.h"
-
 #include "taglib.h"
 #include "tdebug.h"
 #include "tsmartptr.h"

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -835,16 +835,16 @@ MP4::Tag::setPictures(const PictureMap &l)
         ++pictureListIt) {
       Picture picture = *pictureListIt;
       CoverArt::Format format;
-      const char *mime = picture.mime().toCString();
-      if(std::strcmp("image/", mime) == 0)
+	  String mime = picture.mime();
+      if(String("image/") == mime)
         format = CoverArt::Unknown;
-      else if(std::strcmp("image/bmp", mime) == 0)
+      else if(String("image/bmp") == mime)
         format = CoverArt::BMP;
-      else if(std::strcmp("image/png", mime) == 0)
+      else if(String("image/png") == mime)
         format = CoverArt::PNG;
-      else if(std::strcmp("image/gif", mime) == 0)
+      else if(String("image/gif") == mime)
         format = CoverArt::GIF;
-      else if(std::strcmp("image/jpeg", mime) == 0)
+      else if(String("image/jpeg") == mime)
         format = CoverArt::JPEG;
       else
         format = CoverArt::Unknown;

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -835,7 +835,7 @@ MP4::Tag::setPictures(const PictureMap &l)
         ++pictureListIt) {
       Picture picture = *pictureListIt;
       CoverArt::Format format;
-	    String mime = picture.mime();
+      String mime = picture.mime();
       if(String("image/") == mime)
         format = CoverArt::Unknown;
       else if(String("image/bmp") == mime)

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -835,7 +835,7 @@ MP4::Tag::setPictures(const PictureMap &l)
         ++pictureListIt) {
       Picture picture = *pictureListIt;
       CoverArt::Format format;
-	  String mime = picture.mime();
+	    String mime = picture.mime();
       if(String("image/") == mime)
         format = CoverArt::Unknown;
       else if(String("image/bmp") == mime)


### PR DESCRIPTION
Fixed errors occurring when saving pictures to mp4 containers when taglib is compiled to use wstrings.