### PR TITLE
Fix "error: duplicate ‘volatile’" on systems without HAVE_GCC_ATOMIC in 1.12

### DIFF
--- a/taglib/toolkit/trefcounter.cpp
+++ b/taglib/toolkit/trefcounter.cpp
@@ -66,7 +66,7 @@ namespace TagLib
     RefCounterPrivate() :
       refCount(1) {}
 
-    volatile ATOMIC_INT refCount;
+    ATOMIC_INT refCount;
   };
 
   RefCounter::RefCounter() :

--- a/taglib/toolkit/trefcounter.cpp
+++ b/taglib/toolkit/trefcounter.cpp
@@ -52,7 +52,7 @@
 # define ATOMIC_INC(x) __sync_add_and_fetch(&x, 1)
 # define ATOMIC_DEC(x) __sync_sub_and_fetch(&x, 1)
 #else
-# define ATOMIC_INT volatile int
+# define ATOMIC_INT int
 # define ATOMIC_INC(x) (++x)
 # define ATOMIC_DEC(x) (--x)
 #endif
@@ -66,7 +66,7 @@ namespace TagLib
     RefCounterPrivate() :
       refCount(1) {}
 
-    ATOMIC_INT refCount;
+    volatile ATOMIC_INT refCount;
   };
 
   RefCounter::RefCounter() :


### PR DESCRIPTION
If you don't have `HAVE_GCC_ATOMIC` defined (for some reason) you'll get an error:
```
../../../libs/taglib/taglib-1.12/taglib/toolkit/trefcounter.cpp:55:21: error: duplicate ‘volatile’
   55 | # define ATOMIC_INT volatile int
      |                     ^~~~~~~~
../../../libs/taglib/taglib-1.12/taglib/toolkit/trefcounter.cpp:69:14: note: in expansion of macro ‘ATOMIC_INT’
   69 |     volatile ATOMIC_INT refCount;
   ```