### PR TITLE
Adding support for Linux on power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ compiler:
   - gcc
   - clang
 
+arch:
+  - ppc64le
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hi,
I had added ppc64le (Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/ujjwalsh/taglib/builds/182294668

Please have a look.
Regards,
Ujjwal