### PR TITLE
clang-tidy: init members by default

### DIFF
--- a/taglib/ape/apefile.cpp
+++ b/taglib/ape/apefile.cpp
@@ -55,15 +55,7 @@ namespace
 class APE::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    APELocation(-1),
-    APESize(0),
-    ID3v1Location(-1),
-    ID3v2Header(nullptr),
-    ID3v2Location(-1),
-    ID3v2Size(0),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete ID3v2Header;
@@ -73,18 +65,18 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  offset_t APELocation;
-  long APESize;
+  offset_t APELocation { -1 };
+  long APESize { 0 };
 
-  offset_t ID3v1Location;
+  offset_t ID3v1Location { -1 };
 
-  ID3v2::Header *ID3v2Header;
-  offset_t ID3v2Location;
-  long ID3v2Size;
+  ID3v2::Header *ID3v2Header { nullptr };
+  offset_t ID3v2Location { -1 };
+  long ID3v2Size { 0 };
 
   TagUnion tag;
 
-  Properties *properties;
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ape/apefooter.cpp
+++ b/taglib/ape/apefooter.cpp
@@ -38,23 +38,15 @@ using namespace APE;
 class APE::Footer::FooterPrivate
 {
 public:
-  FooterPrivate() :
-    version(0),
-    footerPresent(true),
-    headerPresent(false),
-    isHeader(false),
-    itemCount(0),
-    tagSize(0) {}
+  unsigned int version { 0 };
 
-  unsigned int version;
+  bool footerPresent { true };
+  bool headerPresent { false };
 
-  bool footerPresent;
-  bool headerPresent;
+  bool isHeader { false };
 
-  bool isHeader;
-
-  unsigned int itemCount;
-  unsigned int tagSize;
+  unsigned int itemCount { 0 };
+  unsigned int tagSize { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ape/apeitem.cpp
+++ b/taglib/ape/apeitem.cpp
@@ -34,15 +34,11 @@ using namespace APE;
 class APE::Item::ItemPrivate
 {
 public:
-  ItemPrivate() :
-    type(Text),
-    readOnly(false) {}
-
-  Item::ItemTypes type;
+  Item::ItemTypes type { Text };
   String key;
   ByteVector value;
   StringList text;
-  bool readOnly;
+  bool readOnly { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ape/apeproperties.cpp
+++ b/taglib/ape/apeproperties.cpp
@@ -41,22 +41,13 @@ using namespace TagLib;
 class APE::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    version(0),
-    bitsPerSample(0),
-    sampleFrames(0) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int version;
-  int bitsPerSample;
-  unsigned int sampleFrames;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int version { 0 };
+  int bitsPerSample { 0 };
+  unsigned int sampleFrames { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -78,12 +78,8 @@ namespace
 class APE::Tag::TagPrivate
 {
 public:
-  TagPrivate() :
-    file(nullptr),
-    footerLocation(0) {}
-
-  File *file;
-  offset_t footerLocation;
+  File *file { nullptr };
+  offset_t footerLocation { 0 };
 
   Footer footer;
   ItemListMap itemListMap;

--- a/taglib/asf/asfattribute.cpp
+++ b/taglib/asf/asfattribute.cpp
@@ -37,17 +37,16 @@ class ASF::Attribute::AttributePrivate
 {
 public:
   AttributePrivate() :
-    pictureValue(ASF::Picture::fromInvalid()),
-    numericValue(0),
-    stream(0),
-    language(0) {}
+    pictureValue(ASF::Picture::fromInvalid())
+  {
+  }
   AttributeTypes type;
   String stringValue;
   ByteVector byteVectorValue;
   ASF::Picture pictureValue;
-  unsigned long long numericValue;
-  int stream;
-  int language;
+  unsigned long long numericValue { 0 };
+  int stream { 0 };
+  int language { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -51,15 +51,7 @@ public:
   class MetadataObject;
   class MetadataLibraryObject;
 
-  FilePrivate():
-    headerSize(0),
-    tag(nullptr),
-    properties(nullptr),
-    contentDescriptionObject(nullptr),
-    extendedContentDescriptionObject(nullptr),
-    headerExtensionObject(nullptr),
-    metadataObject(nullptr),
-    metadataLibraryObject(nullptr)
+  FilePrivate()
   {
     objects.setAutoDelete(true);
   }
@@ -73,18 +65,18 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  unsigned long long headerSize;
+  unsigned long long headerSize { 0 };
 
-  ASF::Tag *tag;
-  ASF::Properties *properties;
+  ASF::Tag *tag { nullptr };
+  ASF::Properties *properties { nullptr };
 
   List<BaseObject *> objects;
 
-  ContentDescriptionObject         *contentDescriptionObject;
-  ExtendedContentDescriptionObject *extendedContentDescriptionObject;
-  HeaderExtensionObject            *headerExtensionObject;
-  MetadataObject                   *metadataObject;
-  MetadataLibraryObject            *metadataLibraryObject;
+  ContentDescriptionObject *contentDescriptionObject { nullptr };
+  ExtendedContentDescriptionObject *extendedContentDescriptionObject { nullptr };
+  HeaderExtensionObject *headerExtensionObject { nullptr };
+  MetadataObject *metadataObject { nullptr };
+  MetadataLibraryObject *metadataLibraryObject { nullptr };
 };
 
 namespace

--- a/taglib/asf/asfproperties.cpp
+++ b/taglib/asf/asfproperties.cpp
@@ -32,24 +32,15 @@ using namespace TagLib;
 class ASF::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    bitsPerSample(0),
-    codec(ASF::Properties::Unknown),
-    encrypted(false) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int bitsPerSample;
-  ASF::Properties::Codec codec;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int bitsPerSample { 0 };
+  ASF::Properties::Codec codec { ASF::Properties::Unknown };
   String codecName;
   String codecDescription;
-  bool encrypted;
+  bool encrypted { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -302,10 +302,7 @@ namespace
 class FileRef::FileRefPrivate
 {
 public:
-  FileRefPrivate() :
-    file(nullptr),
-    stream(nullptr) {}
-
+  FileRefPrivate() = default;
   ~FileRefPrivate()
   {
     delete file;
@@ -315,8 +312,8 @@ public:
   FileRefPrivate(const FileRefPrivate &) = delete;
   FileRefPrivate &operator=(const FileRefPrivate &) = delete;
 
-  File     *file;
-  IOStream *stream;
+  File *file { nullptr };
+  IOStream *stream { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -62,14 +62,7 @@ class FLAC::File::FilePrivate
 {
 public:
   FilePrivate(const ID3v2::FrameFactory *frameFactory = ID3v2::FrameFactory::instance()) :
-    ID3v2FrameFactory(frameFactory),
-    ID3v2Location(-1),
-    ID3v2OriginalSize(0),
-    ID3v1Location(-1),
-    properties(nullptr),
-    flacStart(0),
-    streamStart(0),
-    scanned(false)
+    ID3v2FrameFactory(frameFactory)
   {
     blocks.setAutoDelete(true);
   }
@@ -83,20 +76,20 @@ public:
   FilePrivate &operator=(const FilePrivate &) = delete;
 
   const ID3v2::FrameFactory *ID3v2FrameFactory;
-  offset_t ID3v2Location;
-  long ID3v2OriginalSize;
+  offset_t ID3v2Location { -1 };
+  long ID3v2OriginalSize { 0 };
 
-  offset_t ID3v1Location;
+  offset_t ID3v1Location { -1 };
 
   TagUnion tag;
 
-  Properties *properties;
+  Properties *properties { nullptr };
   ByteVector xiphCommentData;
   BlockList blocks;
 
-  offset_t flacStart;
-  offset_t streamStart;
-  bool scanned;
+  offset_t flacStart { 0 };
+  offset_t streamStart { 0 };
+  bool scanned { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/flac/flacpicture.cpp
+++ b/taglib/flac/flacpicture.cpp
@@ -32,21 +32,13 @@ using namespace TagLib;
 class FLAC::Picture::PicturePrivate
 {
 public:
-  PicturePrivate() :
-    type(FLAC::Picture::Other),
-    width(0),
-    height(0),
-    colorDepth(0),
-    numColors(0)
-    {}
-
-  Type type;
+  Type type { FLAC::Picture::Other };
   String mimeType;
   String description;
-  int width;
-  int height;
-  int colorDepth;
-  int numColors;
+  int width { 0 };
+  int height { 0 };
+  int colorDepth { 0 };
+  int numColors { 0 };
   ByteVector data;
 };
 

--- a/taglib/flac/flacproperties.cpp
+++ b/taglib/flac/flacproperties.cpp
@@ -35,20 +35,12 @@ using namespace TagLib;
 class FLAC::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    bitsPerSample(0),
-    channels(0),
-    sampleFrames(0) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int bitsPerSample;
-  int channels;
-  unsigned long long sampleFrames;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int bitsPerSample { 0 };
+  int channels { 0 };
+  unsigned long long sampleFrames { 0 };
   ByteVector signature;
 };
 

--- a/taglib/flac/flacunknownmetadatablock.cpp
+++ b/taglib/flac/flacunknownmetadatablock.cpp
@@ -33,9 +33,7 @@ using namespace TagLib;
 class FLAC::UnknownMetadataBlock::UnknownMetadataBlockPrivate
 {
 public:
-  UnknownMetadataBlockPrivate() : code(0) {}
-
-  int code;
+  int code { 0 };
   ByteVector data;
 };
 

--- a/taglib/it/itproperties.cpp
+++ b/taglib/it/itproperties.cpp
@@ -32,40 +32,21 @@ using namespace IT;
 class IT::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    channels(0),
-    lengthInPatterns(0),
-    instrumentCount(0),
-    sampleCount(0),
-    patternCount(0),
-    version(0),
-    compatibleVersion(0),
-    flags(0),
-    special(0),
-    globalVolume(0),
-    mixVolume(0),
-    tempo(0),
-    bpmSpeed(0),
-    panningSeparation(0),
-    pitchWheelDepth(0)
-  {
-  }
-
-  int            channels;
-  unsigned short lengthInPatterns;
-  unsigned short instrumentCount;
-  unsigned short sampleCount;
-  unsigned short patternCount;
-  unsigned short version;
-  unsigned short compatibleVersion;
-  unsigned short flags;
-  unsigned short special;
-  unsigned char  globalVolume;
-  unsigned char  mixVolume;
-  unsigned char  tempo;
-  unsigned char  bpmSpeed;
-  unsigned char  panningSeparation;
-  unsigned char  pitchWheelDepth;
+  int channels { 0 };
+  unsigned short lengthInPatterns { 0 };
+  unsigned short instrumentCount { 0 };
+  unsigned short sampleCount { 0 };
+  unsigned short patternCount { 0 };
+  unsigned short version { 0 };
+  unsigned short compatibleVersion { 0 };
+  unsigned short flags { 0 };
+  unsigned short special { 0 };
+  unsigned char globalVolume { 0 };
+  unsigned char mixVolume { 0 };
+  unsigned char tempo { 0 };
+  unsigned char bpmSpeed { 0 };
+  unsigned char panningSeparation { 0 };
+  unsigned char pitchWheelDepth { 0 };
 };
 
 IT::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :

--- a/taglib/mod/modproperties.cpp
+++ b/taglib/mod/modproperties.cpp
@@ -32,16 +32,9 @@ using namespace Mod;
 class Mod::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    channels(0),
-    instrumentCount(0),
-    lengthInPatterns(0)
-  {
-  }
-
-  int           channels;
-  unsigned int  instrumentCount;
-  unsigned char lengthInPatterns;
+  int channels { 0 };
+  unsigned int instrumentCount { 0 };
+  unsigned char lengthInPatterns { 0 };
 };
 
 Mod::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :

--- a/taglib/mp4/mp4atom.h
+++ b/taglib/mp4/mp4atom.h
@@ -66,9 +66,9 @@ namespace TagLib {
 
     struct AtomData {
       AtomData(AtomDataType type, const ByteVector &data) :
-        type(type), locale(0), data(data) { }
+        type(type), data(data) { }
       AtomDataType type;
-      int locale;
+      int locale { 0 };
       ByteVector data;
     };
 

--- a/taglib/mp4/mp4coverart.cpp
+++ b/taglib/mp4/mp4coverart.cpp
@@ -32,10 +32,7 @@ using namespace TagLib;
 class MP4::CoverArt::CoverArtPrivate
 {
 public:
-  CoverArtPrivate() :
-    format(MP4::CoverArt::JPEG) {}
-
-  Format format;
+  Format format { MP4::CoverArt::JPEG };
   ByteVector data;
 };
 

--- a/taglib/mp4/mp4file.cpp
+++ b/taglib/mp4/mp4file.cpp
@@ -52,11 +52,7 @@ namespace
 class MP4::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    tag(nullptr),
-    atoms(nullptr),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete atoms;
@@ -67,9 +63,9 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  MP4::Tag        *tag;
-  MP4::Atoms      *atoms;
-  MP4::Properties *properties;
+  MP4::Tag *tag { nullptr };
+  MP4::Atoms *atoms { nullptr };
+  MP4::Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mp4/mp4item.cpp
+++ b/taglib/mp4/mp4item.cpp
@@ -32,12 +32,8 @@ using namespace TagLib;
 class MP4::Item::ItemPrivate
 {
 public:
-  ItemPrivate() :
-    valid(true),
-    atomDataType(TypeUndefined) {}
-
-  bool valid;
-  AtomDataType atomDataType;
+  bool valid { true };
+  AtomDataType atomDataType { TypeUndefined };
   union {
     bool m_bool;
     int m_int;

--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -55,22 +55,13 @@ namespace
 class MP4::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    bitsPerSample(0),
-    encrypted(false),
-    codec(MP4::Properties::Unknown) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int bitsPerSample;
-  bool encrypted;
-  Codec codec;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int bitsPerSample { 0 };
+  bool encrypted { false };
+  Codec codec { MP4::Properties::Unknown };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -37,12 +37,8 @@ using namespace TagLib;
 class MP4::Tag::TagPrivate
 {
 public:
-  TagPrivate() :
-    file(nullptr),
-    atoms(nullptr) {}
-
-  TagLib::File *file;
-  Atoms *atoms;
+  TagLib::File *file { nullptr };
+  Atoms *atoms { nullptr };
   ItemMap items;
 };
 

--- a/taglib/mpc/mpcfile.cpp
+++ b/taglib/mpc/mpcfile.cpp
@@ -47,15 +47,7 @@ namespace
 class MPC::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    APELocation(-1),
-    APESize(0),
-    ID3v1Location(-1),
-    ID3v2Header(nullptr),
-    ID3v2Location(-1),
-    ID3v2Size(0),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete ID3v2Header;
@@ -65,18 +57,18 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  offset_t APELocation;
-  long APESize;
+  offset_t APELocation { -1 };
+  long APESize { 0 };
 
-  offset_t ID3v1Location;
+  offset_t ID3v1Location { -1 };
 
-  ID3v2::Header *ID3v2Header;
-  offset_t ID3v2Location;
-  long ID3v2Size;
+  ID3v2::Header *ID3v2Header { nullptr };
+  offset_t ID3v2Location { -1 };
+  long ID3v2Size { 0 };
 
   TagUnion tag;
 
-  Properties *properties;
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -38,30 +38,17 @@ using namespace TagLib;
 class MPC::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    version(0),
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    totalFrames(0),
-    sampleFrames(0),
-    trackGain(0),
-    trackPeak(0),
-    albumGain(0),
-    albumPeak(0) {}
-
-  int version;
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  unsigned int totalFrames;
-  unsigned int sampleFrames;
-  int trackGain;
-  int trackPeak;
-  int albumGain;
-  int albumPeak;
+  int version { 0 };
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  unsigned int totalFrames { 0 };
+  unsigned int sampleFrames { 0 };
+  int trackGain { 0 };
+  int trackPeak { 0 };
+  int albumGain { 0 };
+  int albumPeak { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v1/id3v1tag.cpp
+++ b/taglib/mpeg/id3v1/id3v1tag.cpp
@@ -42,22 +42,16 @@ namespace
 class ID3v1::Tag::TagPrivate
 {
 public:
-  TagPrivate() :
-    file(nullptr),
-    tagOffset(0),
-    track(0),
-    genre(255) {}
-
-  File *file;
-  offset_t tagOffset;
+  File *file { nullptr };
+  offset_t tagOffset { 0 };
 
   String title;
   String artist;
   String album;
   String year;
   String comment;
-  unsigned char track;
-  unsigned char genre;
+  unsigned char track { 0 };
+  unsigned char genre { 255 };
 };
 
 class ID3v1::StringHandler::StringHandlerPrivate

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
@@ -34,12 +34,9 @@ using namespace ID3v2;
 class AttachedPictureFrame::AttachedPictureFramePrivate
 {
 public:
-  AttachedPictureFramePrivate() : textEncoding(String::Latin1),
-                                  type(AttachedPictureFrame::Other) {}
-
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   String mimeType;
-  AttachedPictureFrame::Type type;
+  AttachedPictureFrame::Type type { AttachedPictureFrame::Other };
   String description;
   ByteVector data;
 };

--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -36,22 +36,17 @@ using namespace ID3v2;
 class ChapterFrame::ChapterFramePrivate
 {
 public:
-  ChapterFramePrivate() :
-    tagHeader(nullptr),
-    startTime(0),
-    endTime(0),
-    startOffset(0),
-    endOffset(0)
+  ChapterFramePrivate()
   {
     embeddedFrameList.setAutoDelete(true);
   }
 
-  const ID3v2::Header *tagHeader;
+  const ID3v2::Header *tagHeader { nullptr };
   ByteVector elementID;
-  unsigned int startTime;
-  unsigned int endTime;
-  unsigned int startOffset;
-  unsigned int endOffset;
+  unsigned int startTime { 0 };
+  unsigned int endTime { 0 };
+  unsigned int startOffset { 0 };
+  unsigned int endOffset { 0 };
   FrameListMap embeddedFrameListMap;
   FrameList embeddedFrameList;
 };

--- a/taglib/mpeg/id3v2/frames/commentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/commentsframe.cpp
@@ -38,8 +38,7 @@ using namespace ID3v2;
 class CommentsFrame::CommentsFramePrivate
 {
 public:
-  CommentsFramePrivate() : textEncoding(String::Latin1) {}
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   ByteVector language;
   String description;
   String text;

--- a/taglib/mpeg/id3v2/frames/eventtimingcodesframe.cpp
+++ b/taglib/mpeg/id3v2/frames/eventtimingcodesframe.cpp
@@ -35,9 +35,7 @@ using namespace ID3v2;
 class EventTimingCodesFrame::EventTimingCodesFramePrivate
 {
 public:
-  EventTimingCodesFramePrivate() :
-    timestampFormat(EventTimingCodesFrame::AbsoluteMilliseconds) {}
-  EventTimingCodesFrame::TimestampFormat timestampFormat;
+  EventTimingCodesFrame::TimestampFormat timestampFormat { EventTimingCodesFrame::AbsoluteMilliseconds };
   EventTimingCodesFrame::SynchedEventList synchedEvents;
 };
 

--- a/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
+++ b/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
@@ -37,9 +37,7 @@ using namespace ID3v2;
 class GeneralEncapsulatedObjectFrame::GeneralEncapsulatedObjectFramePrivate
 {
 public:
-  GeneralEncapsulatedObjectFramePrivate() : textEncoding(String::Latin1) {}
-
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   String mimeType;
   String fileName;
   String description;

--- a/taglib/mpeg/id3v2/frames/popularimeterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/popularimeterframe.cpp
@@ -33,10 +33,9 @@ using namespace ID3v2;
 class PopularimeterFrame::PopularimeterFramePrivate
 {
 public:
-  PopularimeterFramePrivate() : rating(0), counter(0) {}
   String email;
-  int rating;
-  unsigned int counter;
+  int rating { 0 };
+  unsigned int counter { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/frames/relativevolumeframe.cpp
+++ b/taglib/mpeg/id3v2/frames/relativevolumeframe.cpp
@@ -33,10 +33,8 @@ using namespace ID3v2;
 
 struct ChannelData
 {
-  ChannelData() : channelType(RelativeVolumeFrame::Other), volumeAdjustment(0) {}
-
-  RelativeVolumeFrame::ChannelType channelType;
-  short volumeAdjustment;
+  RelativeVolumeFrame::ChannelType channelType { RelativeVolumeFrame::Other };
+  short volumeAdjustment { 0 };
   RelativeVolumeFrame::PeakVolume peakVolume;
 };
 

--- a/taglib/mpeg/id3v2/frames/relativevolumeframe.h
+++ b/taglib/mpeg/id3v2/frames/relativevolumeframe.h
@@ -82,17 +82,12 @@ namespace TagLib {
        * The peak volume is described as a series of bits that is padded to fill
        * a block of bytes.  These two values should always be updated in tandem.
        */
-      struct PeakVolume
-      {
-        /*!
-         * Constructs an empty peak volume description.
-         */
-        PeakVolume() : bitsRepresentingPeak(0) {}
+      struct PeakVolume {
         /*!
          * The number of bits (in the range of 0 to 255) used to describe the
          * peak volume.
          */
-        unsigned char bitsRepresentingPeak;
+        unsigned char bitsRepresentingPeak { 0 };
         /*!
          * The array of bits (represented as a series of bytes) used to describe
          * the peak volume.

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
@@ -35,14 +35,10 @@ using namespace ID3v2;
 class SynchronizedLyricsFrame::SynchronizedLyricsFramePrivate
 {
 public:
-  SynchronizedLyricsFramePrivate() :
-    textEncoding(String::Latin1),
-    timestampFormat(SynchronizedLyricsFrame::AbsoluteMilliseconds),
-    type(SynchronizedLyricsFrame::Lyrics) {}
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   ByteVector language;
-  SynchronizedLyricsFrame::TimestampFormat timestampFormat;
-  SynchronizedLyricsFrame::Type type;
+  SynchronizedLyricsFrame::TimestampFormat timestampFormat { SynchronizedLyricsFrame::AbsoluteMilliseconds };
+  SynchronizedLyricsFrame::Type type { SynchronizedLyricsFrame::Lyrics };
   String description;
   SynchronizedLyricsFrame::SynchedTextList synchedText;
 };

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -35,18 +35,15 @@ using namespace ID3v2;
 class TableOfContentsFrame::TableOfContentsFramePrivate
 {
 public:
-  TableOfContentsFramePrivate() :
-    tagHeader(nullptr),
-    isTopLevel(false),
-    isOrdered(false)
+  TableOfContentsFramePrivate()
   {
     embeddedFrameList.setAutoDelete(true);
   }
 
-  const ID3v2::Header *tagHeader;
+  const ID3v2::Header *tagHeader { nullptr };
   ByteVector elementID;
-  bool isTopLevel;
-  bool isOrdered;
+  bool isTopLevel { false };
+  bool isOrdered { false };
   ByteVectorList childElements;
   FrameListMap embeddedFrameListMap;
   FrameList embeddedFrameList;

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -37,8 +37,7 @@ using namespace ID3v2;
 class TextIdentificationFrame::TextIdentificationFramePrivate
 {
 public:
-  TextIdentificationFramePrivate() : textEncoding(String::Latin1) {}
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   StringList fieldList;
 };
 

--- a/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
@@ -38,8 +38,7 @@ using namespace ID3v2;
 class UnsynchronizedLyricsFrame::UnsynchronizedLyricsFramePrivate
 {
 public:
-  UnsynchronizedLyricsFramePrivate() : textEncoding(String::Latin1) {}
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   ByteVector language;
   String description;
   String text;

--- a/taglib/mpeg/id3v2/frames/urllinkframe.cpp
+++ b/taglib/mpeg/id3v2/frames/urllinkframe.cpp
@@ -44,8 +44,7 @@ public:
 class UserUrlLinkFrame::UserUrlLinkFramePrivate
 {
 public:
-  UserUrlLinkFramePrivate() : textEncoding(String::Latin1) {}
-  String::Type textEncoding;
+  String::Type textEncoding { String::Latin1 };
   String description;
 };
 

--- a/taglib/mpeg/id3v2/id3v2extendedheader.cpp
+++ b/taglib/mpeg/id3v2/id3v2extendedheader.cpp
@@ -32,9 +32,7 @@ using namespace ID3v2;
 class ExtendedHeader::ExtendedHeaderPrivate
 {
 public:
-  ExtendedHeaderPrivate() : size(0) {}
-
-  unsigned int size;
+  unsigned int size { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -50,10 +50,7 @@ using namespace ID3v2;
 class Frame::FramePrivate
 {
 public:
-  FramePrivate() :
-    header(nullptr)
-    {}
-
+  FramePrivate() = default;
   ~FramePrivate()
   {
     delete header;
@@ -62,7 +59,7 @@ public:
   FramePrivate(const FramePrivate &) = delete;
   FramePrivate &operator=(const FramePrivate &) = delete;
 
-  Frame::Header *header;
+  Frame::Header *header { nullptr };
 };
 
 namespace
@@ -179,7 +176,6 @@ void Frame::setData(const ByteVector &data)
 
 void Frame::setText(const String &)
 {
-
 }
 
 ByteVector Frame::render() const
@@ -491,33 +487,20 @@ void Frame::splitProperties(const PropertyMap &original, PropertyMap &singleFram
 class Frame::Header::HeaderPrivate
 {
 public:
-  HeaderPrivate() :
-    frameSize(0),
-    version(4),
-    tagAlterPreservation(false),
-    fileAlterPreservation(false),
-    readOnly(false),
-    groupingIdentity(false),
-    compression(false),
-    encryption(false),
-    unsynchronisation(false),
-    dataLengthIndicator(false)
-    {}
-
   ByteVector frameID;
-  unsigned int frameSize;
-  unsigned int version;
+  unsigned int frameSize { 0 };
+  unsigned int version { 4 };
 
   // flags
 
-  bool tagAlterPreservation;
-  bool fileAlterPreservation;
-  bool readOnly;
-  bool groupingIdentity;
-  bool compression;
-  bool encryption;
-  bool unsynchronisation;
-  bool dataLengthIndicator;
+  bool tagAlterPreservation { false };
+  bool fileAlterPreservation { false };
+  bool readOnly { false };
+  bool groupingIdentity { false };
+  bool compression { false };
+  bool encryption { false };
+  bool unsynchronisation { false };
+  bool dataLengthIndicator { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -93,12 +93,8 @@ namespace
 class FrameFactory::FrameFactoryPrivate
 {
 public:
-  FrameFactoryPrivate() :
-    defaultEncoding(String::Latin1),
-    useDefaultEncoding(false) {}
-
-  String::Type defaultEncoding;
-  bool useDefaultEncoding;
+  String::Type defaultEncoding { String::Latin1 };
+  bool useDefaultEncoding { false };
 
   template <class T> void setTextEncoding(T *frame)
   {

--- a/taglib/mpeg/id3v2/id3v2header.cpp
+++ b/taglib/mpeg/id3v2/id3v2header.cpp
@@ -40,24 +40,15 @@ using namespace ID3v2;
 class Header::HeaderPrivate
 {
 public:
-  HeaderPrivate() :
-    majorVersion(4),
-    revisionNumber(0),
-    unsynchronisation(false),
-    extendedHeader(false),
-    experimentalIndicator(false),
-    footerPresent(false),
-    tagSize(0) {}
+  unsigned int majorVersion { 4 };
+  unsigned int revisionNumber { 0 };
 
-  unsigned int majorVersion;
-  unsigned int revisionNumber;
+  bool unsynchronisation { false };
+  bool extendedHeader { false };
+  bool experimentalIndicator { false };
+  bool footerPresent { false };
 
-  bool unsynchronisation;
-  bool extendedHeader;
-  bool experimentalIndicator;
-  bool footerPresent;
-
-  unsigned int tagSize;
+  unsigned int tagSize { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -70,12 +70,7 @@ namespace
 class ID3v2::Tag::TagPrivate
 {
 public:
-  TagPrivate() :
-    factory(nullptr),
-    file(nullptr),
-    tagOffset(0),
-    extendedHeader(nullptr),
-    footer(nullptr)
+  TagPrivate()
   {
     frameList.setAutoDelete(true);
   }
@@ -89,14 +84,14 @@ public:
   TagPrivate(const TagPrivate &) = delete;
   TagPrivate &operator=(const TagPrivate &) = delete;
 
-  const FrameFactory *factory;
+  const FrameFactory *factory { nullptr };
 
-  File *file;
-  offset_t tagOffset;
+  File *file { nullptr };
+  offset_t tagOffset { 0 };
 
   Header header;
-  ExtendedHeader *extendedHeader;
-  Footer *footer;
+  ExtendedHeader *extendedHeader { nullptr };
+  Footer *footer { nullptr };
 
   FrameListMap frameListMap;
   FrameList frameList;

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -49,13 +49,9 @@ class MPEG::File::FilePrivate
 {
 public:
   FilePrivate(const ID3v2::FrameFactory *frameFactory = ID3v2::FrameFactory::instance()) :
-    ID3v2FrameFactory(frameFactory),
-    ID3v2Location(-1),
-    ID3v2OriginalSize(0),
-    APELocation(-1),
-    APEOriginalSize(0),
-    ID3v1Location(-1),
-    properties(nullptr) {}
+    ID3v2FrameFactory(frameFactory)
+  {
+  }
 
   ~FilePrivate()
   {
@@ -67,17 +63,17 @@ public:
 
   const ID3v2::FrameFactory *ID3v2FrameFactory;
 
-  offset_t ID3v2Location;
-  long ID3v2OriginalSize;
+  offset_t ID3v2Location { -1 };
+  long ID3v2OriginalSize { 0 };
 
-  offset_t APELocation;
-  long APEOriginalSize;
+  offset_t APELocation { -1 };
+  long APEOriginalSize { 0 };
 
-  offset_t ID3v1Location;
+  offset_t ID3v1Location { -1 };
 
   TagUnion tag;
 
-  Properties *properties;
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/mpegheader.cpp
+++ b/taglib/mpeg/mpegheader.cpp
@@ -39,32 +39,18 @@ using namespace TagLib;
 class MPEG::Header::HeaderPrivate
 {
 public:
-  HeaderPrivate() :
-    isValid(false),
-    version(Version1),
-    layer(0),
-    protectionEnabled(false),
-    bitrate(0),
-    sampleRate(0),
-    isPadded(false),
-    channelMode(Stereo),
-    isCopyrighted(false),
-    isOriginal(false),
-    frameLength(0),
-    samplesPerFrame(0) {}
-
-  bool isValid;
-  Version version;
-  int layer;
-  bool protectionEnabled;
-  int bitrate;
-  int sampleRate;
-  bool isPadded;
-  ChannelMode channelMode;
-  bool isCopyrighted;
-  bool isOriginal;
-  int frameLength;
-  int samplesPerFrame;
+  bool isValid { false };
+  Version version { Version1 };
+  int layer { 0 };
+  bool protectionEnabled { false };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  bool isPadded { false };
+  ChannelMode channelMode { Stereo };
+  bool isCopyrighted { false };
+  bool isOriginal { false };
+  int frameLength { 0 };
+  int samplesPerFrame { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/mpegproperties.cpp
+++ b/taglib/mpeg/mpegproperties.cpp
@@ -38,19 +38,7 @@ using namespace TagLib;
 class MPEG::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    xingHeader(nullptr),
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    layer(0),
-    version(Header::Version1),
-    channelMode(Header::Stereo),
-    protectionEnabled(false),
-    isCopyrighted(false),
-    isOriginal(false) {}
-
+  PropertiesPrivate() = default;
   ~PropertiesPrivate()
   {
     delete xingHeader;
@@ -59,17 +47,17 @@ public:
   PropertiesPrivate(const PropertiesPrivate &) = delete;
   PropertiesPrivate &operator=(const PropertiesPrivate &) = delete;
 
-  XingHeader *xingHeader;
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int layer;
-  Header::Version version;
-  Header::ChannelMode channelMode;
-  bool protectionEnabled;
-  bool isCopyrighted;
-  bool isOriginal;
+  XingHeader *xingHeader { nullptr };
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int layer { 0 };
+  Header::Version version { Header::Version1 };
+  Header::ChannelMode channelMode { Header::Stereo };
+  bool protectionEnabled { false };
+  bool isCopyrighted { false };
+  bool isOriginal { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/xingheader.cpp
+++ b/taglib/mpeg/xingheader.cpp
@@ -36,15 +36,10 @@ using namespace TagLib;
 class MPEG::XingHeader::XingHeaderPrivate
 {
 public:
-  XingHeaderPrivate() :
-    frames(0),
-    size(0),
-    type(MPEG::XingHeader::Invalid) {}
+  unsigned int frames { 0 };
+  unsigned int size { 0 };
 
-  unsigned int frames;
-  unsigned int size;
-
-  MPEG::XingHeader::HeaderType type;
+  MPEG::XingHeader::HeaderType type { MPEG::XingHeader::Invalid };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -39,15 +39,7 @@ using TagLib::FLAC::Properties;
 class Ogg::FLAC::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    comment(nullptr),
-    properties(nullptr),
-    streamStart(0),
-    streamLength(0),
-    scanned(false),
-    hasXiphComment(false),
-    commentPacket(0) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete comment;
@@ -57,17 +49,17 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  Ogg::XiphComment *comment;
+  Ogg::XiphComment *comment { nullptr };
 
-  Properties *properties;
+  Properties *properties { nullptr };
   ByteVector streamInfoData;
   ByteVector xiphCommentData;
-  offset_t streamStart;
-  offset_t streamLength;
-  bool scanned;
+  offset_t streamStart { 0 };
+  offset_t streamLength { 0 };
+  bool scanned { false };
 
-  bool hasXiphComment;
-  int commentPacket;
+  bool hasXiphComment { false };
+  int commentPacket { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -49,9 +49,7 @@ namespace
 class Ogg::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    firstPageHeader(nullptr),
-    lastPageHeader(nullptr)
+  FilePrivate()
   {
     pages.setAutoDelete(true);
   }
@@ -67,8 +65,8 @@ public:
 
   unsigned int streamSerialNumber;
   List<Page *> pages;
-  PageHeader *firstPageHeader;
-  PageHeader *lastPageHeader;
+  PageHeader *firstPageHeader { nullptr };
+  PageHeader *lastPageHeader { nullptr };
   Map<unsigned int, ByteVector> dirtyPackets;
 };
 

--- a/taglib/ogg/oggpage.cpp
+++ b/taglib/ogg/oggpage.cpp
@@ -105,13 +105,14 @@ public:
   PagePrivate(File *f = nullptr, offset_t pageOffset = -1) :
     file(f),
     fileOffset(pageOffset),
-    header(f, pageOffset),
-    firstPacketIndex(-1) {}
+    header(f, pageOffset)
+  {
+  }
 
   File *file;
   offset_t fileOffset;
   PageHeader header;
-  int firstPacketIndex;
+  int firstPacketIndex { -1 };
   ByteVectorList packets;
 };
 

--- a/taglib/ogg/oggpageheader.cpp
+++ b/taglib/ogg/oggpageheader.cpp
@@ -38,29 +38,17 @@ using namespace TagLib;
 class Ogg::PageHeader::PageHeaderPrivate
 {
 public:
-  PageHeaderPrivate() :
-    isValid(false),
-    firstPacketContinued(false),
-    lastPacketCompleted(false),
-    firstPageOfStream(false),
-    lastPageOfStream(false),
-    absoluteGranularPosition(0),
-    streamSerialNumber(0),
-    pageSequenceNumber(-1),
-    size(0),
-    dataSize(0) {}
-
-  bool isValid;
+  bool isValid { false };
   List<int> packetSizes;
-  bool firstPacketContinued;
-  bool lastPacketCompleted;
-  bool firstPageOfStream;
-  bool lastPageOfStream;
-  long long absoluteGranularPosition;
-  unsigned int streamSerialNumber;
-  int pageSequenceNumber;
-  int size;
-  int dataSize;
+  bool firstPacketContinued { false };
+  bool lastPacketCompleted { false };
+  bool firstPageOfStream { false };
+  bool lastPageOfStream { false };
+  long long absoluteGranularPosition { 0 };
+  unsigned int streamSerialNumber { 0 };
+  int pageSequenceNumber { -1 };
+  int size { 0 };
+  int dataSize { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/opus/opusfile.cpp
+++ b/taglib/ogg/opus/opusfile.cpp
@@ -40,10 +40,7 @@ using namespace TagLib::Ogg;
 class Opus::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    comment(nullptr),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete comment;
@@ -53,8 +50,8 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  Ogg::XiphComment *comment;
-  Properties *properties;
+  Ogg::XiphComment *comment { nullptr };
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/opus/opusproperties.cpp
+++ b/taglib/ogg/opus/opusproperties.cpp
@@ -42,18 +42,11 @@ using namespace TagLib::Ogg;
 class Opus::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    inputSampleRate(0),
-    channels(0),
-    opusVersion(0) {}
-
-  int length;
-  int bitrate;
-  int inputSampleRate;
-  int channels;
-  int opusVersion;
+  int length { 0 };
+  int bitrate { 0 };
+  int inputSampleRate { 0 };
+  int channels { 0 };
+  int opusVersion { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/speex/speexfile.cpp
+++ b/taglib/ogg/speex/speexfile.cpp
@@ -40,10 +40,7 @@ using namespace TagLib::Ogg;
 class Speex::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    comment(nullptr),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete comment;
@@ -53,8 +50,8 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  Ogg::XiphComment *comment;
-  Properties *properties;
+  Ogg::XiphComment *comment { nullptr };
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/speex/speexproperties.cpp
+++ b/taglib/ogg/speex/speexproperties.cpp
@@ -42,24 +42,14 @@ using namespace TagLib::Ogg;
 class Speex::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    bitrateNominal(0),
-    sampleRate(0),
-    channels(0),
-    speexVersion(0),
-    vbr(false),
-    mode(0) {}
-
-  int length;
-  int bitrate;
-  int bitrateNominal;
-  int sampleRate;
-  int channels;
-  int speexVersion;
-  bool vbr;
-  int mode;
+  int length { 0 };
+  int bitrate { 0 };
+  int bitrateNominal { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int speexVersion { 0 };
+  bool vbr { false };
+  int mode { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/ogg/vorbis/vorbisfile.cpp
+++ b/taglib/ogg/vorbis/vorbisfile.cpp
@@ -37,10 +37,7 @@ using namespace TagLib;
 class Vorbis::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    comment(nullptr),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete comment;
@@ -50,8 +47,8 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  Ogg::XiphComment *comment;
-  Properties *properties;
+  Ogg::XiphComment *comment { nullptr };
+  Properties *properties { nullptr };
 };
 
 namespace TagLib {

--- a/taglib/ogg/vorbis/vorbisproperties.cpp
+++ b/taglib/ogg/vorbis/vorbisproperties.cpp
@@ -37,24 +37,14 @@ using namespace TagLib;
 class Vorbis::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    vorbisVersion(0),
-    bitrateMaximum(0),
-    bitrateNominal(0),
-    bitrateMinimum(0) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int vorbisVersion;
-  int bitrateMaximum;
-  int bitrateNominal;
-  int bitrateMinimum;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int vorbisVersion { 0 };
+  int bitrateMaximum { 0 };
+  int bitrateNominal { 0 };
+  int bitrateMinimum { 0 };
 };
 
 namespace TagLib {

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -37,11 +37,7 @@ using namespace TagLib;
 class RIFF::AIFF::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    properties(nullptr),
-    tag(nullptr),
-    hasID3v2(false) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete properties;
@@ -51,10 +47,10 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  Properties *properties;
-  ID3v2::Tag *tag;
+  Properties *properties { nullptr };
+  ID3v2::Tag *tag { nullptr };
 
-  bool hasID3v2;
+  bool hasID3v2 { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/riff/aiff/aiffproperties.cpp
+++ b/taglib/riff/aiff/aiffproperties.cpp
@@ -33,24 +33,16 @@ using namespace TagLib;
 class RIFF::AIFF::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    bitsPerSample(0),
-    sampleFrames(0) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int bitsPerSample;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int bitsPerSample { 0 };
 
   ByteVector compressionType;
   String compressionName;
 
-  unsigned int sampleFrames;
+  unsigned int sampleFrames { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -48,14 +48,14 @@ class RIFF::File::FilePrivate
 {
 public:
   FilePrivate(Endianness endianness) :
-    endianness(endianness),
-    size(0),
-    sizeOffset(0) {}
+    endianness(endianness)
+  {
+  }
 
   const Endianness endianness;
 
-  unsigned int size;
-  offset_t sizeOffset;
+  unsigned int size { 0 };
+  offset_t sizeOffset { 0 };
 
   std::vector<Chunk> chunks;
 };

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -45,11 +45,7 @@ namespace
 class RIFF::WAV::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    properties(nullptr),
-    hasID3v2(false),
-    hasInfo(false) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete properties;
@@ -58,11 +54,11 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  Properties *properties;
+  Properties *properties { nullptr };
   TagUnion tag;
 
-  bool hasID3v2;
-  bool hasInfo;
+  bool hasID3v2 { false };
+  bool hasInfo { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -43,22 +43,13 @@ namespace
 class RIFF::WAV::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    format(0),
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    bitsPerSample(0),
-    sampleFrames(0) {}
-
-  int format;
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int bitsPerSample;
-  unsigned int sampleFrames;
+  int format { 0 };
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int bitsPerSample { 0 };
+  unsigned int sampleFrames { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/s3m/s3mproperties.cpp
+++ b/taglib/s3m/s3mproperties.cpp
@@ -32,34 +32,18 @@ using namespace S3M;
 class S3M::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    lengthInPatterns(0),
-    channels(0),
-    stereo(false),
-    sampleCount(0),
-    patternCount(0),
-    flags(0),
-    trackerVersion(0),
-    fileFormatVersion(0),
-    globalVolume(0),
-    masterVolume(0),
-    tempo(0),
-    bpmSpeed(0)
-  {
-  }
-
-  unsigned short lengthInPatterns;
-  int            channels;
-  bool           stereo;
-  unsigned short sampleCount;
-  unsigned short patternCount;
-  unsigned short flags;
-  unsigned short trackerVersion;
-  unsigned short fileFormatVersion;
-  unsigned char  globalVolume;
-  unsigned char  masterVolume;
-  unsigned char  tempo;
-  unsigned char  bpmSpeed;
+  unsigned short lengthInPatterns { 0 };
+  int channels { 0 };
+  bool stereo { false };
+  unsigned short sampleCount { 0 };
+  unsigned short patternCount { 0 };
+  unsigned short flags { 0 };
+  unsigned short trackerVersion { 0 };
+  unsigned short fileFormatVersion { 0 };
+  unsigned char globalVolume { 0 };
+  unsigned char masterVolume { 0 };
+  unsigned char tempo { 0 };
+  unsigned char bpmSpeed { 0 };
 };
 
 S3M::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :

--- a/taglib/toolkit/tbytevectorstream.cpp
+++ b/taglib/toolkit/tbytevectorstream.cpp
@@ -40,12 +40,11 @@ public:
   ByteVectorStreamPrivate(const ByteVector &data);
 
   ByteVector data;
-  offset_t position;
+  offset_t position { 0 };
 };
 
 ByteVectorStream::ByteVectorStreamPrivate::ByteVectorStreamPrivate(const ByteVector &data) :
-  data(data),
-  position(0)
+  data(data)
 {
 }
 

--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -70,8 +70,9 @@ class File::FilePrivate
 public:
   FilePrivate(IOStream *stream, bool owner) :
     stream(stream),
-    streamOwner(owner),
-    valid(true) {}
+    streamOwner(owner)
+  {
+  }
 
   ~FilePrivate()
   {
@@ -84,7 +85,7 @@ public:
 
   IOStream *stream;
   bool streamOwner;
-  bool valid;
+  bool valid { true };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -129,16 +129,14 @@ namespace
 class FileStream::FileStreamPrivate
 {
 public:
-  FileStreamPrivate(const FileName &fileName)
-    : file(InvalidFileHandle)
-    , name(fileName)
-    , readOnly(true)
+  FileStreamPrivate(const FileName &fileName) :
+    name(fileName)
   {
   }
 
-  FileHandle file;
+  FileHandle file { InvalidFileHandle };
   FileNameHandle name;
-  bool readOnly;
+  bool readOnly { true };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -52,11 +52,9 @@ class TrueAudio::File::FilePrivate
 {
 public:
   FilePrivate(const ID3v2::FrameFactory *frameFactory = ID3v2::FrameFactory::instance()) :
-    ID3v2FrameFactory(frameFactory),
-    ID3v2Location(-1),
-    ID3v2OriginalSize(0),
-    ID3v1Location(-1),
-    properties(nullptr) {}
+    ID3v2FrameFactory(frameFactory)
+  {
+  }
 
   ~FilePrivate()
   {
@@ -67,14 +65,14 @@ public:
   FilePrivate &operator=(const FilePrivate &) = delete;
 
   const ID3v2::FrameFactory *ID3v2FrameFactory;
-  offset_t ID3v2Location;
-  long ID3v2OriginalSize;
+  offset_t ID3v2Location { -1 };
+  long ID3v2OriginalSize { 0 };
 
-  offset_t ID3v1Location;
+  offset_t ID3v1Location { -1 };
 
   TagUnion tag;
 
-  Properties *properties;
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/trueaudio/trueaudioproperties.cpp
+++ b/taglib/trueaudio/trueaudioproperties.cpp
@@ -40,22 +40,13 @@ using namespace TagLib;
 class TrueAudio::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    version(0),
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    bitsPerSample(0),
-    sampleFrames(0) {}
-
-  int version;
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int bitsPerSample;
-  unsigned int sampleFrames;
+  int version { 0 };
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int bitsPerSample { 0 };
+  unsigned int sampleFrames { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/wavpack/wavpackfile.cpp
+++ b/taglib/wavpack/wavpackfile.cpp
@@ -51,12 +51,7 @@ namespace
 class WavPack::File::FilePrivate
 {
 public:
-  FilePrivate() :
-    APELocation(-1),
-    APESize(0),
-    ID3v1Location(-1),
-    properties(nullptr) {}
-
+  FilePrivate() = default;
   ~FilePrivate()
   {
     delete properties;
@@ -65,14 +60,14 @@ public:
   FilePrivate(const FilePrivate &) = delete;
   FilePrivate &operator=(const FilePrivate &) = delete;
 
-  offset_t APELocation;
-  long APESize;
+  offset_t APELocation { -1 };
+  long APESize { 0 };
 
-  offset_t ID3v1Location;
+  offset_t ID3v1Location { -1 };
 
   TagUnion tag;
 
-  Properties *properties;
+  Properties *properties { nullptr };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/wavpack/wavpackproperties.cpp
+++ b/taglib/wavpack/wavpackproperties.cpp
@@ -45,24 +45,14 @@ using namespace TagLib;
 class WavPack::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    length(0),
-    bitrate(0),
-    sampleRate(0),
-    channels(0),
-    version(0),
-    bitsPerSample(0),
-    lossless(false),
-    sampleFrames(0) {}
-
-  int length;
-  int bitrate;
-  int sampleRate;
-  int channels;
-  int version;
-  int bitsPerSample;
-  bool lossless;
-  unsigned int sampleFrames;
+  int length { 0 };
+  int bitrate { 0 };
+  int sampleRate { 0 };
+  int channels { 0 };
+  int version { 0 };
+  int bitsPerSample { 0 };
+  bool lossless { false };
+  unsigned int sampleFrames { 0 };
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/xm/xmproperties.cpp
+++ b/taglib/xm/xmproperties.cpp
@@ -32,30 +32,16 @@ using namespace XM;
 class XM::Properties::PropertiesPrivate
 {
 public:
-  PropertiesPrivate() :
-    lengthInPatterns(0),
-    channels(0),
-    version(0),
-    restartPosition(0),
-    patternCount(0),
-    instrumentCount(0),
-    sampleCount(0),
-    flags(0),
-    tempo(0),
-    bpmSpeed(0)
-  {
-  }
-
-  unsigned short lengthInPatterns;
-  int            channels;
-  unsigned short version;
-  unsigned short restartPosition;
-  unsigned short patternCount;
-  unsigned short instrumentCount;
-  unsigned int   sampleCount;
-  unsigned short flags;
-  unsigned short tempo;
-  unsigned short bpmSpeed;
+  unsigned short lengthInPatterns { 0 };
+  int channels { 0 };
+  unsigned short version { 0 };
+  unsigned short restartPosition { 0 };
+  unsigned short patternCount { 0 };
+  unsigned short instrumentCount { 0 };
+  unsigned int sampleCount { 0 };
+  unsigned short flags { 0 };
+  unsigned short tempo { 0 };
+  unsigned short bpmSpeed { 0 };
 };
 
 XM::Properties::Properties(AudioProperties::ReadStyle propertiesStyle) :


### PR DESCRIPTION
Found with modernize-use-default-member-init