### PR TITLE
Mp4 MediaHeader v1 parsing fix

### DIFF
--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -175,8 +175,8 @@ MP4::Properties::read(File *file, Atoms *atoms)
       debug("MP4: Atom 'trak.mdia.mdhd' is smaller than expected");
       return;
     }
-    unit   = data.toLongLong(28U);
-    length = data.toLongLong(36U);
+    unit   = data.toUInt(28U);
+    length = data.toLongLong(32U);
   }
   else {
     if(data.size() < 24 + 4) {


### PR DESCRIPTION
When parsing mp4 media header version 1 (mdhd) atoms, the timescale (unit) is parsed as a `LongLong` (8 bytes), but instead should be a `UInt` (4 bytes). This results in an incorrect timescale, and also pushes the offset of the duration (length) off by 4 bytes.

The end result being that the AudioProperties track length for mp4's with mdhd v1 comes back as 0.

**Note**: This change is untested.

Relates to #891 & #892 

See: https://wiki.multimedia.cx/index.php/QuickTime_container

|  Entry | Bytes (v0) | Bytes (v1) |
| :---         |     :---:      | :---: |
| size  | 4  | 4 |
| type  | 4  | 4 |
| version | 1 | 1 |
| flags | 3 | 3 |
| creation time* | 4 | **8** |
| modification time* | 4 | **8** |
| time scale | 4 | 4 |
| duration* | 4 | **8** |
| language | 2 | 2 |
| quality | 2 | 2 |