### PR TITLE
Add direct support for "rate" atom

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -74,7 +74,7 @@ MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms) :
             atom->name == "hdvd" || atom->name == "shwm") {
       parseBool(atom);
     }
-    else if(atom->name == "tmpo" || atom->name == "\251mvi" || atom->name == "\251mvc") {
+    else if(atom->name == "tmpo" || atom->name == "rate" || atom->name == "\251mvi" || atom->name == "\251mvc") {
       parseInt(atom);
     }
     else if(atom->name == "tvsn" || atom->name == "tves" || atom->name == "cnID" ||
@@ -476,7 +476,7 @@ MP4::Tag::save()
             name == "shwm") {
       data.append(renderBool(name.data(String::Latin1), it->second));
     }
-    else if(name == "tmpo" || name == "\251mvi" || name == "\251mvc") {
+    else if(name == "tmpo" || name == "rate" || name == "\251mvi" || name == "\251mvc") {
       data.append(renderInt(name.data(String::Latin1), it->second));
     }
     else if(name == "tvsn" || name == "tves" || name == "cnID" ||


### PR DESCRIPTION
Although the rate atom is technically unnofficial, it is widely supported with the standard form of using integers 0-100 and dividing by 20 to get a 5 star rating. Previously attempts to write this tag would fail by trying to treat this atom as general text. This treats the atom as an integer during both reading and writing.

Resolves #817