### PR TITLE
clang-tidy: replace static_cast with dynamic_cast

### DIFF
--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -340,19 +340,20 @@ void FrameFactory::rebuildAggregateFrames(ID3v2::Tag *tag) const
   {
     TextIdentificationFrame *tdrc =
       dynamic_cast<TextIdentificationFrame *>(tag->frameList("TDRC").front());
-    UnknownFrame *tdat = static_cast<UnknownFrame *>(tag->frameList("TDAT").front());
+    UnknownFrame *tdat = dynamic_cast<UnknownFrame *>(tag->frameList("TDAT").front());
 
     if(tdrc &&
        tdrc->fieldList().size() == 1 &&
        tdrc->fieldList().front().size() == 4 &&
+       tdat &&
        tdat->data().size() >= 5)
     {
       String date(tdat->data().mid(1), String::Type(tdat->data()[0]));
       if(date.length() == 4) {
         tdrc->setText(tdrc->toString() + '-' + date.substr(2, 2) + '-' + date.substr(0, 2));
         if(tag->frameList("TIME").size() == 1) {
-          UnknownFrame *timeframe = static_cast<UnknownFrame *>(tag->frameList("TIME").front());
-          if(timeframe->data().size() >= 5) {
+          UnknownFrame *timeframe = dynamic_cast<UnknownFrame *>(tag->frameList("TIME").front());
+          if(timeframe && timeframe->data().size() >= 5) {
             String time(timeframe->data().mid(1), String::Type(timeframe->data()[0]));
             if(time.length() == 4) {
               tdrc->setText(tdrc->toString() + 'T' + time.substr(0, 2) + ':' + time.substr(2, 2));

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -197,7 +197,7 @@ String ID3v2::Tag::genre() const
   // appended to the genre string.  Multiple fields will be appended as the
   // string is built.
 
-  TextIdentificationFrame *f = static_cast<TextIdentificationFrame *>(
+  TextIdentificationFrame *f = dynamic_cast<TextIdentificationFrame *>(
     d->frameListMap["TCON"].front());
 
   StringList fields = f->fieldList();

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -185,8 +185,10 @@ String ID3v2::Tag::genre() const
   // should be separated by " / " instead of " ".  For the moment to keep
   // the behavior the same as released versions it is being left with " ".
 
-  if(d->frameListMap["TCON"].isEmpty() ||
-     !dynamic_cast<TextIdentificationFrame *>(d->frameListMap["TCON"].front()))
+  const FrameList &tconFrames = d->frameListMap["TCON"];
+  TextIdentificationFrame *f;
+  if(tconFrames.isEmpty() ||
+     !(f = dynamic_cast<TextIdentificationFrame *>(tconFrames.front())))
   {
     return String();
   }
@@ -196,9 +198,6 @@ String ID3v2::Tag::genre() const
   // Here was assume that if an ID3v1 string is present that it should be
   // appended to the genre string.  Multiple fields will be appended as the
   // string is built.
-
-  TextIdentificationFrame *f = dynamic_cast<TextIdentificationFrame *>(
-    d->frameListMap["TCON"].front());
 
   StringList fields = f->fieldList();
 


### PR DESCRIPTION
Found with cppcoreguidelines-pro-type-static-cast-downcast

Signed-off-by: Rosen Penev <rosenp@gmail.com>