### PR TITLE
Add BPM read-only information to "generic" interface and C bindings

### DIFF
--- a/bindings/c/tag_c.cpp
+++ b/bindings/c/tag_c.cpp
@@ -210,6 +210,12 @@ unsigned int taglib_tag_track(const TagLib_Tag *tag)
   const Tag *t = reinterpret_cast<const Tag *>(tag);
   return t->track();
 }
+ 
+unsigned int taglib_tag_bpm(const TagLib_Tag *tag)
+{
+  const Tag *t = reinterpret_cast<const Tag *>(tag);
+  return t->bpm();
+}
 
 void taglib_tag_set_title(TagLib_Tag *tag, const char *title)
 {

--- a/bindings/c/tag_c.h
+++ b/bindings/c/tag_c.h
@@ -202,6 +202,12 @@ TAGLIB_C_EXPORT unsigned int taglib_tag_year(const TagLib_Tag *tag);
 TAGLIB_C_EXPORT unsigned int taglib_tag_track(const TagLib_Tag *tag);
 
 /*!
+ * Returns the beats-per-minute (bpm) of the track; if there is no bpm 
+ * set, or bpm tag in the metadata, this will return 0.
+ */ 
+TAGLIB_C_EXPORT unsigned int taglib_tag_bpm(const TagLib_Tag *tag); 
+
+/*!
  * Sets the tag's title.
  *
  * \note By default this string should be UTF8 encoded.

--- a/examples/tagreader_c.c
+++ b/examples/tagreader_c.c
@@ -59,6 +59,7 @@ int main(int argc, char *argv[])
       printf("year    - \"%i\"\n", taglib_tag_year(tag));
       printf("comment - \"%s\"\n", taglib_tag_comment(tag));
       printf("track   - \"%i\"\n", taglib_tag_track(tag));
+      printf("bpm     - \"%i\"\n", taglib_tag_bpm(tag));
       printf("genre   - \"%s\"\n", taglib_tag_genre(tag));
     }
 

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -167,7 +167,7 @@ unsigned int APE::Tag::track() const
 
 unsigned int APE::Tag::bpm() const 
 { 
-  // TODO: proper bpm information 
+  // APE tags don't implement BPM information
   return 0;
 }
 

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -165,6 +165,12 @@ unsigned int APE::Tag::track() const
   return d->itemListMap["TRACK"].toString().toInt();
 }
 
+unsigned int APE::Tag::bpm() const 
+{ 
+  // TODO: proper bpm information 
+  return 0;
+}
+
 void APE::Tag::setTitle(const String &s)
 {
   addValue("TITLE", s, true);

--- a/taglib/ape/apetag.h
+++ b/taglib/ape/apetag.h
@@ -94,6 +94,7 @@ namespace TagLib {
       virtual String genre() const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
+      virtual unsigned int bpm() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -103,6 +103,12 @@ unsigned int ASF::Tag::track() const
   return 0;
 }
 
+unsigned int ASF::Tag::bpm() const 
+{ 
+  // TODO: proper bpm information 
+  return 0;
+}
+
 String ASF::Tag::genre() const
 {
   if(d->attributeListMap.contains("WM/Genre"))

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -105,7 +105,8 @@ unsigned int ASF::Tag::track() const
 
 unsigned int ASF::Tag::bpm() const 
 { 
-  // TODO: proper bpm information 
+  if(d->attributeListMap.contains("WM/BeatsPerMinute"))
+    return d->attributeListMap["WM/BeatsPerMinute"][0].toUInt();
   return 0;
 }
 

--- a/taglib/asf/asftag.h
+++ b/taglib/asf/asftag.h
@@ -99,6 +99,12 @@ namespace TagLib {
       virtual unsigned int track() const;
 
       /*!
+       * Returns the beats-per-minute (bpm) of the track; if there is no bpm 
+       * set, or bpm tag in the metadata, this will return 0.
+       */ 
+      virtual unsigned int bpm() const; 
+
+      /*!
        * Sets the title to \a s.
        */
       virtual void setTitle(const String &s);

--- a/taglib/mod/modtag.cpp
+++ b/taglib/mod/modtag.cpp
@@ -89,6 +89,11 @@ unsigned int Mod::Tag::track() const
   return 0;
 }
 
