### PR TITLE
Fix taglib-config for cross compiling, again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 
 project(taglib)
 
+include(GNUInstallDirs)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 if(DEFINED ENABLE_STATIC)
@@ -47,11 +49,10 @@ add_definitions(-DHAVE_CONFIG_H)
 set(TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests/")
 
 ## the following are directories where stuff will be installed to
-set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")
 set(EXEC_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}" CACHE PATH "Base directory for executables and libraries")
-set(BIN_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/bin" CACHE PATH "The subdirectory to the binaries prefix (default prefix/bin)")
-set(LIB_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})")
-set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The subdirectory to the header prefix")
+set(BIN_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" CACHE PATH "The subdirectory to the binaries prefix (default prefix/bin)")
+set(LIB_INSTALL_DIR "${EXEC_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})")
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" CACHE PATH "The subdirectory to the header prefix")
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")

--- a/taglib-config.cmake
+++ b/taglib-config.cmake
@@ -16,8 +16,8 @@ EOH
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@LIB_INSTALL_DIR@
-includedir=@INCLUDE_INSTALL_DIR@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 flags=""
 


### PR DESCRIPTION
Commit 7470f92a67375d00e53b3785a88fa7b26ad6f1da fixed using taglib-config in a cross compiling context. Commit cd9e6b750206417f155574c78d2551242a779a97 broke using `taglib-config --libs` when cross compiling as the sysroot path is not included in `LIB_INSTALL_DIR`.

Use CMakes `GNUInstallDirs` and its variables `CMAKE_INSTALL_<dir>` to get the directory name `lib` or `lib64` from CMake.

This should hopefully fixe **cross compilation and lib64** issues.