### PR TITLE
Replacing space with other characters for repeated tags

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -115,39 +115,39 @@ ByteVector APE::Tag::fileIdentifier()
   return ByteVector::fromCString("APETAGEX");
 }
 
-String APE::Tag::title() const
+String APE::Tag::title(const String &separator) const
 {
   if(d->itemListMap["TITLE"].isEmpty())
     return String();
-  return d->itemListMap["TITLE"].values().toString();
+  return d->itemListMap["TITLE"].values().toString(separator);
 }
 
-String APE::Tag::artist() const
+String APE::Tag::artist(const String &separator) const
 {
   if(d->itemListMap["ARTIST"].isEmpty())
     return String();
-  return d->itemListMap["ARTIST"].values().toString();
+  return d->itemListMap["ARTIST"].values().toString(separator);
 }
 
-String APE::Tag::album() const
+String APE::Tag::album(const String &separator) const
 {
   if(d->itemListMap["ALBUM"].isEmpty())
     return String();
-  return d->itemListMap["ALBUM"].values().toString();
+  return d->itemListMap["ALBUM"].values().toString(separator);
 }
 
-String APE::Tag::comment() const
+String APE::Tag::comment(const String &separator) const
 {
   if(d->itemListMap["COMMENT"].isEmpty())
     return String();
-  return d->itemListMap["COMMENT"].values().toString();
+  return d->itemListMap["COMMENT"].values().toString(separator);
 }
 
-String APE::Tag::genre() const
+String APE::Tag::genre(const String &separator) const
 {
   if(d->itemListMap["GENRE"].isEmpty())
     return String();
-  return d->itemListMap["GENRE"].values().toString();
+  return d->itemListMap["GENRE"].values().toString(separator);
 }
 
 unsigned int APE::Tag::year() const

--- a/taglib/ape/apetag.h
+++ b/taglib/ape/apetag.h
@@ -87,11 +87,11 @@ namespace TagLib {
 
       // Reimplementations.
 
-      virtual String title() const;
-      virtual String artist() const;
-      virtual String album() const;
-      virtual String comment() const;
-      virtual String genre() const;
+      virtual String title(const String &separator = " ") const;
+      virtual String artist(const String &separator = " ") const;
+      virtual String album(const String &separator = " ") const;
+      virtual String comment(const String &separator = " ") const;
+      virtual String genre(const String &separator = " ") const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
 

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -50,17 +50,17 @@ ASF::Tag::~Tag()
   delete d;
 }
 
-String ASF::Tag::title() const
+String ASF::Tag::title(const String &separator) const
 {
   return d->title;
 }
 
-String ASF::Tag::artist() const
+String ASF::Tag::artist(const String &separator) const
 {
   return d->artist;
 }
 
-String ASF::Tag::album() const
+String ASF::Tag::album(const String &separator) const
 {
   if(d->attributeListMap.contains("WM/AlbumTitle"))
     return d->attributeListMap["WM/AlbumTitle"][0].toString();
@@ -72,7 +72,7 @@ String ASF::Tag::copyright() const
   return d->copyright;
 }
 
-String ASF::Tag::comment() const
+String ASF::Tag::comment(const String &separator) const
 {
   return d->comment;
 }
@@ -103,7 +103,7 @@ unsigned int ASF::Tag::track() const
   return 0;
 }
 
