### PR TITLE
Update mp3 id3 cover art example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg/id3v1
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg/id3v2
+  ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg/id3v2/frames
   ${CMAKE_CURRENT_SOURCE_DIR}/../bindings/c/
 )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,3 +37,6 @@ target_link_libraries(framelist tag)
 add_executable(strip-id3v1 strip-id3v1.cpp)
 target_link_libraries(strip-id3v1 tag)
 
+########### next target ###############
+add_executable(update-mp3-image updatemp3apicframe.cpp)
+target_link_libraries(update-mp3-image tag)

--- a/examples/updatemp3apicframe.cpp
+++ b/examples/updatemp3apicframe.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 
-#include <taglib/attachedpictureframe.h>
-#include <taglib/id3v2tag.h>
-#include <taglib/mpegfile.h>
-#include <taglib/tag.h>
-#include <taglib/tbytevector.h>
-#include <taglib/tfile.h>
+#include <attachedpictureframe.h>
+#include <id3v2tag.h>
+#include <mpegfile.h>
+#include <tag.h>
+#include <tbytevector.h>
+#include <tfile.h>
 
 using namespace std;
 

--- a/examples/updatemp3apicframe.cpp
+++ b/examples/updatemp3apicframe.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+
+#include <taglib/attachedpictureframe.h>
+#include <taglib/id3v2tag.h>
+#include <taglib/mpegfile.h>
+#include <taglib/tag.h>
+#include <taglib/tbytevector.h>
+#include <taglib/tfile.h>
+
+using namespace std;
+
+class imagefile : public TagLib::File
+{
+public:
+    imagefile(const char *file) : TagLib::File(file) { }
+
+    TagLib::ByteVector data()
+    {
+        return readBlock(length());
+    }
+
+private:
+    virtual TagLib::Tag* tag() const
+    {
+        return 0;
+    }
+    virtual TagLib::AudioProperties* audioProperties() const
+    {
+        return 0;
+    }
+    virtual bool save()
+    {
+        return false;
+    }
+};
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        cout<<"provide arguments in the following format:"<<endl;
+        cout<<"update song path img path"<<endl;
+        return -1;
+    }
+
+    const auto songpath = argv[1];
+    const auto imgpath = argv[2];
+
+    imagefile img(imgpath);
+    TagLib::MPEG::File song(songpath);
+    TagLib::ID3v2::Tag *tag = song.ID3v2Tag();
+
+    auto framelist = tag->frameListMap()["APIC"];
+
+    if (!framelist.isEmpty()) {
+        for (auto it = tag->frameList().begin(); it != tag->frameList().end(); ++it) {
+            auto frameID = (*it)->frameID();
+            string framestr{frameID.data(), frameID.size()};
+
+            if (framestr.compare("APIC") == 0) {
+                cout<<"removing APIC frame"<<endl;
+                tag->removeFrame((*it));
+                it = tag->frameList().begin();
+            }
+        }
+    } else {
+        cout<<"song does not contain any cover art"<<endl;
+    }
+
+    auto picframe = new TagLib::ID3v2::AttachedPictureFrame;
+    picframe->setPicture(img.data());
+    picframe->setType(TagLib::ID3v2::AttachedPictureFrame::FrontCover);
+
+    tag->addFrame(picframe);
+
+    song.save();
+
+    cout<<"saved cover to the mp3 as the front cover"<<endl;
+
+    return 0;
+}


### PR DESCRIPTION
Added an example to update an mp3 song's front cover art. It's a simple program where the two arguments are required - song path and image path. A check is done to find any cover art found the the id3 tag and then remove the frame from the id3 tag. Then the specified image path will be applied to the cover art.

I switched over to TagLib recently and though it might help someone else if they wanted to see an example on how to update the cover art.