### PR TITLE
clang-tidy: use nullptr

### DIFF
--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -77,7 +77,7 @@ namespace
   {
 #ifdef _WIN32
     if(::wcslen(fileName) == 0)
-      return 0;
+      return nullptr;
 #else
     if(::strlen(fileName) == 0)
       return nullptr;

--- a/taglib/toolkit/tdebuglistener.cpp
+++ b/taglib/toolkit/tdebuglistener.cpp
@@ -44,10 +44,10 @@ namespace
 #ifdef _WIN32
 
       const wstring wstr = msg.toWString();
-      const int len = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, NULL, 0, NULL, NULL);
+      const int len = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
       if(len != 0) {
         std::vector<char> buf(len);
-        WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &buf[0], len, NULL, NULL);
+        WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &buf[0], len, nullptr, nullptr);
 
         std::cerr << std::string(&buf[0]);
       }

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -52,9 +52,9 @@ namespace
     const DWORD access = readOnly ? GENERIC_READ : (GENERIC_READ | GENERIC_WRITE);
 
 #if defined (PLATFORM_WINRT)
-    return CreateFile2(path.wstr().c_str(), access, FILE_SHARE_READ, OPEN_EXISTING, NULL);
+    return CreateFile2(path.wstr().c_str(), access, FILE_SHARE_READ, OPEN_EXISTING, nullptr);
 #else
-    return CreateFileW(path.wstr().c_str(), access, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
+    return CreateFileW(path.wstr().c_str(), access, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
 #endif
   }
 
@@ -71,7 +71,7 @@ namespace
   size_t readFile(FileHandle file, ByteVector &buffer)
   {
     DWORD length;
-    if(ReadFile(file, buffer.data(), static_cast<DWORD>(buffer.size()), &length, NULL))
+    if(ReadFile(file, buffer.data(), static_cast<DWORD>(buffer.size()), &length, nullptr))
       return static_cast<size_t>(length);
     else
       return 0;
@@ -80,7 +80,7 @@ namespace
   size_t writeFile(FileHandle file, const ByteVector &buffer)
   {
     DWORD length;
-    if(WriteFile(file, buffer.data(), static_cast<DWORD>(buffer.size()), &length, NULL))
+    if(WriteFile(file, buffer.data(), static_cast<DWORD>(buffer.size()), &length, nullptr))
       return static_cast<size_t>(length);
     else
       return 0;
@@ -378,7 +378,7 @@ void FileStream::seek(offset_t offset, Position p)
   LARGE_INTEGER liOffset;
   liOffset.QuadPart = offset;
 
-  if(!SetFilePointerEx(d->file, liOffset, NULL, static_cast<DWORD>(p))) {
+  if(!SetFilePointerEx(d->file, liOffset, nullptr, static_cast<DWORD>(p))) {
     debug("FileStream::seek() -- Failed to set the file pointer.");
   }
 

--- a/taglib/toolkit/tiostream.cpp
+++ b/taglib/toolkit/tiostream.cpp
@@ -38,7 +38,7 @@ namespace
 {
   std::wstring ansiToUnicode(const char *str)
   {
-    const int len = MultiByteToWideChar(CP_ACP, 0, str, -1, NULL, 0);
+    const int len = MultiByteToWideChar(CP_ACP, 0, str, -1, nullptr, 0);
     if(len == 0)
       return std::wstring();
 


### PR DESCRIPTION
Found with modernize-use-nullptr