### PR TITLE
clang-tidy: use data()

### DIFF
--- a/taglib/toolkit/tdebuglistener.cpp
+++ b/taglib/toolkit/tdebuglistener.cpp
@@ -47,9 +47,9 @@ namespace
       const int len = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
       if(len != 0) {
         std::vector<char> buf(len);
-        WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &buf[0], len, nullptr, nullptr);
+        WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, buf.data(), len, nullptr, nullptr);
 
-        std::cerr << std::string(&buf[0]);
+        std::cerr << std::string(buf.begin(), buf.end());
       }
 
 #else

--- a/taglib/toolkit/tiostream.cpp
+++ b/taglib/toolkit/tiostream.cpp
@@ -43,7 +43,7 @@ namespace
       return std::wstring();
 
     std::wstring wstr(len - 1, L'\0');
-    MultiByteToWideChar(CP_ACP, 0, str, -1, &wstr[0], len);
+    MultiByteToWideChar(CP_ACP, 0, str, -1, wstr.data(), len);
 
     return wstr;
   }


### PR DESCRIPTION
Found with readability-container-data-pointer