### PR TITLE
clang: remove const return

### DIFF
--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -159,7 +159,7 @@ namespace TagLib {
      * If the map does not contain \a key, it returns defaultValue.
      * If no defaultValue is specified, it returns a default-constructed value.
      */
-    const T value(const Key &key, const T &defaultValue = T()) const;
+    T value(const Key &key, const T &defaultValue = T()) const;
 
     /*!
      * Returns a reference to the value associated with \a key.

--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -156,7 +156,7 @@ unsigned int Map<Key, T>::size() const
 }
 
 template <class Key, class T>
-const T Map<Key, T>::value(const Key &key, const T &defaultValue) const
+T Map<Key, T>::value(const Key &key, const T &defaultValue) const
 {
   ConstIterator it = d->map.find(key);
   return it != d->map.end() ? it->second : defaultValue;

--- a/taglib/toolkit/tpropertymap.cpp
+++ b/taglib/toolkit/tpropertymap.cpp
@@ -117,7 +117,7 @@ PropertyMap &PropertyMap::merge(const PropertyMap &other)
   return *this;
 }
 
-const StringList PropertyMap::value(const String &key,
+StringList PropertyMap::value(const String &key,
                                     const StringList &defaultValue) const
 {
   return SimplePropertyMap::value(key.upper(), defaultValue);

--- a/taglib/toolkit/tpropertymap.h
+++ b/taglib/toolkit/tpropertymap.h
@@ -197,7 +197,7 @@ namespace TagLib {
      * If the map does not contain \a key, it returns defaultValue.
      * If no defaultValue is specified, it returns an empty string list.
      */
-    const StringList value(const String &key,
+    StringList value(const String &key,
                            const StringList &defaultValue = StringList()) const;
 
     /*!

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -714,21 +714,21 @@ const String::Type String::WCharByteOrder = wcharByteOrder();
 // related non-member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-const TagLib::String operator+(const TagLib::String &s1, const TagLib::String &s2)
+TagLib::String operator+(const TagLib::String &s1, const TagLib::String &s2)
 {
   TagLib::String s(s1);
   s.append(s2);
   return s;
 }
 
-const TagLib::String operator+(const char *s1, const TagLib::String &s2)
+TagLib::String operator+(const char *s1, const TagLib::String &s2)
 {
   TagLib::String s(s1);
   s.append(s2);
   return s;
 }
 
-const TagLib::String operator+(const TagLib::String &s1, const char *s2)
+TagLib::String operator+(const TagLib::String &s1, const char *s2)
 {
   TagLib::String s(s1);
   s.append(s2);

--- a/taglib/toolkit/tstring.h
+++ b/taglib/toolkit/tstring.h
@@ -553,21 +553,21 @@ namespace TagLib {
  *
  * Concatenates \a s1 and \a s2 and returns the result as a string.
  */
-TAGLIB_EXPORT const TagLib::String operator+(const TagLib::String &s1, const TagLib::String &s2);
+TAGLIB_EXPORT TagLib::String operator+(const TagLib::String &s1, const TagLib::String &s2);
 
 /*!
  * \relates TagLib::String
  *
  * Concatenates \a s1 and \a s2 and returns the result as a string.
  */
-TAGLIB_EXPORT const TagLib::String operator+(const char *s1, const TagLib::String &s2);
+TAGLIB_EXPORT TagLib::String operator+(const char *s1, const TagLib::String &s2);
 
 /*!
  * \relates TagLib::String
  *
  * Concatenates \a s1 and \a s2 and returns the result as a string.
  */
-TAGLIB_EXPORT const TagLib::String operator+(const TagLib::String &s1, const char *s2);
+TAGLIB_EXPORT TagLib::String operator+(const TagLib::String &s1, const char *s2);
 
 
 /*!


### PR DESCRIPTION
Found with readability-const-return-type

Signed-off-by: Rosen Penev <rosenp@gmail.com>