### PR TITLE
Drop CMAKE_SYSROOT from taglib-config

### DIFF
--- a/taglib-config.cmake
+++ b/taglib-config.cmake
@@ -14,8 +14,8 @@ EOH
 	exit 1;
 }
 
-prefix=@CMAKE_SYSROOT@@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_SYSROOT@@CMAKE_INSTALL_PREFIX@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 


### PR DESCRIPTION
Commit d4c938cbc766ffb400c09efb9e696fce2537d81e is about fixing taglib-config for proper cross-compilation (#906). The fix is right in principle, but wrong in adding `CMAKE_SYSROOT`. The correct prefix path should be set outside of the config file as some embedded Linux distros like OpenWrt or OpenEmbedded install with a different DESTDIR, and dependent packages see a different sysroot.