### PR TITLE
add missing const

### DIFF
--- a/taglib/mp4/mp4atom.cpp
+++ b/taglib/mp4/mp4atom.cpp
@@ -31,7 +31,7 @@
 
 using namespace TagLib;
 
-const char *MP4::Atom::containers[11] = {
+const char *const MP4::Atom::containers[11] = {
     "moov", "udta", "mdia", "meta", "ilst",
     "stbl", "minf", "moof", "traf", "trak",
     "stsd"

--- a/taglib/mp4/mp4atom.h
+++ b/taglib/mp4/mp4atom.h
@@ -88,7 +88,7 @@ namespace TagLib {
       AtomList children;
     private:
       static const int numContainers = 11;
-      static const char *containers[11];
+      static const char *const containers[11];
     };
 
     //! Root-level atoms

--- a/taglib/mpeg/id3v1/id3v1genres.cpp
+++ b/taglib/mpeg/id3v1/id3v1genres.cpp
@@ -29,7 +29,7 @@ using namespace TagLib;
 
 namespace
 {
-  const wchar_t *genres[] = {
+  const wchar_t *const genres[] = {
     L"Blues",
     L"Classic Rock",
     L"Country",


### PR DESCRIPTION
Avoids using a non const global variable.

Signed-off-by: Rosen Penev <rosenp@gmail.com>