### PR TITLE
Fix crash in vorbis when opening invalid files

### DIFF
--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -180,6 +180,7 @@ void Ogg::FLAC::File::read(bool readProperties, Properties::ReadStyle properties
 
   if (!d->scanned) {
     setValid(false);
+    d->comment = new Ogg::XiphComment();
     return;
   }
 

--- a/taglib/ogg/opus/opusfile.cpp
+++ b/taglib/ogg/opus/opusfile.cpp
@@ -132,6 +132,7 @@ void Opus::File::read(bool readProperties)
   if(!opusHeaderData.startsWith("OpusHead")) {
     setValid(false);
     debug("Opus::File::read() -- invalid Opus identification header");
+    d->comment = new Ogg::XiphComment();
     return;
   }
 
@@ -140,6 +141,7 @@ void Opus::File::read(bool readProperties)
   if(!commentHeaderData.startsWith("OpusTags")) {
     setValid(false);
     debug("Opus::File::read() -- invalid Opus tags header");
+    d->comment = new Ogg::XiphComment();
     return;
   }
 

--- a/taglib/ogg/speex/speexfile.cpp
+++ b/taglib/ogg/speex/speexfile.cpp
@@ -131,6 +131,7 @@ void Speex::File::read(bool readProperties)
 
   if(!speexHeaderData.startsWith("Speex   ")) {
     debug("Speex::File::read() -- invalid Speex identification header");
+    d->comment = new Ogg::XiphComment();
     return;
   }
 

--- a/taglib/ogg/vorbis/vorbisfile.cpp
+++ b/taglib/ogg/vorbis/vorbisfile.cpp
@@ -140,6 +140,7 @@ void Vorbis::File::read(bool readProperties)
   if(commentHeaderData.mid(0, 7) != vorbisCommentHeaderID) {
     debug("Vorbis::File::read() - Could not find the Vorbis comment header.");
     setValid(false);
+    d->comment = new Ogg::XiphComment();
     return;
   }
 


### PR DESCRIPTION
When invalid vorbis files are put into taglib, no XiphComment is generated. This leads dereferences on invalid pointers when calling any function on the tags later (e.g. title(), properties() etc.) and crashes.
Fix this by creating a default XiphComment when opening of the file fails.