### PR TITLE
Add simple runtime version check API

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -297,6 +297,7 @@ set(xm_SRCS
 )
 
 set(toolkit_SRCS
+  toolkit/taglib.cpp
   toolkit/tstring.cpp
   toolkit/tstringlist.cpp
   toolkit/tbytevector.cpp

--- a/taglib/toolkit/taglib.cpp
+++ b/taglib/toolkit/taglib.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+    copyright            : (C) 2020 by Kevin Andre
+    email                : hyperquantum@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "taglib.h"
+
+#include "tutils.h"
+
+bool TagLib::isTagLibVersionAtLeast(int major, int minor)
+{
+  return isTagLibVersionAtLeast(major, minor, 0);
+}
+
+bool TagLib::isTagLibVersionAtLeast(int major, int minor, int patch)
+{
+  int actualMajor = TAGLIB_MAJOR_VERSION;
+  int actualMinor = TAGLIB_MINOR_VERSION;
+  int actualPatch = TAGLIB_PATCH_VERSION;
+
+  return TagLib::Utils::compareVersions(major, minor, patch,
+                                        actualMajor, actualMinor, actualPatch) <= 0;
+}

--- a/taglib/toolkit/taglib.h
+++ b/taglib/toolkit/taglib.h
@@ -27,6 +27,7 @@
 #define TAGLIB_H
 
 #include "taglib_config.h"
+#include "taglib_export.h"
 
 #define TAGLIB_MAJOR_VERSION 1
 #define TAGLIB_MINOR_VERSION 11
@@ -84,6 +85,22 @@ namespace TagLib {
    * so I'm providing something here that should be constant.
    */
   typedef std::basic_string<wchar_t> wstring;
+
+  /*!
+   * Checks if the version of TagLib you are using is at least the specified version.
+   *
+   * This is a runtime check, taking into account that your program may have been linked
+   * to a more recent version of TagLib than it was compiled with.
+   */
+  TAGLIB_EXPORT bool isTagLibVersionAtLeast(int major, int minor);
+
+  /*!
+   * Checks if the version of TagLib you are using is at least the specified version.
+   *
+   * This is a runtime check, taking into account that your program may have been linked
+   * to a more recent version of TagLib than it was compiled with.
+   */
+  TAGLIB_EXPORT bool isTagLibVersionAtLeast(int major, int minor, int patch);
 }
 
 /*!

--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -163,6 +163,35 @@ namespace TagLib
       }
 
       /*!
+       * Compares two int values and returns the sign of the difference
+       * between them.
+       */
+      inline int compareInts(int a, int b)
+      {
+          if(a < b) return -1;
+          if(a > b) return 1;
+          return 0;
+      }
+
+      /*!
+       * Compares two versions. Returns a negative number if the first version
+       * is smaller than the second one, returns zero if the versions are
+       * equal, or returns a strictly positive result if the first version is
+       * greater than the second one.
+       */
+      inline int compareVersions(int major1, int minor1, int patch1,
+                                 int major2, int minor2, int patch2)
+      {
+          int majorComparisonResult = compareInts(major1, major2);
+          if (majorComparisonResult != 0) return majorComparisonResult;
+
+          int minorComparisonResult = compareInts(minor1, minor2);
+          if (minorComparisonResult != 0) return minorComparisonResult;
+
+          return compareInts(patch1, patch2);
+      }
+
+      /*!
        * Returns a formatted string just like standard sprintf(), but makes use of
        * safer functions such as snprintf() if available.
        */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ INCLUDE_DIRECTORIES(
 
 SET(test_runner_SRCS
   main.cpp
+  test_taglib.cpp
+  test_utils.cpp
   test_list.cpp
   test_map.cpp
   test_mpeg.cpp

--- a/tests/test_taglib.cpp
+++ b/tests/test_taglib.cpp
@@ -1,0 +1,85 @@
+/***************************************************************************
+    copyright           : (C) 2020 by Kevin Andre
+    email               : hyperquantum@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include <taglib.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+using namespace TagLib;
+
+class TestTagLib : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestTagLib);
+  CPPUNIT_TEST(testAtLeastVersionActualVersion);
+  CPPUNIT_TEST(testAtLeastVersionMajorMinor);
+  CPPUNIT_TEST(testAtLeastVersionMajorMinorPatch);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void testAtLeastVersionActualVersion()
+  {
+    int actualMajor = TAGLIB_MAJOR_VERSION;
+    int actualMinor = TAGLIB_MINOR_VERSION;
+    int actualPatch = TAGLIB_PATCH_VERSION;
+
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(actualMajor, actualMinor));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(actualMajor, actualMinor, actualPatch));
+  }
+
+  void testAtLeastVersionMajorMinor()
+  {
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(0, 9));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 9));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 10));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 11));
+
+    // the following may need to be adjusted in the future :)
+    CPPUNIT_ASSERT(!isTagLibVersionAtLeast(3, 0));
+    CPPUNIT_ASSERT(!isTagLibVersionAtLeast(3, 7));
+  }
+
+  void testAtLeastVersionMajorMinorPatch()
+  {
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(0, 9, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(0, 9, 999));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(0, 9, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 0, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 9, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 9, 1));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 10, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 10, 999));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 11, 0));
+    CPPUNIT_ASSERT(isTagLibVersionAtLeast(1, 11, 1));
+
+    // the following may need to be adjusted in the future :)
+    CPPUNIT_ASSERT(!isTagLibVersionAtLeast(2, 99, 0));
+    CPPUNIT_ASSERT(!isTagLibVersionAtLeast(3, 0, 0));
+    CPPUNIT_ASSERT(!isTagLibVersionAtLeast(3, 50, 0));
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestTagLib);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+    copyright           : (C) 2020 by Kevin Andre
+    email               : hyperquantum@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include <tutils.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+using namespace TagLib;
+
+class TestUtils : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestUtils);
+  CPPUNIT_TEST(testCompareInts);
+  CPPUNIT_TEST(testCompareVersions);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void testCompareInts()
+  {
+    CPPUNIT_ASSERT(Utils::compareInts(6, 7) < 0);
+    CPPUNIT_ASSERT_EQUAL(0, Utils::compareInts(7, 7));
+    CPPUNIT_ASSERT(Utils::compareInts(8, 7) > 0);
+  }
+
+  void testCompareVersions()
+  {
+    CPPUNIT_ASSERT(Utils::compareVersions(0, 9, 99, 0, 9, 99) == 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 0, 1, 0, 0) == 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 1, 1, 1, 1) == 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(5, 4, 3, 5, 4, 3) == 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(0, 9, 99, 1, 0, 0) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 0, 0, 9, 99) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 0, 1, 0, 1) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 1, 1, 0, 0) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 1, 1, 1, 0) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 0, 1, 0, 1) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 0, 1, 1, 0) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 0, 1, 0, 0) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 0, 1, 1, 1) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 1, 1, 0, 0) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 1, 1, 1, 1) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 1, 1, 0, 1) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 0, 1, 1, 1) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 1, 1, 1, 0) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 1, 100, 1, 2, 0) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 2, 0, 1, 1, 100) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(1, 0, 0, 2, 0, 0) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(2, 0, 0, 1, 0, 0) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(4, 6, 2, 4, 6, 3) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(4, 6, 3, 4, 6, 2) > 0);
+
+    CPPUNIT_ASSERT(Utils::compareVersions(4, 8, 0, 4, 9, 0) < 0);
+    CPPUNIT_ASSERT(Utils::compareVersions(4, 9, 0, 4, 8, 0) > 0);
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestUtils);


### PR DESCRIPTION
This adds a simple runtime version check as requested in #920 .

How to use:

```
  #include <taglib.h>

  if (TagLib::isTagLibVersionAtLeast(1, 11, 1)) {
    // running v1.11.1 or higher
  }

  if (TagLib::isTagLibVersionAtLeast(1, 12)) {
    // running v1.12 or higher
  }
```