### PR TITLE
FileStream: seek only when length exceeds buffer size

### DIFF
--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -206,9 +206,12 @@ ByteVector FileStream::readBlock(unsigned long length)
   if(length == 0)
     return ByteVector();
 
-  const unsigned long streamLength = static_cast<unsigned long>(FileStream::length());
-  if(length > bufferSize() && length > streamLength)
-    length = streamLength;
+  if(length > bufferSize()) {
+    const unsigned long streamLength = static_cast<unsigned long>(FileStream::length());
+    if(length > streamLength) {
+      length = streamLength;
+    }
+  }
 
   ByteVector buffer(static_cast<unsigned int>(length));
 


### PR DESCRIPTION
Hi,
When playing around with my app I spotted that `hotspot` shows taglib's `FileStream::readBlock` spending a significant amount of time reading file length for what seems like prevention of over-allocating the buffer. Turns out that fseeking around the file on each read is not ideal, however, the mechanism is worth to keep around since allocating e.g. (uint32_t(0) - 1) bytes isn't ideal either.

Tested it based with taglib v1.12 as a shared lib that I had previously installed, on manjaro with 5.19.13-1 kernel with i5-4690k cpu and my playlist that consists of 1270 tracks:
```
    208 flac
     21 m4a
   1007 mp3
     34 wav
```

Some flamegraphs, highlighted parts are paths to `FileStream::length`.

Before:
![before-pr](https://user-images.githubusercontent.com/10281628/194733656-dd73dfe9-3619-4270-9419-2beeae114c97.svg)

After:
![after-pr](https://user-images.githubusercontent.com/10281628/194733658-34586f77-7968-45ca-bad0-d791da106087.svg)

```shell
hyperfine --warmup 3 -r 30 --prepare 'rm ~/.config/foobar-debug/cache.db' './foobar' './old/foobar'
Benchmark 1: ./foobar (after PR)
  Time (mean ± σ):     702.0 ms ±   8.2 ms    [User: 292.3 ms, System: 121.5 ms]
  Range (min … max):   693.6 ms … 729.8 ms    30 runs
  
Benchmark 2: ./old/foobar (before PR)
  Time (mean ± σ):     741.1 ms ±   8.6 ms    [User: 312.1 ms, System: 142.4 ms]
  Range (min … max):   730.3 ms … 779.7 ms    30 runs
  
Summary
  './foobar' ran
    1.06 ± 0.02 times faster than './old/foobar'
```

I'm getting quite a speed improvement considering I just moved a line around.