### PR TITLE
Use C++11 atomics for RefCounter

### DIFF
--- a/taglib/toolkit/trefcounter.cpp
+++ b/taglib/toolkit/trefcounter.cpp
@@ -36,7 +36,7 @@ namespace TagLib
     RefCounterPrivate() :
       refCount(1)
     {
-	}
+    }
 
     std::atomic_int refCount;
   };

--- a/taglib/toolkit/trefcounter.h
+++ b/taglib/toolkit/trefcounter.h
@@ -29,26 +29,6 @@
 #include "taglib_export.h"
 #include "taglib.h"
 
-#ifdef __APPLE__
-#  define OSATOMIC_DEPRECATED 0
-#  include <libkern/OSAtomic.h>
-#  define TAGLIB_ATOMIC_MAC
-#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
-#  ifndef NOMINMAX
-#    define NOMINMAX
-#  endif
-#  include <windows.h>
-#  define TAGLIB_ATOMIC_WIN
-#elif defined (__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 401)    \
-      && (defined(__i386__) || defined(__i486__) || defined(__i586__) || \
-          defined(__i686__) || defined(__x86_64) || defined(__ia64)) \
-      && !defined(__INTEL_COMPILER)
-#  define TAGLIB_ATOMIC_GCC
-#elif defined(__ia64) && defined(__INTEL_COMPILER)
-#  include <ia64intrin.h>
-#  define TAGLIB_ATOMIC_GCC
-#endif
-
 #ifndef DO_NOT_DOCUMENT // Tell Doxygen to skip this class.
 /*!
   * \internal


### PR DESCRIPTION
Since it appears the next version of TagLib will use C++17 features it's possible to simplify `RefCounter` using C++11 atomics.