### PR TITLE
Added virtual destructor for FileTypeResolver which is an abstract class

### DIFF
--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -355,6 +355,8 @@ const FileRef::FileTypeResolver *FileRef::addFileTypeResolver(const FileRef::Fil
   return resolver;
 }
 
+FileRef::FileTypeResolver::~FileTypeResolver() { }
+
 StringList FileRef::defaultFileExtensions()
 {
   StringList l;

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -106,6 +106,7 @@ namespace TagLib {
                                bool readAudioProperties = true,
                                AudioProperties::ReadStyle
                                audioPropertiesStyle = AudioProperties::Average) const = 0;
+      virtual ~FileTypeResolver();
     };
 
     /*!


### PR DESCRIPTION
`FileRef::FileTypeResolver` is an abstract class with a pure virtual function but the destructor isn't marked virtual.

I have added a virtual destructor but haven't made it pure virtual so the deriving classes have the option of implementing a destructor and are not forced to define a destructor.