### PR TITLE
Crash when loading an empty mpeg file

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -108,10 +108,8 @@ bool MPEG::File::isSupported(IOStream *stream)
   long headerOffset;
   const ByteVector buffer = Utils::readHeader(stream, bufferSize(), true, &headerOffset);
 
-  if (buffer.isEmpty())
-  {
-	   return false;
-  }
+  if(buffer.isEmpty())
+	  return false;
   
   const long originalPosition = stream->tell();
   AdapterFile file(stream);

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -108,6 +108,11 @@ bool MPEG::File::isSupported(IOStream *stream)
   long headerOffset;
   const ByteVector buffer = Utils::readHeader(stream, bufferSize(), true, &headerOffset);
 
+  if (buffer.isEmpty())
+  {
+	  return false;
+  }
+  
   const long originalPosition = stream->tell();
   AdapterFile file(stream);
 

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -110,7 +110,7 @@ bool MPEG::File::isSupported(IOStream *stream)
 
   if (buffer.isEmpty())
   {
-	  return false;
+	   return false;
   }
   
   const long originalPosition = stream->tell();


### PR DESCRIPTION
This is not really  a question. When loading an empty (empty.txt -> empty.mp3 ), program will crash.
buffer.size() is 0, then buffer.size() - 1 is undefined (unsigned int).