### PR TITLE
fix reading audioproperties for broken mp3 files

### DIFF
--- a/taglib/mpeg/mpegproperties.cpp
+++ b/taglib/mpeg/mpegproperties.cpp
@@ -200,13 +200,14 @@ void MPEG::Properties::read(File *file)
     const long lastFrameOffset = file->lastFrameOffset();
     if(lastFrameOffset < 0) {
       debug("MPEG::Properties::read() -- Could not find an MPEG frame in the stream.");
-      return;
     }
-
-    const Header lastHeader(file, lastFrameOffset, false);
-    const long streamLength = lastFrameOffset - firstFrameOffset + lastHeader.frameLength();
-    if(streamLength > 0)
-      d->length = static_cast<int>(streamLength * 8.0 / d->bitrate + 0.5);
+    else
+    {
+      const Header lastHeader(file, lastFrameOffset, false);
+      const long streamLength = lastFrameOffset - firstFrameOffset + lastHeader.frameLength();
+      if (streamLength > 0)
+        d->length = static_cast<int>(streamLength * 8.0 / d->bitrate + 0.5);
+    }
   }
 
   d->sampleRate        = firstHeader.sampleRate();


### PR DESCRIPTION
Do not ran away if we cannot find last frame, still export info we've got

Test file: https://yadi.sk/d/BXPDT2jB3SwrUg