### PR TITLE
clang-tidy: use = default

### DIFF
--- a/taglib/toolkit/tiostream.cpp
+++ b/taglib/toolkit/tiostream.cpp
@@ -59,10 +59,7 @@ FileName::FileName(const char *name) :
 {
 }
 
-FileName::FileName(const FileName &name) :
-  m_wname(name.m_wname)
-{
-}
+FileName::FileName(const FileName &name) = default;
 
 FileName::operator const wchar_t *() const
 {


### PR DESCRIPTION
Found with: modernize-use-equals-default