### PR TITLE
Add compile_commands.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ CMakeFiles/
 taglib.h.stamp
 taglib.xcodeproj
 CMakeScripts
+/.clang-format
+/compile_commands.json
+.clangd
+.cache
+.idea


### PR DESCRIPTION
Other entries were copied from KDE/marble repo as well.

See also: https://invent.kde.org/sdk/kdesrc-build/-/issues/86