### PR TITLE
List: Support Braced List Initialization

### DIFF
--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -27,6 +27,7 @@
 #define TAGLIB_LIST_H
 
 #include <list>
+#include <initializer_list>
 #include <memory>
 
 #include "taglib.h"
@@ -70,6 +71,11 @@ namespace TagLib {
      * pass-by-value usage.
      */
     List(const List<T> &l);
+
+    /*!
+     * Construct a List with the contents of the braced initiliazer list
+     */
+    List(std::initializer_list<T> init);
 
     /*!
      * Destroys this List instance.  If auto deletion is enabled and this list
@@ -246,6 +252,13 @@ namespace TagLib {
      * pass-by-value usage.
      */
     List<T> &operator=(const List<T> &l);
+
+    /*!
+     * Replace the contents of the list with those of the braced initializer list.
+     *
+     * If auto deletion is enabled and the list contains a pointer type, the members are also deleted
+     */
+    List<T> &operator=(std::initializer_list<T> init);
 
     /*!
      * Exchanges the content of this list by the content of \a l.

--- a/taglib/toolkit/tlist.tcc
+++ b/taglib/toolkit/tlist.tcc
@@ -53,6 +53,7 @@ template <class TP> class List<T>::ListPrivate  : public ListPrivateBase
 public:
   using ListPrivateBase::ListPrivateBase;
   ListPrivate(const std::list<TP> &l) : list(l) {}
+  ListPrivate(std::initializer_list<TP> init) : list(init) {}
   void clear() {
     list.clear();
   }
@@ -68,6 +69,7 @@ template <class TP> class List<T>::ListPrivate<TP *> : public ListPrivateBase
 public:
   using ListPrivateBase::ListPrivateBase;
   ListPrivate(const std::list<TP *> &l) : list(l) {}
+  ListPrivate(std::initializer_list<TP *> init) : list(init) {}
   ~ListPrivate() {
     clear();
   }
@@ -95,6 +97,12 @@ List<T>::List() :
 
 template <class T>
 List<T>::List(const List<T> &) = default;
+
+template <class T>
+List<T>::List(std::initializer_list<T> init) :
+  d(std::make_shared<ListPrivate<T>>(init))
+{
+}
 
 template <class T>
 List<T>::~List() = default;
@@ -292,6 +300,15 @@ const T &List<T>::operator[](unsigned int i) const
 
 template <class T>
 List<T> &List<T>::operator=(const List<T> &) = default;
+
+template <class T>
+List<T> &List<T>::operator=(std::initializer_list<T> init)
+{
+  bool autoDelete = d->autoDelete;
+  d = std::make_shared<ListPrivate<T>>(init);
+  setAutoDelete(autoDelete);
+  return *this;
+}
 
 template <class T>
 void List<T>::swap(List<T> &l)

--- a/taglib/toolkit/tlist.tcc
+++ b/taglib/toolkit/tlist.tcc
@@ -305,7 +305,7 @@ template <class T>
 List<T> &List<T>::operator=(std::initializer_list<T> init)
 {
   bool autoDelete = d->autoDelete;
-  d = std::make_shared<ListPrivate<T>>(init);
+  List(init).swap(*this);
   setAutoDelete(autoDelete);
   return *this;
 }

--- a/tests/test_list.cpp
+++ b/tests/test_list.cpp
@@ -34,6 +34,7 @@ class TestList : public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE(TestList);
   CPPUNIT_TEST(testAppend);
   CPPUNIT_TEST(testDetach);
+  CPPUNIT_TEST(bracedInit);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -69,6 +70,56 @@ public:
     *it = 33;
     CPPUNIT_ASSERT_EQUAL(3,  l1[2]);
     CPPUNIT_ASSERT_EQUAL(33, l2[2]);
+  }
+
+  void bracedInit()
+  {
+    List<int> l1 {
+      1,
+      2,
+      3
+    };
+    CPPUNIT_ASSERT_EQUAL(3, static_cast<int>(l1.size()));
+    CPPUNIT_ASSERT_EQUAL(1, l1[0]);
+    CPPUNIT_ASSERT_EQUAL(2, l1[1]);
+    CPPUNIT_ASSERT_EQUAL(3, l1[2]);
+
+    List<int*> l2 {
+      new int(1),
+      new int(2),
+      new int(3)
+    };
+    l2.setAutoDelete(true);
+    CPPUNIT_ASSERT_EQUAL(3, static_cast<int>(l2.size()));
+    CPPUNIT_ASSERT_EQUAL(1, *l2[0]);
+    CPPUNIT_ASSERT_EQUAL(2, *l2[1]);
+    CPPUNIT_ASSERT_EQUAL(3, *l2[2]);
+
+    List<int> l3 = {
+      1,
+      2,
+      3
+    };
+    CPPUNIT_ASSERT_EQUAL(3, static_cast<int>(l3.size()));
+    CPPUNIT_ASSERT_EQUAL(1, l3[0]);
+    CPPUNIT_ASSERT_EQUAL(2, l3[1]);
+    CPPUNIT_ASSERT_EQUAL(3, l3[2]);
+
+    List<int*> l4 = {
+      new int(1),
+      new int(2),
+      new int(3)
+    };
+    l4.setAutoDelete(true);
+    l4 = {
+      new int(4),
+      new int(5),
+      new int(6)
+    };
+    CPPUNIT_ASSERT_EQUAL(3, static_cast<int>(l4.size()));
+    CPPUNIT_ASSERT_EQUAL(4, *l4[0]);
+    CPPUNIT_ASSERT_EQUAL(5, *l4[1]);
+    CPPUNIT_ASSERT_EQUAL(6, *l4[2]);
   }
 
 };


### PR DESCRIPTION
Adds C++11 braced list initialization to `List`, same as for `std::list`. For example:

```C++
TagLib::List<int> m1 {
  1,
  2,
  3
};
```

- Tests have been added for construction and assignment, for both the regular and pointer specialization.
- For assignment, verified that the members are deleted when the list is of pointer type and auto delete is set to true

