### PR TITLE
tfilestream truncate/read bug - MP3 stripping fix

### DIFF
--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -493,6 +493,7 @@ void FileStream::truncate(long length)
 
 #else
 
+  fflush(d->file);
   const int error = ftruncate(fileno(d->file), length);
   if(error != 0)
     debug("FileStream::truncate() -- Coundn't truncate the file.");


### PR DESCRIPTION
Closes https://github.com/taglib/taglib/issues/913.

The `fread(3C)` function potentially buffers the input stream and needs `fflush` following a `ftruncate(2)` being called; ie
```
FILE* f = fopen(...);
ftruncate(fileno(f), 10);
// fflush(f);  -- this is needed here
fseek(f, 10, SEEK_SET);  // seek to where we've truncated the file
fread(....);   // this will read data that has been truncated but buffered
```
These functions are used by code by `tfilestream` for some file operations, in particular the stripping of MP3 tags.

The missing `fflush` causes a problem with MP3 stripping of APE and ID3v1 tags - these tags reside at the end of the file and in this order if both exist.

Stripping functionality for `APE` tags `seek` to the end of the tag (based on `APELocation` and `APEOriginalSize`) and performs a _blind_ `fread()` until it reaches EOF, assuming it to be the ID3v1 tag.

Striipping functionality for `ID3v1` tag simply performs a `ftruncate()` from the start of the tag position (`ID3v1Location`).

The bug can be observed by:
```
    f.strip(ID3v1);
    f.strip(APE);  // the ID3v1 will be untouched/not stripped
```
This means current master executes:
* truncate file to ID3v1 pos
* seek to end of APE tag pos and `fread()` til end of file; the data returned here is potentially buffered  (ie reads the ID3v1 tag that was just truncated/stripped)
* rewrite all the read data (ie the stripped ID3v1) at the APE tag position

This commit performs a simple `fflush()` following the `ftruncate()` to discard any buffered data to ensure no phantom data being returned.

The [POSIX defintion](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fflush.html) for `fflush()` defines the behavior for input streams, whilst the latest draft [C2x standard](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2346.pdf) leaves it undefined.

Tested on Linux/Fedora 26.