### PR TITLE
Don't list the description twice in `UserTextIdentificationFrame::toString()`

### DIFF
--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -339,7 +339,13 @@ UserTextIdentificationFrame::UserTextIdentificationFrame(const String &descripti
 
 String UserTextIdentificationFrame::toString() const
 {
-  return "[" + description() + "] " + fieldList().toString();
+  // first entry is the description itself, drop from values list
+  StringList l = fieldList();
+  for(StringList::Iterator it = l.begin(); it != l.end(); ++it) {
+    l.erase(it);
+    break;
+  }
+  return "[" + description() + "] " + l.toString();
 }
 
 String UserTextIdentificationFrame::description() const


### PR DESCRIPTION
Before:

```
$ ./examples/framelist ../tests/data/rare_frames.mp3 
******************** "../tests/data/rare_frames.mp3"********************
ID3v2.4.0, 997 bytes in tag
COMM - "A COMMENT"
TXXX - "[userTextDescription1] userTextDescription1 userTextData1 userTextData2"
TXXX - "[QuodLibet::userTextDescription2] QuodLibet::userTextDescription2 userTextData1 userTextData2"
TCON - "13"
WXXX - "[userUrl] http://a.user.url"
WXXX - "[] http://a.user.url/with/empty/description"
```

After:

```
$ ./examples/framelist ../tests/data/rare_frames.mp3 
******************** "../tests/data/rare_frames.mp3"********************
ID3v2.4.0, 997 bytes in tag
COMM - "A COMMENT"
TXXX - "[userTextDescription1] userTextData1 userTextData2"
TXXX - "[QuodLibet::userTextDescription2] userTextData1 userTextData2"
TCON - "13"
WXXX - "[userUrl] http://a.user.url"
WXXX - "[] http://a.user.url/with/empty/description"
```