### PR TITLE
Add taglib_default_file_extensions() to C bindings

### DIFF
--- a/bindings/c/tag_c.cpp
+++ b/bindings/c/tag_c.cpp
@@ -50,6 +50,8 @@ namespace
   bool unicodeStrings = true;
   bool stringManagementEnabled = true;
 
+  const StringList defaultFileExtensions = FileRef::defaultFileExtensions();
+
   char *stringToCharArray(const String &s)
   {
     const std::string str = s.to8Bit(unicodeStrings);
@@ -289,6 +291,16 @@ int taglib_audioproperties_channels(const TagLib_AudioProperties *audioPropertie
 {
   const AudioProperties *p = reinterpret_cast<const AudioProperties *>(audioProperties);
   return p->channels();
+}
+
+const char **taglib_default_file_extensions(unsigned int *size)
+{
+  *size = defaultFileExtensions.size();
+  const char** dest = (const char**)malloc(*size * sizeof(char*));
+  for(unsigned int i = 0; i < *size; ++i) {
+      dest[i] = defaultFileExtensions[i].toCString();
+  }
+  return dest;
 }
 
 void taglib_id3v2_set_default_text_encoding(TagLib_ID3v2_Encoding encoding)

--- a/bindings/c/tag_c.h
+++ b/bindings/c/tag_c.h
@@ -275,6 +275,13 @@ TAGLIB_C_EXPORT int taglib_audioproperties_samplerate(const TagLib_AudioProperti
  */
 TAGLIB_C_EXPORT int taglib_audioproperties_channels(const TagLib_AudioProperties *audioProperties);
 
+/*!
+ * Returns the list of file extensions that are used by default.
+ *
+ * \note This array of strings should be freed using taglib_free().
+ */
+TAGLIB_C_EXPORT const char **taglib_default_file_extensions(unsigned int *size);
+
 /*******************************************************************************
  * Special convenience ID3v2 functions
  *******************************************************************************/


### PR DESCRIPTION
This PR add `taglib_default_file_extensions()` to the C bindings (see #814). I think this function may  be useful to check if a file is supported by TagLib without having to open and read the file.