### PR TITLE
Fix WinRT configuring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ option(BUILD_BINDINGS "Build the bindings" ON)
 
 option(NO_ITUNES_HACKS "Disable workarounds for iTunes bugs" OFF)
 
+option(PLATFORM_WINRT "Enable WinRT support" OFF)
+if(PLATFORM_WINRT)
+  add_definitions(-DPLATFORM_WINRT)
+endif()
+
 add_definitions(-DHAVE_CONFIG_H)
 set(TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests/")
 

--- a/ConfigureChecks.cmake
+++ b/ConfigureChecks.cmake
@@ -209,3 +209,7 @@ if(BUILD_TESTS AND NOT BUILD_SHARED_LIBS)
   endif()
 endif()
 
+# Detect WinRT mode
+if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+	set(PLATFORM WINRT 1)
+endif()

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -51,7 +51,7 @@ namespace
   {
     const DWORD access = readOnly ? GENERIC_READ : (GENERIC_READ | GENERIC_WRITE);
 
-#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)
+#if defined (PLATFORM_WINRT)
     return CreateFile2(path.wstr().c_str(), access, FILE_SHARE_READ, OPEN_EXISTING, NULL);
 #else
     return CreateFileW(path.wstr().c_str(), access, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);


### PR DESCRIPTION
Don't rely on `_WIN32_WINNT` value to enable WinRT support.

if _WIN32_WINNT is not set manually, it is defaulted to SDK version. So if you use SDK > 8 you cannot use TagLib under Win7 and lower because of `CreateFile2` function dependency.

`PLATFORM_WINRT` option (`OFF` by default) was introduced to enable WinRT build.

Related issues: https://github.com/Microsoft/vcpkg/issues/1240