+unsigned int Mod::Tag::bpm() const
+{
+  return 0;
+}
+
 String Mod::Tag::trackerName() const
 {
   return d->trackerName;

--- a/taglib/mod/modtag.h
+++ b/taglib/mod/modtag.h
@@ -89,6 +89,11 @@ namespace TagLib {
       virtual unsigned int track() const;
 
       /*!
+       * Not supported by module files. Therefore always return 0.
+       */
+      virtual unsigned int bpm() const; 
+
+      /*!
        * Returns the name of the tracker used to create/edit the module file.
        * Only XM files store this tag to the file as such, for other formats
        * (Mod, S3M, IT) this is derived from the file type or the flavour of

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -751,6 +751,13 @@ MP4::Tag::track() const
   return 0;
 }
 
+unsigned int 
+MP4::Tag::bpm() const
+{
+  // TODO: proper bpm information 
+  return 0;
+}
+
 void
 MP4::Tag::setTitle(const String &value)
 {

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -754,7 +754,8 @@ MP4::Tag::track() const
 unsigned int 
 MP4::Tag::bpm() const
 {
-  // TODO: proper bpm information 
+  if(d->items.contains("tmpo"))
+    return d->items["tmpo"].toIntPair().first;
   return 0;
 }
 

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -60,6 +60,7 @@ namespace TagLib {
         virtual String genre() const;
         virtual unsigned int year() const;
         virtual unsigned int track() const;
+        virtual unsigned int bpm() const;
 
         virtual void setTitle(const String &value);
         virtual void setArtist(const String &value);

--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -162,6 +162,11 @@ unsigned int ID3v1::Tag::track() const
   return d->track;
 }
 
+unsigned int ID3v1::Tag::bpm() const { 
+  // TODO: proper bpm information 
+  return 0;
+}
+
 void ID3v1::Tag::setTitle(const String &s)
 {
   d->title = s;

--- a/taglib/mpeg/id3v1/id3v1tag.h
+++ b/taglib/mpeg/id3v1/id3v1tag.h
@@ -142,6 +142,7 @@ namespace TagLib {
       virtual String genre() const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
+      virtual unsigned int bpm() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -228,6 +228,11 @@ unsigned int ID3v2::Tag::track() const
   return 0;
 }
 
+unsigned int ID3v2::Tag::bpm() const { 
+  // TODO: proper bpm information 
+  return 0;
+}
+
 void ID3v2::Tag::setTitle(const String &s)
 {
   setTextFrame("TIT2", s);

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -229,7 +229,8 @@ unsigned int ID3v2::Tag::track() const
 }
 
 unsigned int ID3v2::Tag::bpm() const { 
-  // TODO: proper bpm information 
+  if(!d->frameListMap["TBPM"].isEmpty())
+    return d->frameListMap["TBPM"].front()->toString().toInt();
   return 0;
 }
 

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -171,6 +171,7 @@ namespace TagLib {
       virtual String genre() const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
+      virtual unsigned int bpm() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -139,6 +139,12 @@ unsigned int Ogg::XiphComment::track() const
   return 0;
 }
 
+unsigned int Ogg::XiphComment::bpm() const 
+{ 
+  // TODO: proper bpm information 
+  return 0;
+}
+
 void Ogg::XiphComment::setTitle(const String &s)
 {
   addField("TITLE", s);

--- a/taglib/ogg/xiphcomment.h
+++ b/taglib/ogg/xiphcomment.h
@@ -87,6 +87,7 @@ namespace TagLib {
       virtual String genre() const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
+      virtual unsigned int bpm() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -123,6 +123,12 @@ unsigned int RIFF::Info::Tag::track() const
   return fieldText("IPRT").toInt();
 }
 
+unsigned int RIFF::Info::Tag::bpm() const 
+{
+  // TODO: proper bpm information 
+  return 0;
+}
+
 void RIFF::Info::Tag::setTitle(const String &s)
 {
   setFieldText("INAM", s);

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -125,7 +125,8 @@ unsigned int RIFF::Info::Tag::track() const
 
 unsigned int RIFF::Info::Tag::bpm() const 
 {
-  // TODO: proper bpm information 
+  // TODO: proper bpm information
+  // RIFF doesn't seem to support BPM information. 
   return 0;
 }
 

--- a/taglib/riff/wav/infotag.h
+++ b/taglib/riff/wav/infotag.h
@@ -109,6 +109,7 @@ namespace TagLib {
       virtual String genre() const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
+      virtual unsigned int bpm() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -120,6 +120,12 @@ namespace TagLib {
     virtual unsigned int track() const = 0;
 
     /*!
+     * Returns the beats-per-minute (bpm) of the track; if there is no bpm 
+     * set, or bpm tag in the metadata, this will return 0.
+     */ 
+    virtual unsigned int bpm() const = 0; 
+
+    /*!
      * Sets the title to \a s.  If \a s is String::null then this value will be
      * cleared.
      */

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -199,6 +199,11 @@ unsigned int TagUnion::track() const
   numberUnion(track);
 }
 
+unsigned int TagUnion::bpm() const
+{
+  numberUnion(bpm);
+}
+
 void TagUnion::setTitle(const String &s)
 {
   setUnion(Title, s);

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -66,6 +66,7 @@ namespace TagLib {
     virtual String genre() const;
     virtual unsigned int year() const;
     virtual unsigned int track() const;
+    virtual unsigned int bpm() const;
 
     virtual void setTitle(const String &s);
     virtual void setArtist(const String &s);


### PR DESCRIPTION
This PR adds further functionality to the "generic" tag interface, and (on top of that), the C bindings. 

This may be a contentious addition, as only 3/7 of the tag "types" (i.e. classes that inherit from `Tag`) currently support BPM information. I would, however, that the majority of "modern" media formats for which we care about BPM information (such as ALAC, FLAC, mp3, m4a, etc) are covered by some combination of those 3 tag types. 

I would welcome some discussion on this, in case there's a better way of going about this! 