### PR TITLE
clang-tidy: add ending namespace comments

### DIFF
--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -74,7 +74,7 @@ namespace
       return new MP4::File(s);
     }
   };
-}
+} // namespace
 
 class TestFileRef : public CppUnit::TestFixture
 {

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -120,7 +120,7 @@ namespace TagLib {
 
     return String(text);
   }
-}
+} // namespace TagLib
 
 #endif
 


### PR DESCRIPTION
Found with google-readability-namespace-comments