### PR TITLE
MP4 - setTrack()/setYear() accepts 0 to remove the tag

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -805,13 +805,23 @@ MP4::Tag::setGenre(const String &value)
 void
 MP4::Tag::setYear(unsigned int value)
 {
-  d->items["\251day"] = StringList(String::number(value));
+  if (value == 0) {
+    d->items.erase("\251day");
+  }
+  else {
+    d->items["\251day"] = StringList(String::number(value));
+  }
 }
 
 void
 MP4::Tag::setTrack(unsigned int value)
 {
-  d->items["trkn"] = MP4::Item(value, 0);
+  if (value == 0) {
+    d->items.erase("trkn");
+  }
+  else {
+    d->items["trkn"] = MP4::Item(value, 0);
+  }
 }
 
 bool MP4::Tag::isEmpty() const


### PR DESCRIPTION
setTrack()/setYear() accepts 0 to remove the tag as per documentation/functionality across other tpyes (mp3/flac/...); m4a do not honour this and instead sets the underlying value to 0 instead of removing.

Fixes #911 

Regression test code:
```
#include <iostream>
#include <taglib/mp4file.h>

int main(int argc, char *argv[])
{
    if (argc != 4) {
        return 1;
    }
    try
    {
        TagLib::MP4::File  f(argv[1], false);

        f.tag()->setYear(atoi(argv[2]));
        f.tag()->setTrack(atoi(argv[3]));
        f.save();
    }
    catch (const std::exception& ex)
    {
        std::cerr << ex.what() << std::endl;
    }
    return 0;
}
```
Run as:
```
# set year and track
a.out /tmp/foo.m4a 2019 5

# regression test
a.out /tmp/foo.m4a 0 0

# verify year / track tags exist/removed
fffprobe -hide_banner -i /tmp/foo.m4a
```