### PR TITLE
clang-tidy: convert functions to static

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -328,7 +328,7 @@ MP4::Tag::parseCovr(const MP4::Atom *atom)
 }
 
 ByteVector
-MP4::Tag::padIlst(const ByteVector &data, int length) const
+MP4::Tag::padIlst(const ByteVector &data, int length)
 {
   if(length == -1) {
     length = ((data.size() + 1023) & ~1023) - data.size();
@@ -337,13 +337,13 @@ MP4::Tag::padIlst(const ByteVector &data, int length) const
 }
 
 ByteVector
-MP4::Tag::renderAtom(const ByteVector &name, const ByteVector &data) const
+MP4::Tag::renderAtom(const ByteVector &name, const ByteVector &data)
 {
   return ByteVector::fromUInt(data.size() + 8) + name + data;
 }
 
 ByteVector
-MP4::Tag::renderData(const ByteVector &name, int flags, const ByteVectorList &data) const
+MP4::Tag::renderData(const ByteVector &name, int flags, const ByteVectorList &data)
 {
   ByteVector result;
   for(auto it = data.begin(); it != data.end(); ++it) {
@@ -353,7 +353,7 @@ MP4::Tag::renderData(const ByteVector &name, int flags, const ByteVectorList &da
 }
 
 ByteVector
-MP4::Tag::renderBool(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderBool(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector(1, item.toBool() ? '\1' : '\0'));
@@ -361,7 +361,7 @@ MP4::Tag::renderBool(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderInt(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderInt(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector::fromShort(item.toInt()));
@@ -369,7 +369,7 @@ MP4::Tag::renderInt(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderUInt(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderUInt(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector::fromUInt(item.toUInt()));
@@ -377,7 +377,7 @@ MP4::Tag::renderUInt(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderLongLong(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderLongLong(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector::fromLongLong(item.toLongLong()));
@@ -385,7 +385,7 @@ MP4::Tag::renderLongLong(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderByte(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderByte(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector(1, item.toByte()));
@@ -393,7 +393,7 @@ MP4::Tag::renderByte(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderIntPair(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderIntPair(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector(2, '\0') +
@@ -404,7 +404,7 @@ MP4::Tag::renderIntPair(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderIntPairNoTrailing(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderIntPairNoTrailing(const ByteVector &name, const MP4::Item &item)
 {
   ByteVectorList data;
   data.append(ByteVector(2, '\0') +
@@ -414,7 +414,7 @@ MP4::Tag::renderIntPairNoTrailing(const ByteVector &name, const MP4::Item &item)
 }
 
 ByteVector
-MP4::Tag::renderText(const ByteVector &name, const MP4::Item &item, int flags) const
+MP4::Tag::renderText(const ByteVector &name, const MP4::Item &item, int flags)
 {
   ByteVectorList data;
   const StringList value = item.toStringList();
@@ -425,7 +425,7 @@ MP4::Tag::renderText(const ByteVector &name, const MP4::Item &item, int flags) c
 }
 
 ByteVector
-MP4::Tag::renderCovr(const ByteVector &name, const MP4::Item &item) const
+MP4::Tag::renderCovr(const ByteVector &name, const MP4::Item &item)
 {
   ByteVector data;
   const MP4::CoverArtList value = item.toCoverArtList();
@@ -437,7 +437,7 @@ MP4::Tag::renderCovr(const ByteVector &name, const MP4::Item &item) const
 }
 
 ByteVector
-MP4::Tag::renderFreeForm(const String &name, const MP4::Item &item) const
+MP4::Tag::renderFreeForm(const String &name, const MP4::Item &item)
 {
   StringList header = StringList::split(name, ":");
   if(header.size() != 3) {

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -125,21 +125,21 @@ namespace TagLib {
         void parseBool(const Atom *atom);
         void parseCovr(const Atom *atom);
 
-        ByteVector padIlst(const ByteVector &data, int length = -1) const;
-        ByteVector renderAtom(const ByteVector &name, const ByteVector &data) const;
-        ByteVector renderData(const ByteVector &name, int flags,
-                              const ByteVectorList &data) const;
-        ByteVector renderText(const ByteVector &name, const Item &item,
-                              int flags = TypeUTF8) const;
-        ByteVector renderFreeForm(const String &name, const Item &item) const;
-        ByteVector renderBool(const ByteVector &name, const Item &item) const;
-        ByteVector renderInt(const ByteVector &name, const Item &item) const;
-        ByteVector renderByte(const ByteVector &name, const Item &item) const;
-        ByteVector renderUInt(const ByteVector &name, const Item &item) const;
-        ByteVector renderLongLong(const ByteVector &name, const Item &item) const;
-        ByteVector renderIntPair(const ByteVector &name, const Item &item) const;
-        ByteVector renderIntPairNoTrailing(const ByteVector &name, const Item &item) const;
-        ByteVector renderCovr(const ByteVector &name, const Item &item) const;
+        static ByteVector padIlst(const ByteVector &data, int length = -1);
+        static ByteVector renderAtom(const ByteVector &name, const ByteVector &data);
+        static ByteVector renderData(const ByteVector &name, int flags,
+                                     const ByteVectorList &data);
+        static ByteVector renderText(const ByteVector &name, const Item &item,
+                                     int flags = TypeUTF8);
+        static ByteVector renderFreeForm(const String &name, const Item &item);
+        static ByteVector renderBool(const ByteVector &name, const Item &item);
+        static ByteVector renderInt(const ByteVector &name, const Item &item);
+        static ByteVector renderByte(const ByteVector &name, const Item &item);
+        static ByteVector renderUInt(const ByteVector &name, const Item &item);
+        static ByteVector renderLongLong(const ByteVector &name, const Item &item);
+        static ByteVector renderIntPair(const ByteVector &name, const Item &item);
+        static ByteVector renderIntPairNoTrailing(const ByteVector &name, const Item &item);
+        static ByteVector renderCovr(const ByteVector &name, const Item &item);
 
         void updateParents(const AtomList &path, offset_t delta, int ignore = 0);
         void updateOffsets(offset_t delta, offset_t offset);

--- a/taglib/mpeg/id3v2/id3v2footer.cpp
+++ b/taglib/mpeg/id3v2/id3v2footer.cpp
@@ -42,7 +42,7 @@ unsigned int Footer::size()
   return 10;
 }
 
-ByteVector Footer::render(const Header *header) const
+ByteVector Footer::render(const Header *header)
 {
   ByteVector headerData = header->render();
   headerData[0] = '3';

--- a/taglib/mpeg/id3v2/id3v2footer.h
+++ b/taglib/mpeg/id3v2/id3v2footer.h
@@ -70,7 +70,7 @@ namespace TagLib {
       /*!
        * Renders the footer based on the data in \a header.
        */
-      ByteVector render(const Header *header) const;
+      static ByteVector render(const Header *header);
 
     private:
       class FooterPrivate;

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -216,8 +216,8 @@ namespace TagLib {
        * updated to return the position just after the string that has been read.
        * This is useful for reading strings sequentially.
        */
-      String readStringField(const ByteVector &data, String::Type encoding,
-                             int *position = nullptr);
+      static String readStringField(const ByteVector &data, String::Type encoding,
+                                    int *position = nullptr);
 
       /*!
        * Checks a the list of string values to see if they can be used with the

--- a/taglib/wavpack/wavpackproperties.h
+++ b/taglib/wavpack/wavpackproperties.h
@@ -109,7 +109,7 @@ namespace TagLib {
 
     private:
       void read(File *file, offset_t streamLength);
-      unsigned int seekFinalIndex(File *file, offset_t streamLength);
+      static unsigned int seekFinalIndex(File *file, offset_t streamLength);
 
       class PropertiesPrivate;
       std::unique_ptr<PropertiesPrivate> d;


### PR DESCRIPTION
Found with readability-convert-member-functions-to-static