### PR TITLE
Added setProperties implementation to TagUnion

### DIFF
--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -125,7 +125,8 @@ namespace TagLib
     std::vector<PropertyMap> returnCandidates;
     for (size_t i = 0; i < COUNT; ++i) {
       if (d->tags[i])
-        returnCandidates.insert(returnCandidates.end(), d->tags[i]->setProperties(properties));
+        returnCandidates.insert(returnCandidates.end(),
+          d->tags[i]->setProperties(properties));
     }
 
     if (!returnCandidates.empty()) {
@@ -134,10 +135,14 @@ namespace TagLib
         return returnCandidates.front();
       }
 
-      //Multiple tags in union: if a property has been assigned in any member tag, remove it from ignored properties to return
+      //Multiple tags in union:
+      //if a property has been assigned in any member tag
+      //remove it from ignored properties to return
       PropertyMap propertiesCopy(properties);
-      for (std::vector<PropertyMap>::iterator i = returnCandidates.begin(); i != returnCandidates.end(); i++) {
-        for (PropertyMap::Iterator j = propertiesCopy.begin(); j != propertiesCopy.end();) {
+      for (std::vector<PropertyMap>::iterator i = returnCandidates.begin();
+        i != returnCandidates.end(); i++) {
+        for (PropertyMap::Iterator j = propertiesCopy.begin();
+          j != propertiesCopy.end();) {
           if (!i->contains(j->first)) {
             j = propertiesCopy.erase(j->first).begin();
           }
@@ -148,7 +153,8 @@ namespace TagLib
       }
     }
 
-    //No assignments made by union member tags. Return input (this should not happen)
+    //No assignments made by union member tags.
+    //Return input (this should not happen)
     return properties;
   }
 

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -122,7 +122,7 @@ namespace TagLib
   PropertyMap TagUnion<COUNT>::setProperties(const PropertyMap &properties)
   {
     //Record unassigned properties for each tag in the union
-    std::vector<PropertyMap> returnCandidates();
+    std::vector<PropertyMap> returnCandidates;
     for (size_t i = 0; i < COUNT; ++i) {
       if (d->tags[i])
         returnCandidates.insert(returnCandidates.end(), d->tags[i]->setProperties(properties));

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -122,7 +122,7 @@ namespace TagLib
   PropertyMap TagUnion<COUNT>::setProperties(const PropertyMap &properties)
   {
     //Record unassigned properties for each tag in the union
-    std::vector<PropertyMap> returnCandidates(COUNT);
+    std::vector<PropertyMap> returnCandidates();
     for (size_t i = 0; i < COUNT; ++i) {
       if (d->tags[i])
         returnCandidates.insert(returnCandidates.end(), d->tags[i]->setProperties(properties));
@@ -136,11 +136,13 @@ namespace TagLib
 
       //Multiple tags in union: if a property has been assigned in any member tag, remove it from ignored properties to return
       PropertyMap propertiesCopy(properties);
-      for (PropertyMap::Iterator i = propertiesCopy.begin(); i != propertiesCopy.end(); i++) {
-        for (auto j : returnCandidates) {
-          if (j.contains(i->first)) {
-            i = propertiesCopy.erase(i->first).begin();
-            continue;
+      for (std::vector<PropertyMap>::iterator i = returnCandidates.begin(); i != returnCandidates.end(); i++) {
+        for (PropertyMap::Iterator j = propertiesCopy.begin(); j != propertiesCopy.end();) {
+          if (!i->contains(j->first)) {
+            j = propertiesCopy.erase(j->first).begin();
+          }
+          else {
+            j++;
           }
         }
       }

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -58,8 +58,8 @@ namespace TagLib {
     void set(size_t index, Tag *tag);
 
     virtual PropertyMap properties() const;
-
     virtual void removeUnsupportedProperties(const StringList& properties);
+    virtual PropertyMap setProperties(const PropertyMap& properties);
 
     virtual String title() const;
     virtual String artist() const;


### PR DESCRIPTION
Added setProperties implementation to TagUnion.

It works by calling setProperties  on each tag making up the union and returns only the properties unsupported by all member tags as unsupported.

This allows many commonly supported properties that are not part of the base Tag class accessors (AlbumArtist for example) to be read and written.