### PR TITLE
Fix ID3v2 version handling for embedded frames

### DIFF
--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -294,8 +294,10 @@ ByteVector ChapterFrame::renderFields() const
   data.append(ByteVector::fromUInt(d->startOffset, true));
   data.append(ByteVector::fromUInt(d->endOffset, true));
   FrameList l = d->embeddedFrameList;
-  for(FrameList::ConstIterator it = l.begin(); it != l.end(); ++it)
+  for(FrameList::ConstIterator it = l.begin(); it != l.end(); ++it) {
+    (*it)->header()->setVersion(header()->version());
     data.append((*it)->render());
+  }
 
   return data;
 }

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -344,8 +344,10 @@ ByteVector TableOfContentsFrame::renderFields() const
     it++;
   }
   FrameList l = d->embeddedFrameList;
-  for(FrameList::ConstIterator it = l.begin(); it != l.end(); ++it)
+  for(FrameList::ConstIterator it = l.begin(); it != l.end(); ++it) {
+    (*it)->header()->setVersion(header()->version());
     data.append((*it)->render());
+  }
 
   return data;
 }

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -55,6 +55,8 @@ namespace TagLib {
     {
       friend class Tag;
       friend class FrameFactory;
+      friend class TableOfContentsFrame;
+      friend class ChapterFrame;
 
     public:
 


### PR DESCRIPTION
There currently is no way to set the ID3v2 version of a frame's header using public API.

ID3v2 table of contents and chapter frames may contain other embedded frames. The [specification for these frames](https://id3.org/id3v2-chapters-1.0) is an addendum to both ID3v2.3 and ID3v2.4. While the spec doesn't explicitly state that the ID3 version of the embedded frames should match that of the containing frame, it seems to be a reasonable assumption. The examples given in the spec refer to sync-safe integers so presumably are intended to be examples for ID3v2.4 and not meant to be normative for both ID3 versions.

Currently when an ID3v2 tag is rendered the version of the `Frame::Header` (v2.3 or v2.4) is set in `ID3v2::Tag::render()` prior to calling the frame's `render` method. The frame has access to the version if needed but in the case of table of contents and chapter frames, there is no way to propagate the version to the embedded frames.

This PR solves the issue by making `TableOfContentsFrame` and `ChapterFrame` friends of `Frame` so they can set the header version appropriately. An alternative to this PR would be adding a public method to `Frame` to get and set the ID3v2 version.

Fixes #1053 