### PR TITLE
fix taglib-config file for cross compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ math(EXPR TAGLIB_SOVERSION_PATCH "${TAGLIB_SOVERSION_REVISION}")
 include(ConfigureChecks.cmake)
 
 if(NOT WIN32)
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/taglib-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/taglib-config")
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/taglib-config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/taglib-config" @ONLY)
   install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/taglib-config" DESTINATION "${BIN_INSTALL_DIR}")
 endif()
 

--- a/taglib-config.cmake
+++ b/taglib-config.cmake
@@ -14,10 +14,10 @@ EOH
 	exit 1;
 }
 
-prefix=${CMAKE_INSTALL_PREFIX}
-exec_prefix=${CMAKE_INSTALL_PREFIX}
-libdir=${LIB_INSTALL_DIR}
-includedir=${INCLUDE_INSTALL_DIR}
+prefix=@CMAKE_SYSROOT@@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_SYSROOT@@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
 
 flags=""
 
@@ -35,7 +35,7 @@ do
 	  flags="$flags -I$includedir/taglib"
 	  ;;
     --version)
-	  echo ${TAGLIB_LIB_VERSION_STRING}
+	  echo @TAGLIB_LIB_VERSION_STRING@
 	  ;;
     --prefix)
 	  echo $prefix


### PR DESCRIPTION
Same as #690.

Otherwise, programs which are using `taglib-config` for pulling in taglibs dependency will detect the wrong libraries when cross-compiling.