### PR TITLE
Fixed OOB read when loading invalid ogg flac file. (#868)

### DIFF
--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -231,11 +231,21 @@ void Ogg::FLAC::File::scan()
 
   if(!metadataHeader.startsWith("fLaC"))  {
     // FLAC 1.1.2+
+    // See https://xiph.org/flac/ogg_mapping.html for the header specification.
+    if(metadataHeader.size() < 13)
+      return;
+
+    if(metadataHeader[0] != 0x7f)
+      return;
+
     if(metadataHeader.mid(1, 4) != "FLAC")
       return;
 
-    if(metadataHeader[5] != 1)
-      return; // not version 1
+    if(metadataHeader[5] != 1 && metadataHeader[6] != 0)
+      return; // not version 1.0
+
+    if(metadataHeader.mid(9, 4) != "fLaC")
+      return;
 
     metadataHeader = metadataHeader.mid(13);
   }


### PR DESCRIPTION
Took a stab at fixing CVE-2018-11439 and (#868). Would appreciate an experience taglib developer reviewing this. First time looking at the FLAC - ogg mapping and working on taglib here, so I might have incorrectly interpreted the header or other taglib conventions.