### PR TITLE
Utils: Fix potential ID3v1 false positive in the presence of an APE tag.

### DIFF
--- a/taglib/tagutils.cpp
+++ b/taglib/tagutils.cpp
@@ -38,11 +38,22 @@ long Utils::findID3v1(File *file)
   if(!file->isValid())
     return -1;
 
-  file->seek(-128, File::End);
-  const long p = file->tell();
+  // Differentiate between a match of APEv2 magic and a match of ID3v1 magic.
 
-  if(file->readBlock(3) == ID3v1::Tag::fileIdentifier())
-    return p;
+  if (file->length() >= 131) {
+    file->seek(-131, File::End);
+    const long p = file->tell() + 3;
+    const TagLib::ByteVector data = file->readBlock(8);
+
+    if(data.containsAt(ID3v1::Tag::fileIdentifier(), 3) && (data != APE::Tag::fileIdentifier()))
+      return p;
+  } else {
+    file->seek(-128, File::End);
+    const long p = file->tell();
+
+    if(file->readBlock(3) == ID3v1::Tag::fileIdentifier())
+      return p;
+  }
 
   return -1;
 }

--- a/tests/test_apetag.cpp
+++ b/tests/test_apetag.cpp
@@ -29,6 +29,7 @@
 #include <tstringlist.h>
 #include <tbytevectorlist.h>
 #include <tpropertymap.h>
+#include <apefile.h>
 #include <apetag.h>
 #include <tdebug.h>
 #include <cppunit/extensions/HelperMacros.h>
@@ -46,6 +47,7 @@ class TestAPETag : public CppUnit::TestFixture
   CPPUNIT_TEST(testPropertyInterface2);
   CPPUNIT_TEST(testInvalidKeys);
   CPPUNIT_TEST(testTextBinary);
+  CPPUNIT_TEST(testID3v1Collision);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -163,6 +165,24 @@ public:
     item.setValue("Test Text 2");
     CPPUNIT_ASSERT_EQUAL(String("Test Text 2"), item.toString());
     CPPUNIT_ASSERT_EQUAL(ByteVector(), item.binaryData());
+  }
+
+  void testID3v1Collision()
+  {
+    ScopedFileCopy copy("no-tags", ".mpc");
+    string newname = copy.fileName();
+
+    {
+      APE::File f(newname.c_str());
+      f.APETag(true)->setArtist("Filltointersect    ");
+      f.APETag()->setTitle("Filltointersect    ");
+      f.save();
+    }
+
+    {
+      APE::File f(newname.c_str());
+      CPPUNIT_ASSERT(!f.hasID3v1Tag());
+    }
   }
 
 };


### PR DESCRIPTION
This could cause incorrect tag parsing. Closes https://github.com/taglib/taglib/issues/1043.