### PR TITLE
remove unused typedefs

### DIFF
--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -68,8 +68,7 @@ class FileRef::StreamTypeResolver::StreamTypeResolverPrivate
 
 namespace
 {
-  typedef List<const FileRef::FileTypeResolver *> ResolverList;
-  ResolverList fileTypeResolvers;
+  List<const FileRef::FileTypeResolver *> fileTypeResolvers;
 
   // Detect the file type by user-defined resolvers.
 

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -48,10 +48,6 @@ using namespace TagLib;
 
 namespace
 {
-  typedef List<FLAC::MetadataBlock *> BlockList;
-  typedef BlockList::Iterator BlockIterator;
-  typedef BlockList::ConstIterator BlockConstIterator;
-
   enum { FlacXiphIndex = 0, FlacID3v2Index = 1, FlacID3v1Index = 2 };
 
   const long MinPaddingLength = 4096;
@@ -87,7 +83,7 @@ public:
 
   Properties *properties { nullptr };
   ByteVector xiphCommentData;
-  BlockList blocks;
+  List<FLAC::MetadataBlock *> blocks;
 
   offset_t flacStart { 0 };
   offset_t streamStart { 0 };

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -35,16 +35,6 @@
 
 using namespace TagLib;
 
-namespace
-{
-  typedef Ogg::FieldListMap::Iterator FieldIterator;
-  typedef Ogg::FieldListMap::ConstIterator FieldConstIterator;
-
-  typedef List<FLAC::Picture *> PictureList;
-  typedef PictureList::Iterator PictureIterator;
-  typedef PictureList::ConstIterator PictureConstIterator;
-} // namespace
-
 class Ogg::XiphComment::XiphCommentPrivate
 {
 public:
@@ -56,7 +46,7 @@ public:
   FieldListMap fieldListMap;
   String vendorID;
   String commentField;
-  PictureList pictureList;
+  List<FLAC::Picture *> pictureList;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This was done in C++98 times. No longer needed with auto.