### PR TITLE
Drop leftovers WITH_ASF and WITH_MP4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,6 @@ endif()
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 configure_file(config.h.cmake "${CMAKE_CURRENT_BINARY_DIR}/config.h")
 
-if(WITH_ASF)
-  set(TAGLIB_WITH_ASF TRUE)
-endif()
-if(WITH_MP4)
-  set(TAGLIB_WITH_MP4 TRUE)
-endif()
-
 option(TRACE_IN_RELEASE "Output debug messages even in release mode" OFF)
 if(TRACE_IN_RELEASE)
   set(TRACE_IN_RELEASE TRUE)

--- a/Doxyfile.cmake
+++ b/Doxyfile.cmake
@@ -169,9 +169,7 @@ SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = 
 INCLUDE_FILE_PATTERNS  = 
 PREDEFINED             = DO_NOT_DOCUMENT \
-                         DOXYGEN \
-                         WITH_MP4 \
-                         WITH_ASF
+                         DOXYGEN
 EXPAND_AS_DEFINED      = 
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------


### PR DESCRIPTION
The options WITH_ASF and WITH_MP4 where remove in commit dd846904cbc1ef3ee628d77f0c9df88ef8967816 back in 2011. It's time to remove the leftovers :-)