### PR TITLE
Fuzzer fixes

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -419,9 +419,9 @@ void APE::Tag::parse(const ByteVector &data)
     }
 
     const unsigned int keyLength = nullPos - pos - 8;
-    const unsigned int valLegnth = data.toUInt(pos, false);
+    const unsigned int valLength = data.toUInt(pos, false);
 
-    if(valLegnth >= data.size() || pos > data.size() - valLegnth) {
+    if(valLength >= data.size() || pos > data.size() - valLength) {
       debug("APE::Tag::parse() - Invalid val length. Stopped parsing.");
       return;
     }
@@ -439,6 +439,6 @@ void APE::Tag::parse(const ByteVector &data)
       debug("APE::Tag::parse() - Skipped an item due to an invalid key.");
     }
 
-    pos += keyLength + valLegnth + 9;
+    pos += keyLength + valLength + 9;
   }
 }

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -421,6 +421,11 @@ void APE::Tag::parse(const ByteVector &data)
     const unsigned int keyLength = nullPos - pos - 8;
     const unsigned int valLegnth = data.toUInt(pos, false);
 
+    if(valLegnth >= data.size() || pos > data.size() - valLegnth) {
+      debug("APE::Tag::parse() - Invalid val length. Stopped parsing.");
+      return;
+    }
+
     if(keyLength >= MinKeyLength
       && keyLength <= MaxKeyLength
       && isKeyValid(data.mid(pos + 8, keyLength)))

--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -384,7 +384,7 @@ void ASF::File::FilePrivate::HeaderExtensionObject::parse(ASF::File *file, unsig
     }
     bool ok;
     long long size = readQWORD(file, &ok);
