### PR TITLE
Enable ByteVectorStream to work with FileRef

### DIFF
--- a/taglib/toolkit/tbytevectorstream.cpp
+++ b/taglib/toolkit/tbytevectorstream.cpp
@@ -23,38 +23,40 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#include "tbytevectorstream.h"
+#include <cstring>
+#include <cstdlib>
+
 #include "tstring.h"
 #include "tdebug.h"
-
-#include <stdio.h>
-#include <string.h>
-
-#include <stdlib.h>
+#include "tfilenamehandle.h"
+#include "tbytevectorstream.h"
 
 using namespace TagLib;
 
 class ByteVectorStream::ByteVectorStreamPrivate
 {
 public:
-  ByteVectorStreamPrivate(const ByteVector &data);
+  ByteVectorStreamPrivate(const ByteVector &data, FileName name) :
+    data(data),
+    name(name),
+    position(0) {}
 
-  ByteVector data;
-  long position;
+  ByteVector     data;
+  FileNameHandle name;
+  long           position;
 };
-
-ByteVectorStream::ByteVectorStreamPrivate::ByteVectorStreamPrivate(const ByteVector &data) :
-  data(data),
-  position(0)
-{
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
 ByteVectorStream::ByteVectorStream(const ByteVector &data) :
-  d(new ByteVectorStreamPrivate(data))
+  d(new ByteVectorStreamPrivate(data, ""))
+{
+}
+
+TagLib::ByteVectorStream::ByteVectorStream(const ByteVector &data, FileName fileName) :
+  d(new ByteVectorStreamPrivate(data, fileName))
 {
 }
 
@@ -65,7 +67,7 @@ ByteVectorStream::~ByteVectorStream()
 
 FileName ByteVectorStream::name() const
 {
-  return FileName(""); // XXX do we need a name?
+  return d->name;
 }
 
 ByteVector ByteVectorStream::readBlock(unsigned long length)

--- a/taglib/toolkit/tbytevectorstream.h
+++ b/taglib/toolkit/tbytevectorstream.h
@@ -43,10 +43,17 @@ namespace TagLib {
   {
   public:
     /*!
-     * Construct a File object and opens the \a file.  \a file should be a
-     * be a C-string in the local file system encoding.
+     * Construct an in-memory stream based on \a data.
      */
+    // BIC: Merge with the constructor below.
     ByteVectorStream(const ByteVector &data);
+
+    /*!
+     * Construct an in-memory stream based on \a data and \a fileName.
+     *
+     * \note FileRef requires ByteVectorStream to hold a file name to work with.
+     */
+    ByteVectorStream(const ByteVector &data, FileName fileName);
 
     /*!
      * Destroys this ByteVectorStream instance.

--- a/taglib/toolkit/tfilenamehandle.h
+++ b/taglib/toolkit/tfilenamehandle.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+    copyright            : (C) 2017 by Tsuda Kageyu
+    email                : tsuda.kageyu@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_TFILENAMEHANDLE_H
+#define TAGLIB_TFILENAMEHANDLE_H
+
+// THIS FILE IS NOT A PART OF THE TAGLIB API
+
+#ifndef DO_NOT_DOCUMENT  // tell Doxygen not to document this header
+
+#ifndef _WIN32
+# include <string>
+#endif
+
+#include <tiostream.h>
+
+namespace TagLib
+{
+  namespace
+  {
+#ifdef _WIN32
+
+    typedef FileName FileNameHandle;
+
+#else
+
+    class FileNameHandle
+    {
+    private:
+      const std::string name;
+    public:
+      FileNameHandle(FileName name) : name(name) {}
+      operator FileName() const { return name.c_str(); }
+    };
+
+#endif
+  }
+}
+
+#endif
+
+#endif

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -83,12 +83,6 @@ namespace
 
 #else   // _WIN32
 
-  struct FileNameHandle : public std::string
-  {
-    FileNameHandle(FileName name) : std::string(name) {}
-    operator FileName () const { return c_str(); }
-  };
-
   typedef FILE* FileHandle;
 
   const FileHandle InvalidFileHandle = 0;

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -23,16 +23,17 @@
  *   http://www.mozilla.org/MPL/                                           *
  ***************************************************************************/
 
-#include "tfilestream.h"
-#include "tstring.h"
-#include "tdebug.h"
-
 #ifdef _WIN32
 # include <windows.h>
 #else
 # include <stdio.h>
 # include <unistd.h>
 #endif
+
+#include "tstring.h"
+#include "tdebug.h"
+#include "tfilenamehandle.h"
+#include "tfilestream.h"
 
 using namespace TagLib;
 
@@ -42,7 +43,6 @@ namespace
 
   // Uses Win32 native API instead of POSIX API to reduce the resource consumption.
 
-  typedef FileName FileNameHandle;
   typedef HANDLE FileHandle;
 
   const FileHandle InvalidFileHandle = INVALID_HANDLE_VALUE;

--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -39,9 +39,10 @@
 #include <wavfile.h>
 #include <apefile.h>
 #include <aifffile.h>
+#include <tfilestream.h>
+#include <tbytevectorstream.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
-#include <tfilestream.h>
 
 using namespace std;
 using namespace TagLib;
@@ -129,9 +130,68 @@ public:
       CPPUNIT_ASSERT_EQUAL(f.tag()->track(), (unsigned int)7);
       CPPUNIT_ASSERT_EQUAL(f.tag()->year(), (unsigned int)2080);
     }
+
     {
       FileStream fs(newname.c_str());
       FileRef f(&fs);
+      CPPUNIT_ASSERT(dynamic_cast<T*>(f.file()));
+      CPPUNIT_ASSERT(!f.isNull());
+      CPPUNIT_ASSERT_EQUAL(f.tag()->artist(), String("ttest artist"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->title(), String("ytest title"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->genre(), String("uTest!"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->album(), String("ialbummmm"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->track(), (unsigned int)7);
+      CPPUNIT_ASSERT_EQUAL(f.tag()->year(), (unsigned int)2080);
+      f.tag()->setArtist("test artist");
+      f.tag()->setTitle("test title");
+      f.tag()->setGenre("Test!");
+      f.tag()->setAlbum("albummmm");
+      f.tag()->setTrack(5);
+      f.tag()->setYear(2020);
+      f.save();
+    }
+
+    ByteVector fileContent;
+    {
+      FileStream fs(newname.c_str());
+      FileRef f(&fs);
+      CPPUNIT_ASSERT(dynamic_cast<T*>(f.file()));
+      CPPUNIT_ASSERT(!f.isNull());
+      CPPUNIT_ASSERT_EQUAL(f.tag()->artist(), String("test artist"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->title(), String("test title"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->genre(), String("Test!"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->album(), String("albummmm"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->track(), (unsigned int)5);
+      CPPUNIT_ASSERT_EQUAL(f.tag()->year(), (unsigned int)2020);
+
+      fs.seek(0);
+      fileContent = fs.readBlock(fs.length());
+    }
+
+    {
+      ByteVectorStream bs(fileContent, newname.c_str());
+      FileRef f(&bs);
+      CPPUNIT_ASSERT(dynamic_cast<T*>(f.file()));
+      CPPUNIT_ASSERT(!f.isNull());
+      CPPUNIT_ASSERT_EQUAL(f.tag()->artist(), String("test artist"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->title(), String("test title"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->genre(), String("Test!"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->album(), String("albummmm"));
+      CPPUNIT_ASSERT_EQUAL(f.tag()->track(), (unsigned int)5);
+      CPPUNIT_ASSERT_EQUAL(f.tag()->year(), (unsigned int)2020);
+      f.tag()->setArtist("ttest artist");
+      f.tag()->setTitle("ytest title");
+      f.tag()->setGenre("uTest!");
+      f.tag()->setAlbum("ialbummmm");
+      f.tag()->setTrack(7);
+      f.tag()->setYear(2080);
+      f.save();
+
+      fileContent = *bs.data();
+    }
+    {
+      ByteVectorStream bs(fileContent, newname.c_str());
+      FileRef f(&bs);
       CPPUNIT_ASSERT(dynamic_cast<T*>(f.file()));
       CPPUNIT_ASSERT(!f.isNull());
       CPPUNIT_ASSERT_EQUAL(f.tag()->artist(), String("ttest artist"));


### PR DESCRIPTION
This will fix #796.
`FileRef` requires a file extension to determine the file type, but `ByteVectorStream` can't hold a file name.
This PR enables `ByteVectorStream` to take and hold a file name via its constructor.