### PR TITLE
Map: Support Braced List Initialization

### DIFF
--- a/taglib/toolkit/tmap.h
+++ b/taglib/toolkit/tmap.h
@@ -28,6 +28,8 @@
 
 #include <map>
 #include <memory>
+#include <initializer_list>
+#include <utility>
 
 #include "taglib.h"
 
@@ -73,6 +75,11 @@ namespace TagLib {
      * pass-by-value usage.
      */
     Map(const Map<Key, T> &m);
+
+    /*!
+     * Constructs a Map with the contents of the braced initializer list.
+     */
+    Map(std::initializer_list<std::pair<const Key, T>> init);
 
     /*!
      * Destroys this instance of the Map.
@@ -194,6 +201,11 @@ namespace TagLib {
      * pass-by-value usage.
      */
     Map<Key, T> &operator=(const Map<Key, T> &m);
+
+    /*!
+     * Replace the contents of the map with those of the braced initializer list
+     */
+    Map<Key, T> &operator=(std::initializer_list<std::pair<const Key, T>> init);
 
     /*!
      * Exchanges the content of this map by the content of \a m.

--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -37,9 +37,13 @@ public:
   MapPrivate() = default;
 #ifdef WANT_CLASS_INSTANTIATION_OF_MAP
   MapPrivate(const std::map<class KeyP, class TP>& m) : map(m) {}
+  MapPrivate(std::initializer_list<std::pair<const class KeyP, class TP>> init) : map(init) {}
+
   std::map<class KeyP, class TP> map;
 #else
   MapPrivate(const std::map<KeyP, TP>& m) : map(m) {}
+  MapPrivate(std::initializer_list<std::pair<const KeyP, TP>> init) : map(init) {}
+
   std::map<KeyP, TP> map;
 #endif
 };
@@ -52,6 +56,12 @@ Map<Key, T>::Map() :
 
 template <class Key, class T>
 Map<Key, T>::Map(const Map<Key, T> &) = default;
+
+template <class Key, class T>
+Map<Key, T>::Map(std::initializer_list<std::pair<const Key, T>> init) :
+  d(std::make_shared<MapPrivate<Key, T>>(init))
+{
+}
 
 template <class Key, class T>
 Map<Key, T>::~Map() = default;
@@ -179,6 +189,13 @@ T &Map<Key, T>::operator[](const Key &key)
 
 template <class Key, class T>
 Map<Key, T> &Map<Key, T>::operator=(const Map<Key, T> &) = default;
+
+template <class Key, class T>
+Map<Key, T> &Map<Key, T>::operator=(std::initializer_list<std::pair<const Key, T>> init)
+{
+  d->map = init;
+  return *this;
+}
 
 template <class Key, class T>
 void Map<Key, T>::swap(Map<Key, T> &m)

--- a/taglib/toolkit/tmap.tcc
+++ b/taglib/toolkit/tmap.tcc
@@ -193,7 +193,7 @@ Map<Key, T> &Map<Key, T>::operator=(const Map<Key, T> &) = default;
 template <class Key, class T>
 Map<Key, T> &Map<Key, T>::operator=(std::initializer_list<std::pair<const Key, T>> init)
 {
-  d->map = init;
+  Map(init).swap(*this);
   return *this;
 }
 

--- a/tests/test_map.cpp
+++ b/tests/test_map.cpp
@@ -35,6 +35,7 @@ class TestMap : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestMap);
   CPPUNIT_TEST(testInsert);
   CPPUNIT_TEST(testDetach);
+  CPPUNIT_TEST(testBracedInit);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -65,6 +66,29 @@ public:
     (*it).second = 99;
     CPPUNIT_ASSERT_EQUAL(9,  m1["bob"]);
     CPPUNIT_ASSERT_EQUAL(99, m2["bob"]);
+  }
+
+  void testBracedInit()
+  {
+    Map<String, int> m1 {
+      {"ONE", 1},
+      {"TWO", 2},
+      {"THREE", 3}
+    };
+    CPPUNIT_ASSERT_EQUAL(3, static_cast<int>(m1.size()));
+    CPPUNIT_ASSERT(m1.contains("ONE") && m1["ONE"] == 1);
+    CPPUNIT_ASSERT(m1.contains("TWO") && m1["TWO"] == 2);
+    CPPUNIT_ASSERT(m1.contains("THREE") && m1["THREE"] == 3);
+
+    Map<String, int> m2 = {
+      {"FOUR", 4},
+      {"FIVE", 5},
+      {"SIX", 6}
+    };
+    CPPUNIT_ASSERT_EQUAL(3, static_cast<int>(m2.size()));
+    CPPUNIT_ASSERT(m2.contains("FOUR") && m2["FOUR"] == 4);
+    CPPUNIT_ASSERT(m2.contains("FIVE") && m2["FIVE"] == 5);
+    CPPUNIT_ASSERT(m2.contains("SIX") && m2["SIX"] == 6);
   }
 
 };


### PR DESCRIPTION
Adds C++11 braced list initialization to `Map`, same as for `std::map`. For example:

```C++
TagLib::Map<TagLib::String, int> m1 {
  {"ONE", 1},
  {"TWO", 2},
  {"THREE", 3}
};
```

This can be useful for implementing a static lookup table.

Tests have been added for both construction and assignment.