### PR TITLE
Fix unintentional id3v1 creation

### DIFF
--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -110,7 +110,7 @@ bool MPEG::File::isSupported(IOStream *stream)
 
   if(buffer.isEmpty())
 	  return false;
-  
+
   const long originalPosition = stream->tell();
   AdapterFile file(stream);
 
@@ -195,7 +195,11 @@ MPEG::Properties *MPEG::File::audioProperties() const
 
 bool MPEG::File::save()
 {
-  return save(AllTags);
+  if (hasID3v1Tag() || !ID3v1Tag()->isEmpty()) {
+    return save(AllTags, true, 4, true);
+  } else {
+    return save(AllTags, true, 4, false);
+  }
 }
 
 bool MPEG::File::save(int tags)

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -109,7 +109,7 @@ bool MPEG::File::isSupported(IOStream *stream)
   const ByteVector buffer = Utils::readHeader(stream, bufferSize(), true, &headerOffset);
 
   if(buffer.isEmpty())
-	  return false;
+    return false;
 
   const long originalPosition = stream->tell();
   AdapterFile file(stream);

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -182,7 +182,7 @@ PropertyMap MPEG::File::setProperties(const PropertyMap &properties)
 {
   // update ID3v1 tag if it exists, but ignore the return value
 
-  if(ID3v1Tag())
+  if(hasID3v1Tag())
     ID3v1Tag()->setProperties(properties);
 
   return ID3v2Tag(true)->setProperties(properties);

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -163,14 +163,15 @@ namespace TagLib {
       virtual Properties *audioProperties() const;
 
       /*!
-       * Save the file.  If at least one tag -- ID3v1 or ID3v2 -- exists this
-       * will duplicate its content into the other tag.  This returns true
-       * if saving was successful.
+       * Save the file.  If an ID3v1 tag exists this will duplicate the tag
+       * content into the other tag.  This returns true if saving was
+       * successful.
        *
        * If neither exists or if both tags are empty, this will strip the tags
        * from the file.
        *
-       * This is the same as calling save(AllTags);
+       * This is the same as calling save(AllTags, true, 4, false); or if an
+       * ID3v1 tag exists, save(AllTags, true, 4, true).
        *
        * If you would like more granular control over the content of the tags,
        * with the concession of generality, use parameterized save call below.


### PR DESCRIPTION
Fix unintended creation of id3v1 tags when generically saving or setting tag properties.