### PR TITLE
Minor fix for mp4 media header v0 minimum size check

### DIFF
--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -179,7 +179,7 @@ MP4::Properties::read(File *file, Atoms *atoms)
     length = data.toLongLong(36U);
   }
   else {
-    if(data.size() < 24 + 4) {
+    if(data.size() < 24 + 8) {
       debug("MP4: Atom 'trak.mdia.mdhd' is smaller than expected");
       return;
     }


### PR DESCRIPTION
Mp4 media header (mdhd) v0 atoms are a minimum of 8 bytes for size & type information, plus 24 bytes for remaining entries (`24 +8`) bytes in total, rather than (`24 + 4`).

See https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap2/qtff2.html#//apple_ref/doc/uid/TP40000939-CH204-25615