### PR TITLE
MSVC: Disable warnings for internal invocations of API functions (#1000)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,17 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 endif()
 
-if(MSVC AND ENABLE_STATIC_RUNTIME)
-  foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-  endforeach(flag_var)
+if(MSVC)
+  if(ENABLE_STATIC_RUNTIME)
+    foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endforeach(flag_var)
+  endif()
+  # Disable warnings for internal invocations of API functions
+  # that have been marked with TAGLIB_DEPRECATED
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4996")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4996")
 endif()
 
 # Read version information from file taglib/toolkit/taglib.h into variables


### PR DESCRIPTION
https://raw.githubusercontent.com/microsoft/vcpkg/master/ports/taglib/msvc-disable-deprecated-warnings.patch from Uwe Klotz (uklotzde)