### PR TITLE
Remove MP4 meta atom when empty tag is saved

### DIFF
--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -176,6 +176,26 @@ MP4::File::save()
 }
 
 bool
+MP4::File::strip(int tags)
+{
+  if(readOnly()) {
+    debug("MP4::File::strip() - Cannot strip tags from a read only file.");
+    return false;
+  }
+
+  if(!isValid()) {
+    debug("MP4::File::strip() -- Cannot strip tags from an invalid file.");
+    return false;
+  }
+
+  if(tags & MP4) {
+    return d->tag->strip();
+  }
+
+  return true;
+}
+
+bool
 MP4::File::hasMP4Tag() const
 {
   return (d->atoms->find("moov", "udta", "meta", "ilst") != 0);

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -49,6 +49,19 @@ namespace TagLib {
     {
     public:
       /*!
+       * This set of flags is used for strip() and is suitable for
+       * being OR-ed together.
+       */
+      enum TagTypes {
+        //! Empty set.  Matches no tag types.
+        NoTags  = 0x0000,
+        //! Matches MP4 tags.
+        MP4     = 0x0001,
+        //! Matches all tag types.
+        AllTags = 0xffff
+      };
+
+      /*!
        * Constructs an MP4 file from \a file.  If \a readProperties is true the
        * file's audio properties will also be read.
        *
@@ -113,6 +126,15 @@ namespace TagLib {
        * This returns true if the save was successful.
        */
       bool save();
+
+      /*!
+       * This will strip the tags that match the OR-ed together TagTypes from the
+       * file.  By default it strips all tags.  It returns true if the tags are
+       * successfully stripped.
+       *
+       * \note This will update the file immediately.
+       */
+      bool strip(int tags = AllTags);
 
       /*!
        * Returns whether or not the file on disk actually has an MP4 tag, or the

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -102,6 +102,11 @@ namespace TagLib {
          */
         bool contains(const String &key) const;
 
+        /*!
+         * Saves the associated file with the tag stripped.
+         */
+        bool strip();
+
         PropertyMap properties() const;
         void removeUnsupportedProperties(const StringList& properties);
         PropertyMap setProperties(const PropertyMap &properties);

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -65,6 +65,7 @@ class TestMP4 : public CppUnit::TestFixture
   CPPUNIT_TEST(testRepeatedSave);
   CPPUNIT_TEST(testWithZeroLengthAtom);
   CPPUNIT_TEST(testEmptyValuesRemoveItems);
+  CPPUNIT_TEST(testRemoveMetadata);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -653,6 +654,39 @@ public:
     tag->setTrack(zeroUInt);
     CPPUNIT_ASSERT_EQUAL(zeroUInt, tag->track());
     CPPUNIT_ASSERT(!tag->contains("trkn"));
+  }
+
+  void testRemoveMetadata()
+  {
+    ScopedFileCopy copy("no-tags", ".m4a");
+
+    {
+      MP4::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasMP4Tag());
+      MP4::Tag *tag = f.tag();
+      CPPUNIT_ASSERT(tag->isEmpty());
+      tag->setTitle("TITLE");
+      f.save();
+    }
+    {
+      MP4::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.hasMP4Tag());
+      MP4::Tag *tag = f.tag();
+      CPPUNIT_ASSERT(!tag->isEmpty());
+      tag->setTitle("");
+      f.save();
+    }
+    {
+      MP4::File f(copy.fileName().c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasMP4Tag());
+      CPPUNIT_ASSERT(f.tag()->isEmpty());
+      CPPUNIT_ASSERT(fileEqual(
+        copy.fileName(),
+        TEST_FILE_PATH_C("no-tags.m4a")));
+    }
   }
 };
 

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -673,10 +673,8 @@ public:
       MP4::File f(copy.fileName().c_str());
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT(f.hasMP4Tag());
-      MP4::Tag *tag = f.tag();
-      CPPUNIT_ASSERT(!tag->isEmpty());
-      tag->setTitle("");
-      f.save();
+      CPPUNIT_ASSERT(!f.tag()->isEmpty());
+      f.strip();
     }
     {
       MP4::File f(copy.fileName().c_str());


### PR DESCRIPTION
Currently, MP4 tags can only grow. If items are removed, they are just replaced by padding in the form of "free" atoms. This change will remove the whole "meta" atom when an MP4 tag without items is saved. This will make it possible, to bring the file back to its pristine state without metadata.