### PR TITLE
FLAC - lookup on non existant tags do not inadvertently create entry in FieldListMap

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -116,51 +116,44 @@ ByteVector APE::Tag::fileIdentifier()
 
 String APE::Tag::title() const
 {
-  if(d->itemListMap["TITLE"].isEmpty())
-    return String();
-  return d->itemListMap["TITLE"].values().toString();
+  Item value = d->itemListMap.value("TITLE");
+  return value.isEmpty() ? String() : value.values().toString();
 }
 
 String APE::Tag::artist() const
 {
-  if(d->itemListMap["ARTIST"].isEmpty())
-    return String();
-  return d->itemListMap["ARTIST"].values().toString();
+  Item value = d->itemListMap.value("ARTIST");
+  return value.isEmpty() ? String() : value.values().toString();
 }
 
 String APE::Tag::album() const
 {
-  if(d->itemListMap["ALBUM"].isEmpty())
-    return String();
-  return d->itemListMap["ALBUM"].values().toString();
+  Item value = d->itemListMap.value("ALBUM");
+  return value.isEmpty() ? String() : value.values().toString();
 }
 
 String APE::Tag::comment() const
 {
-  if(d->itemListMap["COMMENT"].isEmpty())
-    return String();
-  return d->itemListMap["COMMENT"].values().toString();
+  Item value = d->itemListMap.value("COMMENT");
+  return value.isEmpty() ? String() : value.values().toString();
 }
 
 String APE::Tag::genre() const
 {
-  if(d->itemListMap["GENRE"].isEmpty())
-    return String();
-  return d->itemListMap["GENRE"].values().toString();
+  Item value = d->itemListMap.value("GENRE");
+  return value.isEmpty() ? String() : value.values().toString();
 }
 
 unsigned int APE::Tag::year() const
 {
-  if(d->itemListMap["YEAR"].isEmpty())
-    return 0;
-  return d->itemListMap["YEAR"].toString().toInt();
+  Item value = d->itemListMap.value("YEAR");
+  return value.isEmpty() ? 0 : value.toString().toInt();
 }
 
 unsigned int APE::Tag::track() const
 {
-  if(d->itemListMap["TRACK"].isEmpty())
-    return 0;
-  return d->itemListMap["TRACK"].toString().toInt();
+  Item value = d->itemListMap.value("TRACK");
+  return value.isEmpty() ? 0 : value.toString().toInt();
 }
 
 void APE::Tag::setTitle(const String &s)

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -78,35 +78,34 @@ Ogg::XiphComment::~XiphComment()
 
 String Ogg::XiphComment::title() const
 {
-  if(d->fieldListMap["TITLE"].isEmpty())
-    return String();
-  return d->fieldListMap["TITLE"].toString();
+  StringList value = d->fieldListMap.value("TITLE");
+  return value.isEmpty() ? String() : value.toString();
 }
 
 String Ogg::XiphComment::artist() const
 {
-  if(d->fieldListMap["ARTIST"].isEmpty())
-    return String();
-  return d->fieldListMap["ARTIST"].toString();
+  StringList value = d->fieldListMap.value("ARTIST");
+  return value.isEmpty() ? String() : value.toString();
 }
 
 String Ogg::XiphComment::album() const
 {
-  if(d->fieldListMap["ALBUM"].isEmpty())
-    return String();
-  return d->fieldListMap["ALBUM"].toString();
+  StringList value = d->fieldListMap.value("ALBUM");
+  return value.isEmpty() ? String() : value.toString();
 }
 
 String Ogg::XiphComment::comment() const
 {
-  if(!d->fieldListMap["DESCRIPTION"].isEmpty()) {
+  StringList value = d->fieldListMap.value("DESCRIPTION");
+  if(!value.isEmpty()) {
     d->commentField = "DESCRIPTION";
-    return d->fieldListMap["DESCRIPTION"].toString();
+    return value.toString();
   }
 
-  if(!d->fieldListMap["COMMENT"].isEmpty()) {
+  value = d->fieldListMap.value("COMMENT");
+  if(!value.isEmpty()) {
     d->commentField = "COMMENT";
-    return d->fieldListMap["COMMENT"].toString();
+    return value.toString();
   }
 
   return String();
@@ -114,26 +113,29 @@ String Ogg::XiphComment::comment() const
 
 String Ogg::XiphComment::genre() const
 {
-  if(d->fieldListMap["GENRE"].isEmpty())
-    return String();
-  return d->fieldListMap["GENRE"].toString();
+  StringList value = d->fieldListMap.value("GENRE");
+  return value.isEmpty() ? String() : value.toString();
 }
 
 unsigned int Ogg::XiphComment::year() const
 {
-  if(!d->fieldListMap["DATE"].isEmpty())
-    return d->fieldListMap["DATE"].front().toInt();
-  if(!d->fieldListMap["YEAR"].isEmpty())
-    return d->fieldListMap["YEAR"].front().toInt();
+  StringList value = d->fieldListMap.value("DATE");
+  if(!value.isEmpty())
+    return value.front().toInt();
+  value = d->fieldListMap.value("YEAR");
+  if(!value.isEmpty())
+    return value.front().toInt();
   return 0;
 }
 
 unsigned int Ogg::XiphComment::track() const
 {
-  if(!d->fieldListMap["TRACKNUMBER"].isEmpty())
-    return d->fieldListMap["TRACKNUMBER"].front().toInt();
-  if(!d->fieldListMap["TRACKNUM"].isEmpty())
-    return d->fieldListMap["TRACKNUM"].front().toInt();
+  StringList value = d->fieldListMap.value("TRACKNUMBER");
+  if(!value.isEmpty())
+    return value.front().toInt();
+  value = d->fieldListMap.value("TRACKNUM");
+  if(!value.isEmpty())
+    return value.front().toInt();
   return 0;
 }
 
@@ -155,7 +157,7 @@ void Ogg::XiphComment::setAlbum(const String &s)
 void Ogg::XiphComment::setComment(const String &s)
 {
   if(d->commentField.isEmpty()) {
-    if(!d->fieldListMap["DESCRIPTION"].isEmpty())
+    if(!d->fieldListMap.value("DESCRIPTION").isEmpty())
       d->commentField = "DESCRIPTION";
     else
       d->commentField = "COMMENT";
@@ -322,7 +324,7 @@ void Ogg::XiphComment::removeAllFields()
 
 bool Ogg::XiphComment::contains(const String &key) const
 {
-  return !d->fieldListMap[key.upper()].isEmpty();
+  return !d->fieldListMap.value(key.upper()).isEmpty();
 }
 
 void Ogg::XiphComment::removePicture(FLAC::Picture *picture, bool del)

--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -154,6 +154,14 @@ namespace TagLib {
     Map<Key, T> &erase(const Key &key);
 
     /*!
+     * Returns the value associated with \a key.
+     *
+     * If the map does not contain \a key, it returns defaultValue.
+     * If no defaultValue is specified, it returns a default-constructed value.
+     */
+    const T value(const Key &key, const T &defaultValue = T()) const;
+
+    /*!
      * Returns a reference to the value associated with \a key.
      *
      * \note This has undefined behavior if the key is not present in the map.

--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -156,6 +156,13 @@ unsigned int Map<Key, T>::size() const
 }
 
 template <class Key, class T>
+const T Map<Key, T>::value(const Key &key, const T &defaultValue) const
+{
+  ConstIterator it = d->map.find(key);
+  return it != d->map.end() ? it->second : defaultValue;
+}
+
+template <class Key, class T>
 const T &Map<Key, T>::operator[](const Key &key) const
 {
   return d->map[key];

--- a/taglib/toolkit/tpropertymap.cpp
+++ b/taglib/toolkit/tpropertymap.cpp
@@ -117,6 +117,12 @@ PropertyMap &PropertyMap::merge(const PropertyMap &other)
   return *this;
 }
 
+const StringList PropertyMap::value(const String &key,
+                                    const StringList &defaultValue) const
+{
+  return SimplePropertyMap::value(key.upper(), defaultValue);
+}
+
 const StringList &PropertyMap::operator[](const String &key) const
 {
   return SimplePropertyMap::operator[](key.upper());

--- a/taglib/toolkit/tpropertymap.h
+++ b/taglib/toolkit/tpropertymap.h
@@ -192,6 +192,15 @@ namespace TagLib {
     PropertyMap &merge(const PropertyMap &other);
 
     /*!
+     * Returns the value associated with \a key.
+     *
+     * If the map does not contain \a key, it returns defaultValue.
+     * If no defaultValue is specified, it returns an empty string list.
+     */
+    const StringList value(const String &key,
+                           const StringList &defaultValue = StringList()) const;
+
+    /*!
      * Returns a reference to the value associated with \a key.
      *
      * \note: If \a key is not contained in the map, an empty

--- a/tests/test_propertymap.cpp
+++ b/tests/test_propertymap.cpp
@@ -25,7 +25,13 @@
 
 #include <tpropertymap.h>
 #include <tag.h>
+#include <apetag.h>
+#include <asftag.h>
 #include <id3v1tag.h>
+#include <id3v2tag.h>
+#include <infotag.h>
+#include <mp4tag.h>
+#include <xiphcomment.h>
 #include <cppunit/extensions/HelperMacros.h>
 #include "utils.h"
 
@@ -35,6 +41,13 @@ class TestPropertyMap : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestPropertyMap);
   CPPUNIT_TEST(testInvalidKeys);
+  CPPUNIT_TEST(testGetSetApe);
+  CPPUNIT_TEST(testGetSetAsf);
+  CPPUNIT_TEST(testGetSetId3v1);
+  CPPUNIT_TEST(testGetSetId3v2);
+  CPPUNIT_TEST(testGetSetInfo);
+  CPPUNIT_TEST(testGetSetMp4);
+  CPPUNIT_TEST(testGetSetXiphComment);
   CPPUNIT_TEST(testGetSet);
   CPPUNIT_TEST_SUITE_END();
 
@@ -60,9 +73,10 @@ public:
 
   }
 
-  void testGetSet()
+  template <typename T>
+  void tagGetSet()
   {
-    ID3v1::Tag tag;
+    T tag;
 
     tag.setTitle("Test Title");
     tag.setArtist("Test Artist");
@@ -88,6 +102,7 @@ public:
     CPPUNIT_ASSERT_EQUAL(String("Test Title 2"),  tag.title());
     CPPUNIT_ASSERT_EQUAL(String("Test Artist 2"), tag.artist());
     CPPUNIT_ASSERT_EQUAL(5U, tag.track());
+    CPPUNIT_ASSERT(!tag.isEmpty());
 
     PropertyMap props = tag.properties();
     CPPUNIT_ASSERT_EQUAL(StringList("Test Artist 2"), props.find("ARTIST")->second);
@@ -104,9 +119,83 @@ public:
 
     tag.setProperties(PropertyMap());
 
+    CPPUNIT_ASSERT(tag.isEmpty());
+    CPPUNIT_ASSERT(tag.properties().isEmpty());
     CPPUNIT_ASSERT_EQUAL(String(""), tag.title());
     CPPUNIT_ASSERT_EQUAL(String(""), tag.artist());
+    CPPUNIT_ASSERT_EQUAL(String(""), tag.album());
+    CPPUNIT_ASSERT_EQUAL(String(""), tag.comment());
+    CPPUNIT_ASSERT_EQUAL(String(""), tag.genre());
     CPPUNIT_ASSERT_EQUAL(0U, tag.track());
+    CPPUNIT_ASSERT(tag.isEmpty());
+    CPPUNIT_ASSERT(tag.properties().isEmpty());
+  }
+
+  void testGetSetId3v1()
+  {
+    tagGetSet<ID3v1::Tag>();
+  }
+
+  void testGetSetId3v2()
+  {
+    tagGetSet<ID3v2::Tag>();
+  }
+
+  void testGetSetXiphComment()
+  {
+    tagGetSet<Ogg::XiphComment>();
+  }
+
+  void testGetSetApe()
+  {
+    tagGetSet<APE::Tag>();
+  }
+
+  void testGetSetAsf()
+  {
+    tagGetSet<ASF::Tag>();
+  }
+
+  void testGetSetMp4()
+  {
+    tagGetSet<MP4::Tag>();
+  }
+
+  void testGetSetInfo()
+  {
+    tagGetSet<RIFF::Info::Tag>();
+  }
+
+  void testGetSet()
+  {
+    PropertyMap props;
+    props["Title"] = String("Test Title");
+    StringList artists("Artist 1");
+    artists.append("Artist 2");
+    props.insert("Artist", artists);
+    CPPUNIT_ASSERT_EQUAL(StringList("Test Title"), props.value("TITLE"));
+    CPPUNIT_ASSERT_EQUAL(StringList("Test Title"), props.value("Title"));
+    CPPUNIT_ASSERT_EQUAL(StringList("Test Title"), props["TITLE"]);
+    CPPUNIT_ASSERT_EQUAL(StringList("Test Title"), props["Title"]);
+    CPPUNIT_ASSERT(props.contains("title"));
+    CPPUNIT_ASSERT_EQUAL(StringList("Test Title"), props.find("TITLE")->second);
+    CPPUNIT_ASSERT_EQUAL(2U, props.size());
+    CPPUNIT_ASSERT(!props.isEmpty());
+    props.clear();
+    CPPUNIT_ASSERT(props.isEmpty());
+    CPPUNIT_ASSERT_EQUAL(StringList(), props.value("TITLE"));
+    CPPUNIT_ASSERT_EQUAL(StringList(), props.value("Title"));
+    CPPUNIT_ASSERT_EQUAL(artists, props.value("Title", artists));
+    CPPUNIT_ASSERT(!props.contains("title"));
+    CPPUNIT_ASSERT(props.find("TITLE") == props.end());
+    CPPUNIT_ASSERT_EQUAL(0U, props.size());
+    CPPUNIT_ASSERT(props.isEmpty());
+    CPPUNIT_ASSERT_EQUAL(StringList(), props["TITLE"]);
+    CPPUNIT_ASSERT_EQUAL(StringList(), props["Title"]);
+    CPPUNIT_ASSERT(props.contains("title"));
+    CPPUNIT_ASSERT(props.find("TITLE") != props.end());
+    CPPUNIT_ASSERT_EQUAL(1U, props.size());
+    CPPUNIT_ASSERT(!props.isEmpty());
   }
 
 };


### PR DESCRIPTION
Fixes #931 

``` 
           TagLib::FLAC::File f(argv[1]);
            f.xiphComment()->removeFields("TITLE");
            std::cout << "FIRST (removed title)\n" << f.properties() << "\n";
            f.save();

            f.tag()->title();
```
Whilst `title()` returns empty string, the `Ogg::XiphComment` interface will create an empty entry in the `FieldListMap` for `TITLE`.  This is inconsistent with MP3/MP4 interfaces in the library.

This behaviour is seen for `TITLE`, `ARTIST`, `ALBUM`, `GENRE`, `COMMENTS`/`DESCRIPTION` which are fixed with this PR