### PR TITLE
Detect by contents if file detected by extension is invalid (#1011)

### DIFF
--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -109,41 +109,52 @@ namespace
 
     // .oga can be any audio in the Ogg container. So leave it to content-based detection.
 
+    File *file = 0;
+
     if(ext == "MP3")
-      return new MPEG::File(stream, ID3v2::FrameFactory::instance(), readAudioProperties, audioPropertiesStyle);
-    if(ext == "OGG")
-      return new Ogg::Vorbis::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "FLAC")
-      return new FLAC::File(stream, ID3v2::FrameFactory::instance(), readAudioProperties, audioPropertiesStyle);
-    if(ext == "MPC")
-      return new MPC::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "WV")
-      return new WavPack::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "SPX")
-      return new Ogg::Speex::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "OPUS")
-      return new Ogg::Opus::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "TTA")
-      return new TrueAudio::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "M4A" || ext == "M4R" || ext == "M4B" || ext == "M4P" || ext == "MP4" || ext == "3G2" || ext == "M4V")
-      return new MP4::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "WMA" || ext == "ASF")
-      return new ASF::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "AIF" || ext == "AIFF" || ext == "AFC" || ext == "AIFC")
-      return new RIFF::AIFF::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "WAV")
-      return new RIFF::WAV::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "APE")
-      return new APE::File(stream, readAudioProperties, audioPropertiesStyle);
+      file = new MPEG::File(stream, ID3v2::FrameFactory::instance(), readAudioProperties, audioPropertiesStyle);
+    else if(ext == "OGG")
+      file = new Ogg::Vorbis::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "FLAC")
+      file = new FLAC::File(stream, ID3v2::FrameFactory::instance(), readAudioProperties, audioPropertiesStyle);
+    else if(ext == "MPC")
+      file = new MPC::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "WV")
+      file = new WavPack::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "SPX")
+      file = new Ogg::Speex::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "OPUS")
+      file = new Ogg::Opus::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "TTA")
+      file = new TrueAudio::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "M4A" || ext == "M4R" || ext == "M4B" || ext == "M4P" || ext == "MP4" || ext == "3G2" || ext == "M4V")
+      file = new MP4::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "WMA" || ext == "ASF")
+      file = new ASF::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "AIF" || ext == "AIFF" || ext == "AFC" || ext == "AIFC")
+      file = new RIFF::AIFF::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "WAV")
+      file = new RIFF::WAV::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "APE")
+      file = new APE::File(stream, readAudioProperties, audioPropertiesStyle);
     // module, nst and wow are possible but uncommon extensions
-    if(ext == "MOD" || ext == "MODULE" || ext == "NST" || ext == "WOW")
-      return new Mod::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "S3M")
-      return new S3M::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "IT")
-      return new IT::File(stream, readAudioProperties, audioPropertiesStyle);
-    if(ext == "XM")
-      return new XM::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "MOD" || ext == "MODULE" || ext == "NST" || ext == "WOW")
+      file = new Mod::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "S3M")
+      file = new S3M::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "IT")
+      file = new IT::File(stream, readAudioProperties, audioPropertiesStyle);
+    else if(ext == "XM")
+      file = new XM::File(stream, readAudioProperties, audioPropertiesStyle);
+
+    // if file is not valid, leave it to content-based detection.
+
+    if(file) {
+      if(file->isValid())
+        return file;
+      else
+        delete file;
+    }
 
     return 0;
   }


### PR DESCRIPTION
This is the case for Opus files with an ogg extension.