-    if(!ok) {
+    if(!ok || size < 0 || size > dataSize - dataPos) {
       file->setValid(false);
       break;
     }

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -497,6 +497,11 @@ void FLAC::File::scan()
 
     seek(nextBlockOffset);
     const ByteVector header = readBlock(4);
+    if(header.size() != 4) {
+      debug("FLAC::File::scan() -- Failed to read a block header");
+      setValid(false);
+      return;
+    }
 
     // Header format (from spec):
     // <1> Last-metadata-block flag

--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -298,6 +298,9 @@ void MPC::Properties::readSV8(File *file, long streamLength)
 void MPC::Properties::readSV7(const ByteVector &data, long streamLength)
 {
   if(data.startsWith("MP+")) {
+    if(data.size() < 4)
+      return;
+
     d->version = data[3] & 15;
     if(d->version < 7)
       return;

--- a/taglib/mpeg/id3v2/frames/ownershipframe.cpp
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.cpp
@@ -118,7 +118,7 @@ void OwnershipFrame::parseFields(const ByteVector &data)
   int pos = 0;
 
   // Need at least 1 byte for the encoding
-  if(data.size() - pos < 1) {
+  if(data.isEmpty()) {
     return;
   }
 

--- a/taglib/mpeg/id3v2/frames/ownershipframe.cpp
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.cpp
@@ -117,6 +117,11 @@ void OwnershipFrame::parseFields(const ByteVector &data)
 {
   int pos = 0;
 
+  // Need at least 1 byte for the encoding
+  if(data.size() - pos < 1) {
+    return;
+  }
+
   // Get the text encoding
   d->textEncoding = String::Type(data[0]);
   pos += 1;

--- a/taglib/mpeg/id3v2/id3v2synchdata.cpp
+++ b/taglib/mpeg/id3v2/id3v2synchdata.cpp
@@ -74,6 +74,10 @@ ByteVector SynchData::fromUInt(unsigned int value)
 
 ByteVector SynchData::decode(const ByteVector &data)
 {
+  if (data.size() == 0) {
+    return ByteVector();
+  }
+
   // We have this optimized method instead of using ByteVector::replace(),
   // since it makes a great difference when decoding huge unsynchronized frames.
 


### PR DESCRIPTION
While fuzzing another project I started getting notifications from KDE that `kdeinit5` was crashing trying to generate thumbnails for the invalid FLAC files that were being produced. That piqued my curiosity and so I made a rudimentary fuzzer for taglib which discovered the following issues.

`kdeinit5` doesn't appear to use taglib for all file types, so opening a folder containing the interesting inputs only produces the following crash logs as well as causing 1 core to pin at 100% inside taglib:

```
#4  0x00007f8b080959d5 in raise () from /lib64/libc.so.6
#5  0x00007f8b0807e8a4 in abort () from /lib64/libc.so.6
#6  0x00007f8ae8274bd8 in std::__replacement_assert(char const*, int, char const*, char const*) () from /lib64/libtag.so.1
#7  0x00007f8ae8280beb in TagLib::ByteVector::operator[](int) const () from /lib64/libtag.so.1
#8  0x00007f8ae8279fb3 in TagLib::MPC::Properties::readSV7(TagLib::ByteVector const&, long) () from /lib64/libtag.so.1
#9  0x00007f8ae827a4a6 in TagLib::MPC::Properties::Properties(TagLib::MPC::File*, long, TagLib::AudioProperties::ReadStyle) () from /lib64/libtag.so.1
#10 0x00007f8ae827d1ae in TagLib::MPC::File::read(bool) () from /lib64/libtag.so.1
#11 0x00007f8ae827d37b in TagLib::MPC::File::File(char const*, bool, TagLib::AudioProperties::ReadStyle) () from /lib64/libtag.so.1
```
```
#4  0x00007f8b080959d5 in raise () from /lib64/libc.so.6
#5  0x00007f8b0807e8a4 in abort () from /lib64/libc.so.6
#6  0x00007f8ae8274bd8 in std::__replacement_assert(char const*, int, char const*, char const*) () from /lib64/libtag.so.1
#7  0x00007f8ae8280beb in TagLib::ByteVector::operator[](int) const () from /lib64/libtag.so.1
#8  0x00007f8ae828a574 in TagLib::FLAC::File::scan() () from /lib64/libtag.so.1
#9  0x00007f8ae828a8ec in TagLib::FLAC::File::read(bool) () from /lib64/libtag.so.1
#10 0x00007f8ae828ab7c in TagLib::FLAC::File::File(char const*, bool, TagLib::AudioProperties::ReadStyle) () from /lib64/libtag.so.1
```
```
#4  0x00007f8b080959d5 in raise () from /lib64/libc.so.6
#5  0x00007f8b0807e8a4 in abort () from /lib64/libc.so.6
#6  0x00007f8ae8274bd8 in std::__replacement_assert(char const*, int, char const*, char const*) () from /lib64/libtag.so.1
#7  0x00007f8ae8280beb in TagLib::ByteVector::operator[](int) const () from /lib64/libtag.so.1
#8  0x00007f8ae8266e3f in TagLib::ID3v2::OwnershipFrame::parseFields(TagLib::ByteVector const&) () from /lib64/libtag.so.1
#9  0x00007f8ae82670ae in TagLib::ID3v2::OwnershipFrame::OwnershipFrame(TagLib::ByteVector const&, TagLib::ID3v2::Frame::Header*) () from /lib64/libtag.so.1
#10 0x00007f8ae825ac6d in TagLib::ID3v2::FrameFactory::createFrame(TagLib::ByteVector const&, TagLib::ID3v2::Header const*) const () from /lib64/libtag.so.1
#11 0x00007f8ae825e483 in TagLib::ID3v2::Tag::parse(TagLib::ByteVector const&) () from /lib64/libtag.so.1
#12 0x00007f8ae825e831 in TagLib::ID3v2::Tag::read() () from /lib64/libtag.so.1
#13 0x00007f8ae825e984 in TagLib::ID3v2::Tag::Tag(TagLib::File*, long, TagLib::ID3v2::FrameFactory const*) () from /lib64/libtag.so.1
#14 0x00007f8ae825ea22 in TagLib::MPEG::File::read(bool) () from /lib64/libtag.so.1
#15 0x00007f8ae825ec6c in TagLib::MPEG::File::File(char const*, bool, TagLib::AudioProperties::ReadStyle) () from /lib64/libtag.so.1
```

Note that there's also a few UBSan issues that fuzzing picked up which I haven't fixed (mostly invalid enum values, but also unspecified `float` to `int` conversions for values that don't fit inside `int`s), however I would strongly recommend setting up something like [oss-fuzz integration](https://github.com/google/oss-fuzz) to catch any remaining issues.