### PR TITLE
Use property "WORK" instead of "CONTENTGROUP" for ID3v2 "TIT1" frame

### DIFF
--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -220,7 +220,7 @@ namespace
     std::make_pair("WM/Year", "DATE"),
     std::make_pair("WM/OriginalReleaseYear", "ORIGINALDATE"),
     std::make_pair("WM/Producer", "PRODUCER"),
-    std::make_pair("WM/ContentGroupDescription", "GROUPING"),
+    std::make_pair("WM/ContentGroupDescription", "WORK"),
     std::make_pair("WM/SubTitle", "SUBTITLE"),
     std::make_pair("WM/SetSubTitle", "DISCSUBTITLE"),
     std::make_pair("WM/TrackNumber", "TRACKNUMBER"),

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -342,7 +342,7 @@ namespace
     std::make_pair("TEXT", "LYRICIST"),
     std::make_pair("TFLT", "FILETYPE"),
     //std::make_pair("TIPL", "INVOLVEDPEOPLE"), handled separately
-    std::make_pair("TIT1", "CONTENTGROUP"), // 'Work' in iTunes
+    std::make_pair("TIT1", "WORK"), // 'Work' in iTunes
     std::make_pair("TIT2", "TITLE"),
     std::make_pair("TIT3", "SUBTITLE"),
     std::make_pair("TKEY", "INITIALKEY"),
@@ -394,6 +394,7 @@ namespace
     std::make_pair("MVNM", "MOVEMENTNAME"),
     std::make_pair("MVIN", "MOVEMENTNUMBER"),
     std::make_pair("GRP1", "GROUPING"),
+    std::make_pair("TCMP", "COMPILATION"),
   };
   const size_t frameTranslationSize = sizeof(frameTranslation) / sizeof(frameTranslation[0]);
 

--- a/tests/test_asf.cpp
+++ b/tests/test_asf.cpp
@@ -328,7 +328,7 @@ public:
     tags["DISCSUBTITLE"] = StringList("Disc Subtitle");
     tags["ENCODEDBY"] = StringList("Encoded by");
     tags["GENRE"] = StringList("Genre");
-    tags["GROUPING"] = StringList("Grouping");
+    tags["WORK"] = StringList("Grouping");
     tags["ISRC"] = StringList("UKAAA0500001");
     tags["LABEL"] = StringList("Label");
     tags["LANGUAGE"] = StringList("eng");

--- a/tests/test_mpeg.cpp
+++ b/tests/test_mpeg.cpp
@@ -314,10 +314,11 @@ public:
     tags["CATALOGNUMBER"] = StringList("Catalog Number");
     tags["COMMENT"] = StringList("Comment");
     tags["COMMENT:CDESC"] = StringList("Comment with Description");
+    tags["COMPILATION"] = StringList("1");
     tags["COMPOSER"] = StringList("Composer");
     tags["COMPOSERSORT"] = StringList("Composer Sort");
     tags["CONDUCTOR"] = StringList("Conductor");
-    tags["CONTENTGROUP"] = StringList("Content Group");
+    tags["WORK"] = StringList("Content Group");
     tags["COPYRIGHT"] = StringList("2021 Copyright");
     tags["COPYRIGHTURL"] = StringList("Copyright URL");
     tags["DATE"] = StringList("2021-01-03 12:29:23");


### PR DESCRIPTION
Also use "WORK" for ASF "WM/ContentGroupDescription", as it corresponds to "TIT1" according to https://docs.microsoft.com/en-us/windows/win32/wmformat/id3-tag-support.
Add property "COMPILATION" for ID3v2 "TCMP" to be consistent with MP4 "cpil".

On request from https://mail.kde.org/pipermail/taglib-devel/2022-March/003025.html.