-String ASF::Tag::genre() const
+String ASF::Tag::genre(const String &separator) const
 {
   if(d->attributeListMap.contains("WM/Genre"))
     return d->attributeListMap["WM/Genre"][0].toString();

--- a/taglib/asf/asftag.h
+++ b/taglib/asf/asftag.h
@@ -52,29 +52,29 @@ namespace TagLib {
       /*!
        * Returns the track name.
        */
-      virtual String title() const;
+      virtual String title(const String &separator = " ") const;
 
       /*!
        * Returns the artist name.
        */
-      virtual String artist() const;
+      virtual String artist(const String &separator = " ") const;
 
       /*!
        * Returns the album name; if no album name is present in the tag
        * String::null will be returned.
        */
-      virtual String album() const;
+      virtual String album(const String &separator = " ") const;
 
       /*!
        * Returns the track comment.
        */
-      virtual String comment() const;
+      virtual String comment(const String &separator = " ") const;
 
       /*!
        * Returns the genre name; if no genre is present in the tag String::null
        * will be returned.
        */
-      virtual String genre() const;
+      virtual String genre(const String &separator = " ") const;
 
       /*!
        * Returns the rating.

--- a/taglib/mod/modtag.cpp
+++ b/taglib/mod/modtag.cpp
@@ -53,27 +53,27 @@ Mod::Tag::~Tag()
   delete d;
 }
 
-String Mod::Tag::title() const
+String Mod::Tag::title(const String &separator) const
 {
   return d->title;
 }
 
-String Mod::Tag::artist() const
+String Mod::Tag::artist(const String &separator) const
 {
   return String();
 }
 
-String Mod::Tag::album() const
+String Mod::Tag::album(const String &separator) const
 {
   return String();
 }
 
-String Mod::Tag::comment() const
+String Mod::Tag::comment(const String &separator) const
 {
   return d->comment;
 }
 
-String Mod::Tag::genre() const
+String Mod::Tag::genre(const String &separator) const
 {
   return String();
 }

--- a/taglib/mod/modtag.h
+++ b/taglib/mod/modtag.h
@@ -54,29 +54,29 @@ namespace TagLib {
        * Returns the track name; if no track name is present in the tag
        * String::null will be returned.
        */
-      virtual String title() const;
+      virtual String title(const String &separator = " ") const;
 
       /*!
        * Not supported by module files.  Therefore always returns String::null.
        */
-      virtual String artist() const;
+      virtual String artist(const String &separator = " ") const;
 
       /*!
        * Not supported by module files.  Therefore always returns String::null.
        */
-      virtual String album() const;
+      virtual String album(const String &separator = " ") const;
 
       /*!
        * Returns the track comment derived from the instrument/sample/pattern
        * names; if no comment is present in the tag String::null will be
        * returned.
        */
-      virtual String comment() const;
+      virtual String comment(const String &separator = " ") const;
 
       /*!
        * Not supported by module files.  Therefore always returns String::null.
        */
-      virtual String genre() const;
+      virtual String genre(const String &separator = " ") const;
 
       /*!
        * Not supported by module files.  Therefore always returns 0.

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -687,42 +687,42 @@ MP4::Tag::saveExisting(ByteVector data, const AtomList &path)
 }
 
 String
-MP4::Tag::title() const
+MP4::Tag::title(const String &separator) const
 {
   if(d->items.contains("\251nam"))
-    return d->items["\251nam"].toStringList().toString(", ");
+    return d->items["\251nam"].toStringList().toString(separator);
   return String();
 }
 
 String
-MP4::Tag::artist() const
+MP4::Tag::artist(const String &separator) const
 {
   if(d->items.contains("\251ART"))
-    return d->items["\251ART"].toStringList().toString(", ");
+    return d->items["\251ART"].toStringList().toString(separator);
   return String();
 }
 
 String
-MP4::Tag::album() const
+MP4::Tag::album(const String &separator) const
 {
   if(d->items.contains("\251alb"))
-    return d->items["\251alb"].toStringList().toString(", ");
+    return d->items["\251alb"].toStringList().toString(separator);
   return String();
 }
 
 String
-MP4::Tag::comment() const
+MP4::Tag::comment(const String &separator) const
 {
   if(d->items.contains("\251cmt"))
-    return d->items["\251cmt"].toStringList().toString(", ");
+    return d->items["\251cmt"].toStringList().toString(separator);
   return String();
 }
 
 String
-MP4::Tag::genre() const
+MP4::Tag::genre(const String &separator) const
 {
   if(d->items.contains("\251gen"))
-    return d->items["\251gen"].toStringList().toString(", ");
+    return d->items["\251gen"].toStringList().toString(separator);
   return String();
 }
 

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -53,11 +53,11 @@ namespace TagLib {
         virtual ~Tag();
         bool save();
 
-        virtual String title() const;
-        virtual String artist() const;
-        virtual String album() const;
-        virtual String comment() const;
-        virtual String genre() const;
+        virtual String title(const String &separator = ", ") const;
+        virtual String artist(const String &separator = ", ") const;
+        virtual String album(const String &separator = ", ") const;
+        virtual String comment(const String &separator = ", ") const;
+        virtual String genre(const String &separator = ", ") const;
         virtual unsigned int year() const;
         virtual unsigned int track() const;
 

--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -127,27 +127,27 @@ ByteVector ID3v1::Tag::fileIdentifier()
   return ByteVector::fromCString("TAG");
 }
 
-String ID3v1::Tag::title() const
+String ID3v1::Tag::title(const String &separator) const
 {
   return d->title;
 }
 
-String ID3v1::Tag::artist() const
+String ID3v1::Tag::artist(const String &separator) const
 {
   return d->artist;
 }
 
-String ID3v1::Tag::album() const
+String ID3v1::Tag::album(const String &separator) const
 {
   return d->album;
 }
 
-String ID3v1::Tag::comment() const
+String ID3v1::Tag::comment(const String &separator) const
 {
   return d->comment;
 }
 
-String ID3v1::Tag::genre() const
+String ID3v1::Tag::genre(const String &separator) const
 {
   return ID3v1::genre(d->genre);
 }

--- a/taglib/mpeg/id3v1/id3v1tag.h
+++ b/taglib/mpeg/id3v1/id3v1tag.h
@@ -135,11 +135,11 @@ namespace TagLib {
 
       // Reimplementations.
 
-      virtual String title() const;
-      virtual String artist() const;
-      virtual String album() const;
-      virtual String comment() const;
-      virtual String genre() const;
+      virtual String title(const String &separator = " ") const;
+      virtual String artist(const String &separator = " ") const;
+      virtual String album(const String &separator = " ") const;
+      virtual String comment(const String &separator = " ") const;
+      virtual String genre(const String &separator = " ") const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
 

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -131,28 +131,28 @@ ID3v2::Tag::~Tag()
   delete d;
 }
 
-String ID3v2::Tag::title() const
+String ID3v2::Tag::title(const String &separator) const
 {
   if(!d->frameListMap["TIT2"].isEmpty())
     return d->frameListMap["TIT2"].front()->toString();
   return String();
 }
 
-String ID3v2::Tag::artist() const
+String ID3v2::Tag::artist(const String &separator) const
 {
   if(!d->frameListMap["TPE1"].isEmpty())
     return d->frameListMap["TPE1"].front()->toString();
   return String();
 }
 
-String ID3v2::Tag::album() const
+String ID3v2::Tag::album(const String &separator) const
 {
   if(!d->frameListMap["TALB"].isEmpty())
     return d->frameListMap["TALB"].front()->toString();
   return String();
 }
 
-String ID3v2::Tag::comment() const
+String ID3v2::Tag::comment(const String &separator) const
 {
   const FrameList &comments = d->frameListMap["COMM"];
 
@@ -170,7 +170,7 @@ String ID3v2::Tag::comment() const
   return comments.front()->toString();
 }
 
-String ID3v2::Tag::genre() const
+String ID3v2::Tag::genre(const String &separator) const
 {
   // TODO: In the next major version (TagLib 2.0) a list of multiple genres
   // should be separated by " / " instead of " ".  For the moment to keep
@@ -210,7 +210,7 @@ String ID3v2::Tag::genre() const
       genres.append(*it);
   }
 
-  return genres.toString();
+  return genres.toString(separator);
 }
 
 unsigned int ID3v2::Tag::year() const

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -164,11 +164,11 @@ namespace TagLib {
 
       // Reimplementations.
 
-      virtual String title() const;
-      virtual String artist() const;
-      virtual String album() const;
-      virtual String comment() const;
-      virtual String genre() const;
+      virtual String title(const String &separator = " ") const;
+      virtual String artist(const String &separator = " ") const;
+      virtual String album(const String &separator = " ") const;
+      virtual String comment(const String &separator = " ") const;
+      virtual String genre(const String &separator = " ") const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
 

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -78,47 +78,47 @@ Ogg::XiphComment::~XiphComment()
   delete d;
 }
 
-String Ogg::XiphComment::title() const
+String Ogg::XiphComment::title(const String &separator) const
 {
   if(d->fieldListMap["TITLE"].isEmpty())
     return String();
-  return d->fieldListMap["TITLE"].toString();
+  return d->fieldListMap["TITLE"].toString(separator);
 }
 
-String Ogg::XiphComment::artist() const
+String Ogg::XiphComment::artist(const String &separator) const
 {
   if(d->fieldListMap["ARTIST"].isEmpty())
     return String();
-  return d->fieldListMap["ARTIST"].toString();
+  return d->fieldListMap["ARTIST"].toString(separator);
 }
 
-String Ogg::XiphComment::album() const
+String Ogg::XiphComment::album(const String &separator) const
 {
   if(d->fieldListMap["ALBUM"].isEmpty())
     return String();
-  return d->fieldListMap["ALBUM"].toString();
+  return d->fieldListMap["ALBUM"].toString(separator);
 }
 
-String Ogg::XiphComment::comment() const
+String Ogg::XiphComment::comment(const String &separator) const
 {
   if(!d->fieldListMap["DESCRIPTION"].isEmpty()) {
     d->commentField = "DESCRIPTION";
-    return d->fieldListMap["DESCRIPTION"].toString();
+    return d->fieldListMap["DESCRIPTION"].toString(separator);
   }
 
   if(!d->fieldListMap["COMMENT"].isEmpty()) {
     d->commentField = "COMMENT";
-    return d->fieldListMap["COMMENT"].toString();
+    return d->fieldListMap["COMMENT"].toString(separator);
   }
 
   return String();
 }
 
-String Ogg::XiphComment::genre() const
+String Ogg::XiphComment::genre(const String &separator) const
 {
   if(d->fieldListMap["GENRE"].isEmpty())
     return String();
-  return d->fieldListMap["GENRE"].toString();
+  return d->fieldListMap["GENRE"].toString(separator);
 }
 
 unsigned int Ogg::XiphComment::year() const

--- a/taglib/ogg/xiphcomment.h
+++ b/taglib/ogg/xiphcomment.h
@@ -80,11 +80,11 @@ namespace TagLib {
        */
       virtual ~XiphComment();
 
-      virtual String title() const;
-      virtual String artist() const;
-      virtual String album() const;
-      virtual String comment() const;
-      virtual String genre() const;
+      virtual String title(const String &separator = " ") const;
+      virtual String artist(const String &separator = " ") const;
+      virtual String album(const String &separator = " ") const;
+      virtual String comment(const String &separator = " ") const;
+      virtual String genre(const String &separator = " ") const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
 

--- a/taglib/riff/wav/infotag.cpp
+++ b/taglib/riff/wav/infotag.cpp
@@ -88,27 +88,27 @@ RIFF::Info::Tag::~Tag()
   delete d;
 }
 
-String RIFF::Info::Tag::title() const
+String RIFF::Info::Tag::title(const String &separator) const
 {
   return fieldText("INAM");
 }
 
-String RIFF::Info::Tag::artist() const
+String RIFF::Info::Tag::artist(const String &separator) const
 {
   return fieldText("IART");
 }
 
-String RIFF::Info::Tag::album() const
+String RIFF::Info::Tag::album(const String &separator) const
 {
   return fieldText("IPRD");
 }
 
-String RIFF::Info::Tag::comment() const
+String RIFF::Info::Tag::comment(const String &separator) const
 {
   return fieldText("ICMT");
 }
 
-String RIFF::Info::Tag::genre() const
+String RIFF::Info::Tag::genre(const String &separator) const
 {
   return fieldText("IGNR");
 }

--- a/taglib/riff/wav/infotag.h
+++ b/taglib/riff/wav/infotag.h
@@ -102,11 +102,11 @@ namespace TagLib {
 
       // Reimplementations
 
-      virtual String title() const;
-      virtual String artist() const;
-      virtual String album() const;
-      virtual String comment() const;
-      virtual String genre() const;
+      virtual String title(const String &separator = " ") const;
+      virtual String artist(const String &separator = " ") const;
+      virtual String album(const String &separator = " ") const;
+      virtual String comment(const String &separator = " ") const;
+      virtual String genre(const String &separator = " ") const;
       virtual unsigned int year() const;
       virtual unsigned int track() const;
 

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -82,31 +82,31 @@ namespace TagLib {
      * Returns the track name; if no track name is present in the tag
      * String::null will be returned.
      */
-    virtual String title() const = 0;
+    virtual String title(const String &separator = " ") const = 0;
 
     /*!
      * Returns the artist name; if no artist name is present in the tag
      * String::null will be returned.
      */
-    virtual String artist() const = 0;
+    virtual String artist(const String &separator = " ") const = 0;
 
     /*!
      * Returns the album name; if no album name is present in the tag
      * String::null will be returned.
      */
-    virtual String album() const = 0;
+    virtual String album(const String &separator = " ") const = 0;
 
     /*!
      * Returns the track comment; if no comment is present in the tag
      * String::null will be returned.
      */
-    virtual String comment() const = 0;
+    virtual String comment(const String &separator = " ") const = 0;
 
     /*!
      * Returns the genre name; if no genre is present in the tag String::null
      * will be returned.
      */
-    virtual String genre() const = 0;
+    virtual String genre(const String &separator = " ") const = 0;
 
     /*!
      * Returns the year; if there is no year set, this will return 0.

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -36,11 +36,11 @@
 using namespace TagLib;
 
 #define stringUnion(method)                                          \
-  if(tag(0) && !tag(0)->method().isEmpty())                          \
+  if(tag(0) && !tag(0)->method(separator).isEmpty())                 \
     return tag(0)->method(separator);                                \
-  if(tag(1) && !tag(1)->method().isEmpty())                          \
+  if(tag(1) && !tag(1)->method(separator).isEmpty())                 \
     return tag(1)->method(separator);                                \
-  if(tag(2) && !tag(2)->method().isEmpty())                          \
+  if(tag(2) && !tag(2)->method(separator).isEmpty())                 \
     return tag(2)->method(separator);                                \
   return String();                                                   \
 

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -37,11 +37,11 @@ using namespace TagLib;
 
 #define stringUnion(method)                                          \
   if(tag(0) && !tag(0)->method().isEmpty())                          \
-    return tag(0)->method();                                         \
+    return tag(0)->method(separator);                                \
   if(tag(1) && !tag(1)->method().isEmpty())                          \
-    return tag(1)->method();                                         \
+    return tag(1)->method(separator);                                \
   if(tag(2) && !tag(2)->method().isEmpty())                          \
-    return tag(2)->method();                                         \
+    return tag(2)->method(separator);                                \
   return String();                                                   \
 
 #define numberUnion(method)                                          \

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -165,27 +165,27 @@ void TagUnion::removeUnsupportedProperties(const StringList &unsupported)
   }
 }
 
-String TagUnion::title() const
+String TagUnion::title(const String &separator) const
 {
   stringUnion(title);
 }
 
-String TagUnion::artist() const
+String TagUnion::artist(const String &separator) const
 {
   stringUnion(artist);
 }
 
-String TagUnion::album() const
+String TagUnion::album(const String &separator) const
 {
   stringUnion(album);
 }
 
-String TagUnion::comment() const
+String TagUnion::comment(const String &separator) const
 {
   stringUnion(comment);
 }
 
-String TagUnion::genre() const
+String TagUnion::genre(const String &separator) const
 {
   stringUnion(genre);
 }

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -59,11 +59,11 @@ namespace TagLib {
     PropertyMap properties() const;
     void removeUnsupportedProperties(const StringList &unsupported);
 
-    virtual String title() const;
-    virtual String artist() const;
-    virtual String album() const;
-    virtual String comment() const;
-    virtual String genre() const;
+    virtual String title(const String &separator = " ") const;
+    virtual String artist(const String &separator = " ") const;
+    virtual String album(const String &separator = " ") const;
+    virtual String comment(const String &separator = " ") const;
+    virtual String genre(const String &separator = " ") const;
     virtual unsigned int year() const;
     virtual unsigned int track() const;
 


### PR DESCRIPTION
Hi all.  I've been working on a [Gerbera media server](https://github.com/gerbera/gerbera) setup for the past few weeks, and one of the things I discovered is a small percentage (but more than I want to retag) of my FLAC files have repeated tags, e.g. `Artist=Artist1`, `Artist=Artist2`, etc.  Since the default behavior of TagLib 1.11.1 is to concatenate repeated tags with spaces I ran into difficulty splitting the artists apart in Gerbera.  Since `StringList::toString()` already takes a separator argument, over this past weekend I added a similar argument to `Tag::genre()`, `Tag::artist()`, `Tag::comment()`, `Tag::title()`, and `Tag::album()` -- honestly genre and artist are the pain points for me, but I can go either way on the others.

Note MP4 was an outlier in that it already passed ", " to `StringList::toString()`, so I kept that as the default value.

I saw several comments about this area of code potentially changing in TagLib2, so I don't know if this change is valuable or not?  Feel free to reject this if it doesn't fit what you're going for.  And to be honest I did all this work against 1.11.1, not master.  I did my best to follow local conventions in the code, but commit messages are 100% my style -- if you'd like changes let me know.  I'm also happy to squash these three into one if it's a better fit.  

Finally there's also the weird question about what's going on with the default argument in `TagUnion` (see the last commit, fc5ac34f9fa7666b9fbfa141ca84e398f9576e33), but it does work for me.