### PR TITLE
Do not ignore non zero RIFF padding if leading to parse error (#882)

### DIFF
--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -325,9 +325,20 @@ void RIFF::File::read()
     if(offset & 1) {
       seek(offset);
       const ByteVector iByte = readBlock(1);
-      if(iByte.size() == 1 && iByte[0] == '\0') {
-        chunk.padding = 1;
-        offset++;
+      if(iByte.size() == 1) {
+        bool skipPadding = iByte[0] == '\0';
+        if(!skipPadding) {
+          // Padding byte is not zero, check if it is good to ignore it
+          const ByteVector fourCcAfterPadding = readBlock(4);
+          if(isValidChunkName(fourCcAfterPadding)) {
+            // Use the padding, it is followed by a valid chunk name.
+            skipPadding = true;
+          }
+        }
+        if(skipPadding) {
+          chunk.padding = 1;
+          offset++;
+        }
       }
     }
 


### PR DESCRIPTION
Currently padding in RIFF files is ignored if it is not zero. To allow parsing of files with non zero padding bytes, this patch changes the parsing of RIFF files in the following way:

* If a zero padding byte is found, it is accepted and handled as before.
* If the padding byte is not zero, it is accepted if the four bytes following the padding byte contain a valid chunk ID but the four bytes starting at the padding byte would not be a valid chunk ID, i.e. parsing would fail without this patch.

This should make parsing more tolerant in the presence of non zero padding bytes while still providing the feature that chunks at odd offsets can be parsed.