### PR TITLE
Respect atom type when converting rate tag

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -74,8 +74,19 @@ MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms) :
             atom->name == "hdvd" || atom->name == "shwm") {
       parseBool(atom);
     }
-    else if(atom->name == "tmpo" || atom->name == "rate" || atom->name == "\251mvi" || atom->name == "\251mvc") {
+    else if(atom->name == "tmpo" || atom->name == "\251mvi" || atom->name == "\251mvc") {
       parseInt(atom);
+    }
+    else if(atom->name == "rate") {
+      AtomDataList data = parseData2(atom);
+      if(!data.isEmpty()) {
+        AtomData val = data[0];
+        if (val.type == TypeUTF8) {
+          addItem(atom->name, StringList(String(val.data, String::UTF8)));
+        } else {
+          addItem(atom->name, (int)(val.data.toShort()));
+        }
+      }
     }
     else if(atom->name == "tvsn" || atom->name == "tves" || atom->name == "cnID" ||
             atom->name == "sfID" || atom->name == "atID" || atom->name == "geID" ||

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -491,8 +491,18 @@ MP4::Tag::save()
             name == "shwm") {
       data.append(renderBool(name.data(String::Latin1), it->second));
     }
-    else if(name == "tmpo" || name == "rate" || name == "\251mvi" || name == "\251mvc") {
+    else if(name == "tmpo" || name == "\251mvi" || name == "\251mvc") {
       data.append(renderInt(name.data(String::Latin1), it->second));
+    }
+    else if (name == "rate") {
+      const MP4::Item& item = it->second;
+      StringList value = item.toStringList();
+      if (value.isEmpty()) {
+        data.append(renderInt(name.data(String::Latin1), item));
+      }
+      else {
+        data.append(renderText(name.data(String::Latin1), item));
+      }
     }
     else if(name == "tvsn" || name == "tves" || name == "cnID" ||
             name == "sfID" || name == "atID" || name == "geID" ||


### PR DESCRIPTION
TagLib prior to #818 (commit ff28cf276c60)read and wrote the "rate" tag as
text, and switched to reading it as integer value even when the atom class
is a text type. This breaks reading existing files, and can be avoided by
taking the atom type into account.

This fixes issue #885.