### PR TITLE
taglib-config.cmake has static libdir and includedir variables

### DIFF
--- a/taglib-config.cmake
+++ b/taglib-config.cmake
@@ -16,8 +16,8 @@ EOH
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+libdir=@LIB_INSTALL_DIR@
+includedir=@INCLUDE_INSTALL_DIR@
 
 flags=""
 


### PR DESCRIPTION
This matches the syntax of the 1.12 beta release and fixes issues where a user's libdir is not at ${exec_prefix}/lib but ${exec_prefix}/lib64 or otherwise.