### PR TITLE
FLAC: Store comment block before picture block (#954)

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -187,16 +187,24 @@ bool FLAC::File::save()
 
   // Replace metadata blocks
 
-  for(BlockIterator it = d->blocks.begin(); it != d->blocks.end(); ++it) {
+  MetadataBlock *commentBlock =
+      new UnknownMetadataBlock(MetadataBlock::VorbisComment, d->xiphCommentData);
+  for(BlockIterator it = d->blocks.begin(); it != d->blocks.end();) {
     if((*it)->code() == MetadataBlock::VorbisComment) {
-      // Set the new Vorbis Comment block
+      // Remove the old Vorbis Comment block
       delete *it;
-      d->blocks.erase(it);
-      break;
+      it = d->blocks.erase(it);
+      continue;
     }
+    if(commentBlock && (*it)->code() == MetadataBlock::Picture) {
+      // Set the new Vorbis Comment block before the first picture block
+      d->blocks.insert(it, commentBlock);
+      commentBlock = 0;
+    }
+    ++it;
   }
-
-  d->blocks.append(new UnknownMetadataBlock(MetadataBlock::VorbisComment, d->xiphCommentData));
+  if(commentBlock)
+    d->blocks.append(commentBlock);
 
   // Render data for the metadata blocks
 


### PR DESCRIPTION
When the picture block is large and comes before the comment block, Windows will no longer display the tags. This can be fixed by storing the comment block before the picture block instead of appending it at the end.