### PR TITLE
clang-tidy: fix mismatched variable names

### DIFF
--- a/taglib/ape/apeitem.h
+++ b/taglib/ape/apeitem.h
@@ -187,11 +187,11 @@ namespace TagLib {
       bool isReadOnly() const;
 
       /*!
-       * Sets the type of the item to \a type.
+       * Sets the type of the item to \a val.
        *
        * \see ItemTypes
        */
-      void setType(ItemTypes type);
+      void setType(ItemTypes val);
 
       /*!
        * Returns the type of the item.

--- a/taglib/asf/asfattribute.h
+++ b/taglib/asf/asfattribute.h
@@ -106,7 +106,7 @@ namespace TagLib
       /*!
        * Construct an attribute as a copy of \a other.
        */
-      Attribute(const Attribute &item);
+      Attribute(const Attribute &other);
 
       /*!
        * Copies the contents of \a other into this item.

--- a/taglib/asf/asftag.h
+++ b/taglib/asf/asftag.h
@@ -102,50 +102,50 @@ namespace TagLib {
       unsigned int track() const override;
 
       /*!
-       * Sets the title to \a s.
+       * Sets the title to \a value.
        */
-      void setTitle(const String &s) override;
+      void setTitle(const String &value) override;
 
       /*!
-       * Sets the artist to \a s.
+       * Sets the artist to \a value.
        */
-      void setArtist(const String &s) override;
+      void setArtist(const String &value) override;
 
       /*!
-       * Sets the album to \a s.  If \a s is String::null then this value will be
+       * Sets the album to \a value.  If \a value is String::null then this value will be
        * cleared.
        */
-      void setAlbum(const String &s) override;
+      void setAlbum(const String &value) override;
 
       /*!
-       * Sets the comment to \a s.
+       * Sets the comment to \a value.
        */
-      void setComment(const String &s) override;
+      void setComment(const String &value) override;
 
       /*!
-       * Sets the rating to \a s.
+       * Sets the rating to \a value.
        */
-      virtual void setRating(const String &s);
+      virtual void setRating(const String &value);
 
       /*!
-       * Sets the copyright to \a s.
+       * Sets the copyright to \a value.
        */
-      virtual void setCopyright(const String &s);
+      virtual void setCopyright(const String &value);
 
       /*!
-       * Sets the genre to \a s.
+       * Sets the genre to \a value.
        */
-      void setGenre(const String &s) override;
+      void setGenre(const String &value) override;
 
       /*!
-       * Sets the year to \a i.  If \a s is 0 then this value will be cleared.
+       * Sets the year to \a value.  If \a value is 0 then this value will be cleared.
        */
-      void setYear(unsigned int i) override;
+      void setYear(unsigned int value) override;
 
       /*!
-       * Sets the track to \a i.  If \a s is 0 then this value will be cleared.
+       * Sets the track to \a value.  If \a value is 0 then this value will be cleared.
        */
-      void setTrack(unsigned int i) override;
+      void setTrack(unsigned int value) override;
 
       /*!
        * Returns true if the tag does not contain any data.  This should be
@@ -168,14 +168,14 @@ namespace TagLib {
       const AttributeListMap &attributeListMap() const;
 
       /*!
-       * \return True if a value for \a attribute is currently set.
+       * \return True if a value for \a key is currently set.
        */
-      bool contains(const String &name) const;
+      bool contains(const String &key) const;
 
       /*!
        * Removes the \a key attribute from the tag
        */
-      void removeItem(const String &name);
+      void removeItem(const String &key);
 
       /*!
        * \return The list of values for the key \a name, or an empty list if no
@@ -184,8 +184,8 @@ namespace TagLib {
       AttributeList attribute(const String &name) const;
 
       /*!
-       * Sets the \a key attribute to the value of \a attribute. If an attribute
-       * with the \a key is already present, it will be replaced.
+       * Sets the \a name attribute to the value of \a attribute. If an attribute
+       * with the \a name is already present, it will be replaced.
        */
       void setAttribute(const String &name, const Attribute &attribute);
 
@@ -195,14 +195,14 @@ namespace TagLib {
       void setAttribute(const String &name, const AttributeList &values);
 
       /*!
-       * Sets the \a key attribute to the value of \a attribute. If an attribute
-       * with the \a key is already present, it will be added to the list.
+       * Sets the \a name attribute to the value of \a attribute. If an attribute
+       * with the \a name is already present, it will be added to the list.
        */
       void addAttribute(const String &name, const Attribute &attribute);
 
       PropertyMap properties() const override;
-      void removeUnsupportedProperties(const StringList& properties) override;
-      PropertyMap setProperties(const PropertyMap &properties) override;
+      void removeUnsupportedProperties(const StringList &props) override;
+      PropertyMap setProperties(const PropertyMap &props) override;
 
     private:
 

--- a/taglib/flac/flacunknownmetadatablock.h
+++ b/taglib/flac/flacunknownmetadatablock.h
@@ -36,7 +36,7 @@ namespace TagLib {
     class TAGLIB_EXPORT UnknownMetadataBlock : public MetadataBlock
     {
     public:
-      UnknownMetadataBlock(int blockType, const ByteVector &data);
+      UnknownMetadataBlock(int code, const ByteVector &data);
       ~UnknownMetadataBlock() override;
 
       UnknownMetadataBlock(const UnknownMetadataBlock &item) = delete;

--- a/taglib/mod/modproperties.h
+++ b/taglib/mod/modproperties.h
@@ -49,7 +49,7 @@ namespace TagLib {
 
       void setChannels(int channels);
 
-      void setInstrumentCount(unsigned int sampleCount);
+      void setInstrumentCount(unsigned int instrumentCount);
       void setLengthInPatterns(unsigned char lengthInPatterns);
 
     private:

--- a/taglib/mp4/mp4item.h
+++ b/taglib/mp4/mp4item.h
@@ -59,7 +59,7 @@ namespace TagLib {
       Item(unsigned int value);
       Item(long long value);
       Item(bool value);
-      Item(int first, int second);
+      Item(int value1, int value2);
       Item(const StringList &value);
       Item(const ByteVectorList &value);
       Item(const CoverArtList &value);

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -99,10 +99,10 @@ namespace TagLib {
         bool strip();
 
         PropertyMap properties() const override;
-        void removeUnsupportedProperties(const StringList& properties) override;
-        PropertyMap setProperties(const PropertyMap &properties) override;
+        void removeUnsupportedProperties(const StringList &props) override;
+        PropertyMap setProperties(const PropertyMap &props) override;
 
-    protected:
+      protected:
         /*!
          * Sets the value of \a key to \a value, overwriting any previous value.
          * If \a value is empty, the item is removed.

--- a/taglib/mpeg/id3v2/frames/commentsframe.h
+++ b/taglib/mpeg/id3v2/frames/commentsframe.h
@@ -100,11 +100,11 @@ namespace TagLib {
       /*!
        * Set the language using the 3 byte language code from
        * <a href="http://en.wikipedia.org/wiki/ISO_639">ISO-639-2</a> to
-       * \a languageCode.
+       * \a languageEncoding.
        *
        * \see language()
        */
-      void setLanguage(const ByteVector &languageCode);
+      void setLanguage(const ByteVector &languageEncoding);
 
       /*!
        * Sets the description of the comment to \a s.

--- a/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.h
+++ b/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.h
@@ -162,7 +162,7 @@ namespace TagLib {
        * \see mimeType()
        * \see setMimeType()
        */
-      void setObject(const ByteVector &object);
+      void setObject(const ByteVector &data);
 
     protected:
       void parseFields(const ByteVector &data) override;

--- a/taglib/mpeg/id3v2/frames/ownershipframe.h
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.h
@@ -82,7 +82,7 @@ namespace TagLib {
        *
        * \see datePurchased()
        */
-      void setDatePurchased(const String &datePurchased);
+      void setDatePurchased(const String &s);
 
       /*!
        * Returns the price paid.
@@ -96,7 +96,7 @@ namespace TagLib {
        *
        * \see pricePaid()
        */
-      void setPricePaid(const String &pricePaid);
+      void setPricePaid(const String &s);
 
       /*!
        * Returns the seller.

--- a/taglib/mpeg/id3v2/frames/popularimeterframe.h
+++ b/taglib/mpeg/id3v2/frames/popularimeterframe.h
@@ -83,7 +83,7 @@ namespace TagLib {
        *
        * \see email()
        */
-      void setEmail(const String &email);
+      void setEmail(const String &s);
 
       /*!
        * Returns the rating.
@@ -97,7 +97,7 @@ namespace TagLib {
        *
        * \see rating()
        */
-      void setRating(int rating);
+      void setRating(int s);
 
       /*!
        * Returns the counter.
@@ -111,7 +111,7 @@ namespace TagLib {
        *
        * \see counter()
        */
-      void setCounter(unsigned int counter);
+      void setCounter(unsigned int s);
 
     protected:
       // Reimplementations.

--- a/taglib/mpeg/id3v2/frames/privateframe.h
+++ b/taglib/mpeg/id3v2/frames/privateframe.h
@@ -88,7 +88,7 @@ namespace TagLib {
       /*!
        *
        */
-      void setData(const ByteVector &v);
+      void setData(const ByteVector &data);
 
     protected:
       // Reimplementations.

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.h
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.h
@@ -178,11 +178,11 @@ namespace TagLib {
       /*!
        * Set the language using the 3 byte language code from
        * <a href="http://en.wikipedia.org/wiki/ISO_639">ISO-639-2</a> to
-       * \a languageCode.
+       * \a languageEncoding.
        *
        * \see language()
        */
-      void setLanguage(const ByteVector &languageCode);
+      void setLanguage(const ByteVector &languageEncoding);
 
       /*!
        * Set the timestamp format.

--- a/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.h
+++ b/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.h
@@ -98,11 +98,11 @@ namespace TagLib {
       /*!
        * Set the language using the 3 byte language code from
        * <a href="http://en.wikipedia.org/wiki/ISO_639">ISO-639-2</a> to
-       * \a languageCode.
+       * \a languageEncoding.
        *
        * \see language()
        */
-      void setLanguage(const ByteVector &languageCode);
+      void setLanguage(const ByteVector &languageEncoding);
 
       /*!
        * Sets the description of the unsynchronized lyrics frame to \a s.

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -386,7 +386,7 @@ namespace TagLib {
        *
        * \see tagAlterPreservation()
        */
-      void setTagAlterPreservation(bool discard);
+      void setTagAlterPreservation(bool preserve);
 
       /*!
        * Returns true if the flag for file alter preservation is set.

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -103,7 +103,7 @@ namespace TagLib {
          */
         PropertyMap properties() const override;
 
-        void removeUnsupportedProperties(const StringList &properties) override;
+        void removeUnsupportedProperties(const StringList &unsupported) override;
 
         /*!
          * Implements the unified property interface -- import function.

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -143,7 +143,7 @@ namespace TagLib {
          */
         PropertyMap properties() const override;
 
-        void removeUnsupportedProperties(const StringList &properties) override;
+        void removeUnsupportedProperties(const StringList &unsupported) override;
 
         /*!
          * Implements the unified property interface -- import function.

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -71,12 +71,12 @@ namespace TagLib {
     virtual void removeUnsupportedProperties(const StringList& properties);
 
     /*!
-     * Sets the tags of this File to those specified in \a properties. This default
+     * Sets the tags of this File to those specified in \a origProps. This default
      * implementation sets only the tags for which setter methods exist in this class
      * (artist, album, ...), and only one value per key; the rest will be contained
      * in the returned PropertyMap.
      */
-    virtual PropertyMap setProperties(const PropertyMap &properties);
+    virtual PropertyMap setProperties(const PropertyMap &origProps);
 
     /*!
      * Returns the track name; if no track name is present in the tag

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -99,9 +99,9 @@ namespace TagLib {
     ~ByteVector();
 
     /*!
-     * Sets the data for the byte array using the first \a length bytes of \a data
+     * Sets the data for the byte array using the first \a length bytes of \a s
      */
-    ByteVector &setData(const char *data, unsigned int length);
+    ByteVector &setData(const char *s, unsigned int length);
 
     /*!
      * Sets the data for the byte array copies \a data up to the first null

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -114,9 +114,9 @@ namespace TagLib {
     ConstIterator cend() const;
 
     /*!
-     * Inserts a copy of \a value before \a it.
+     * Inserts a copy of \a item before \a it.
      */
-    Iterator insert(Iterator it, const T &value);
+    Iterator insert(Iterator it, const T &item);
 
     /*!
      * Inserts the \a value into the list.  This assumes that the list is

--- a/taglib/toolkit/tstringlist.h
+++ b/taglib/toolkit/tstringlist.h
@@ -66,12 +66,12 @@ namespace TagLib {
     StringList(const String &s);
 
     /*!
-     * Makes a deep copy of the data in \a vl.
+     * Makes a deep copy of the data in \a bl.
      *
      * \note This should only be used with the 8-bit codecs Latin1 and UTF8, when
      * used with other codecs it will simply print a warning and exit.
      */
-    StringList(const ByteVectorList &vl, String::Type t = String::Latin1);
+    StringList(const ByteVectorList &bl, String::Type t = String::Latin1);
 
     /*!
      * Destroys this StringList instance.

--- a/taglib/trueaudio/trueaudiofile.h
+++ b/taglib/trueaudio/trueaudiofile.h
@@ -155,7 +155,7 @@ namespace TagLib {
        */
       PropertyMap setProperties(const PropertyMap &) override;
 
-      void removeUnsupportedProperties(const StringList &properties) override;
+      void removeUnsupportedProperties(const StringList &unsupported) override;
 
       /*!
        * Returns the TrueAudio::Properties for this file.  If no audio properties

--- a/taglib/wavpack/wavpackfile.h
+++ b/taglib/wavpack/wavpackfile.h
@@ -119,7 +119,7 @@ namespace TagLib {
        */
       PropertyMap properties() const override;
 
-      void removeUnsupportedProperties(const StringList &properties) override;
+      void removeUnsupportedProperties(const StringList &unsupported) override;
 
       /*!
        * Implements the unified property interface -- import function.


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name