### PR TITLE
Make TagLib seach in its source dir for utf8-cpp.

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -26,7 +26,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/xm
   ${CMAKE_CURRENT_SOURCE_DIR}/dsf
   ${CMAKE_CURRENT_SOURCE_DIR}/dsdiff
-  ${CMAKE_SOURCE_DIR}/3rdparty
+  ${taglib_SOURCE_DIR}/3rdparty
 )
 
 if(ZLIB_FOUND)


### PR DESCRIPTION
Without this change, TagLib is unusable as part of CMake projects that rely on `add_subdirectory()` for dependencies, as it tries to add `<top-level source dir>/3rdparty` to its include directories, instead of `<taglib source dir>/3rdparty`.