### PR TITLE
taglib: fix test build failure on powerpc/c++11

### DIFF
--- a/tests/test_synchdata.cpp
+++ b/tests/test_synchdata.cpp
@@ -75,8 +75,8 @@ public:
 
   void testToUIntBroken()
   {
-    char data[] = { 0, 0, 0, -1 };
-    char data2[] = { 0, 0, -1, -1 };
+    char data[] = { 0, 0, 0, (char)-1 };
+    char data2[] = { 0, 0, (char)-1, (char)-1 };
 
     CPPUNIT_ASSERT_EQUAL((unsigned int)255, ID3v2::SynchData::toUInt(ByteVector(data, 4)));
     CPPUNIT_ASSERT_EQUAL((unsigned int)65535, ID3v2::SynchData::toUInt(ByteVector(data2, 4)));
@@ -84,7 +84,7 @@ public:
 
   void testToUIntBrokenAndTooLarge()
   {
-    char data[] = { 0, 0, 0, -1, 0 };
+    char data[] = { 0, 0, 0, (char)-1, 0 };
     ByteVector v(data, 5);
 
     CPPUNIT_ASSERT_EQUAL((unsigned int)255, ID3v2::SynchData::toUInt(v));


### PR DESCRIPTION
powerpc is a platform with 'char' == 'unsigned char'.
As a result '-1' is not expressible in char and build fails as:

```
    # '-funsigned-char' to force test build failure on other platforms
    $ cmake .. -DBUILD_TESTS=YES -DCMAKE_CXX_FLAGS="-O2 -funsigned-char" -DCMAKE_C_FLAGS="-O2 -funsigned-char"
    ...
    $ make check
    tests/test_synchdata.cpp: In member function 'void TestID3v2SynchData::testToUIntBroken()':
    tests/test_synchdata.cpp:78:33: error: narrowing conversion of '-1' from 'int' to 'char' inside { } [-Wnarrowing]
     char data[] = { 0, 0, 0, -1 };
                                 ^
```

The fix is to expliticly cast -1 to 'char'.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>