### PR TITLE
Unified interface for complex properties like pictures (#94)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ option(WITH_ZLIB "Build with ZLIB" ON)
 
 if(WITH_ZLIB)
   find_package("ZLIB")
-  set(HAVE_ZLIB ZLIB_FOUND)
+  set(HAVE_ZLIB ${ZLIB_FOUND})
 endif()
 
 if(NOT WIN32)

--- a/examples/tagreader.cpp
+++ b/examples/tagreader.cpp
@@ -27,6 +27,8 @@
 #include <cstdio>
 
 #include "tpropertymap.h"
+#include "tstringlist.h"
+#include "tvariant.h"
 #include "fileref.h"
 #include "tag.h"
 
@@ -65,10 +67,39 @@ int main(int argc, char *argv[])
       cout << "-- TAG (properties) --" << endl;
       for(auto i = tags.cbegin(); i != tags.cend(); ++i) {
         for(auto j = i->second.begin(); j != i->second.end(); ++j) {
-          cout << left << std::setw(longest) << i->first << " - " << '"' << *j << '"' << endl;
+          cout << left << std::setfill(' ') << std::setw(longest) << i->first << " - " << '"' << *j << '"' << endl;
         }
       }
 
+      TagLib::StringList names = f.file()->complexPropertyKeys();
+      for(const auto &name : names) {
+        const auto& properties = f.file()->complexProperties(name);
+        for(const auto &property : properties) {
+          cout << name << ":" << endl;
+          for(const auto &[key, value] : property) {
+            cout << "  " << left << std::setfill(' ') << std::setw(11) << key << " - ";
+            if(value.type() == TagLib::Variant::ByteVector) {
+              cout << "(" << value.value<TagLib::ByteVector>().size() << " bytes)" << endl;
+              /* The picture could be extracted using:
+              ofstream picture;
+              TagLib::String fn(argv[i]);
+              int slashPos = fn.rfind('/');
+              int dotPos = fn.rfind('.');
+              if(slashPos >= 0 && dotPos > slashPos) {
+                fn = fn.substr(slashPos + 1, dotPos - slashPos - 1);
+              }
+              fn += ".jpg";
+              picture.open(fn.toCString(), ios_base::out | ios_base::binary);
+              picture << value.value<TagLib::ByteVector>();
+              picture.close();
+              */
+            }
+            else {
+              cout << value << endl;
+            }
+          }
+        }
+      }
     }
 
     if(!f.isNull() && f.audioProperties()) {

--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -47,6 +47,7 @@ set(tag_HDRS
   toolkit/tfilestream.h
   toolkit/tmap.h
   toolkit/tmap.tcc
+  toolkit/tpicturetype.h
   toolkit/tpropertymap.h
   toolkit/tdebuglistener.h
   toolkit/tversionnumber.h
@@ -307,6 +308,7 @@ set(toolkit_SRCS
   toolkit/tfile.cpp
   toolkit/tfilestream.cpp
   toolkit/tdebug.cpp
+  toolkit/tpicturetype.cpp
   toolkit/tpropertymap.cpp
   toolkit/tdebuglistener.cpp
   toolkit/tzlib.cpp

--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -40,6 +40,7 @@ set(tag_HDRS
   toolkit/tstringlist.h
   toolkit/tbytevector.h
   toolkit/tbytevectorlist.h
+  toolkit/tvariant.h
   toolkit/tbytevectorstream.h
   toolkit/tiostream.h
   toolkit/tfile.h
@@ -300,6 +301,7 @@ set(toolkit_SRCS
   toolkit/tstringlist.cpp
   toolkit/tbytevector.cpp
   toolkit/tbytevectorlist.cpp
+  toolkit/tvariant.cpp
   toolkit/tbytevectorstream.cpp
   toolkit/tiostream.cpp
   toolkit/tfile.cpp

--- a/taglib/ape/apetag.h
+++ b/taglib/ape/apetag.h
@@ -130,6 +130,10 @@ namespace TagLib {
        */
       PropertyMap setProperties(const PropertyMap &) override;
 
+      StringList complexPropertyKeys() const override;
+      List<VariantMap> complexProperties(const String &key) const override;
+      bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
       /*!
        * Check if the given String is a valid APE tag key.
        */

--- a/taglib/asf/asfpicture.h
+++ b/taglib/asf/asfpicture.h
@@ -28,6 +28,7 @@
 
 #include "tstring.h"
 #include "tbytevector.h"
+#include "tpicturetype.h"
 #include "taglib_export.h"
 #include "attachedpictureframe.h"
 
@@ -52,50 +53,7 @@ namespace TagLib
       /*!
        * This describes the function or content of the picture.
        */
-      enum Type {
-        //! A type not enumerated below
-        Other              = 0x00,
-        //! 32x32 PNG image that should be used as the file icon
-        FileIcon           = 0x01,
-        //! File icon of a different size or format
-        OtherFileIcon      = 0x02,
-        //! Front cover image of the album
-        FrontCover         = 0x03,
-        //! Back cover image of the album
-        BackCover          = 0x04,
-        //! Inside leaflet page of the album
-        LeafletPage        = 0x05,
-        //! Image from the album itself
-        Media              = 0x06,
-        //! Picture of the lead artist or soloist
-        LeadArtist         = 0x07,
-        //! Picture of the artist or performer
-        Artist             = 0x08,
-        //! Picture of the conductor
-        Conductor          = 0x09,
-        //! Picture of the band or orchestra
-        Band               = 0x0A,
-        //! Picture of the composer
-        Composer           = 0x0B,
-        //! Picture of the lyricist or text writer
-        Lyricist           = 0x0C,
-        //! Picture of the recording location or studio
-        RecordingLocation  = 0x0D,
-        //! Picture of the artists during recording
-        DuringRecording    = 0x0E,
-        //! Picture of the artists during performance
-        DuringPerformance  = 0x0F,
-        //! Picture from a movie or video related to the track
-        MovieScreenCapture = 0x10,
-        //! Picture of a large, coloured fish
-        ColouredFish       = 0x11,
-        //! Illustration related to the track
-        Illustration       = 0x12,
-        //! Logo of the band or performer
-        BandLogo           = 0x13,
-        //! Logo of the publisher (record company)
-        PublisherLogo      = 0x14
-      };
+      DECLARE_PICTURE_TYPE_ENUM(Type)
 
       /*!
        * Constructs an empty picture.

--- a/taglib/asf/asftag.h
+++ b/taglib/asf/asftag.h
@@ -204,6 +204,10 @@ namespace TagLib {
       void removeUnsupportedProperties(const StringList &props) override;
       PropertyMap setProperties(const PropertyMap &props) override;
 
+      StringList complexPropertyKeys() const override;
+      List<VariantMap> complexProperties(const String &key) const override;
+      bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
     private:
 
       class TagPrivate;

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -162,6 +162,23 @@ namespace TagLib {
       PropertyMap setProperties(const PropertyMap &) override;
 
       /*!
+       * Returns ["PICTURE"] if any picture is stored in METADATA_BLOCK_PICTURE.
+       */
+      StringList complexPropertyKeys() const override;
+
+      /*!
+       * Get the pictures stored in METADATA_BLOCK_PICTURE as complex properties
+       * for \a key "PICTURE".
+       */
+      List<VariantMap> complexProperties(const String &key) const override;
+
+      /*!
+       * Set the complex properties \a value as pictures in METADATA_BLOCK_PICTURE
+       * for \a key "PICTURE".
+       */
+      bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
+      /*!
        * Returns the FLAC::Properties for this file.  If no audio properties
        * were read then this will return a null pointer.
        */

--- a/taglib/flac/flacpicture.h
+++ b/taglib/flac/flacpicture.h
@@ -29,6 +29,7 @@
 #include "tlist.h"
 #include "tstring.h"
 #include "tbytevector.h"
+#include "tpicturetype.h"
 #include "taglib_export.h"
 #include "flacmetadatablock.h"
 
@@ -41,50 +42,7 @@ namespace TagLib {
       /*!
        * This describes the function or content of the picture.
        */
-      enum Type {
-        //! A type not enumerated below
-        Other              = 0x00,
-        //! 32x32 PNG image that should be used as the file icon
-        FileIcon           = 0x01,
-        //! File icon of a different size or format
-        OtherFileIcon      = 0x02,
-        //! Front cover image of the album
-        FrontCover         = 0x03,
-        //! Back cover image of the album
-        BackCover          = 0x04,
-        //! Inside leaflet page of the album
-        LeafletPage        = 0x05,
-        //! Image from the album itself
-        Media              = 0x06,
-        //! Picture of the lead artist or soloist
-        LeadArtist         = 0x07,
-        //! Picture of the artist or performer
-        Artist             = 0x08,
-        //! Picture of the conductor
-        Conductor          = 0x09,
-        //! Picture of the band or orchestra
-        Band               = 0x0A,
-        //! Picture of the composer
-        Composer           = 0x0B,
-        //! Picture of the lyricist or text writer
-        Lyricist           = 0x0C,
-        //! Picture of the recording location or studio
-        RecordingLocation  = 0x0D,
-        //! Picture of the artists during recording
-        DuringRecording    = 0x0E,
-        //! Picture of the artists during performance
-        DuringPerformance  = 0x0F,
-        //! Picture from a movie or video related to the track
-        MovieScreenCapture = 0x10,
-        //! Picture of a large, coloured fish
-        ColouredFish       = 0x11,
-        //! Illustration related to the track
-        Illustration       = 0x12,
-        //! Logo of the band or performer
-        BandLogo           = 0x13,
-        //! Logo of the publisher (record company)
-        PublisherLogo      = 0x14
-      };
+      DECLARE_PICTURE_TYPE_ENUM(Type)
 
       Picture();
       Picture(const ByteVector &data);

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -102,6 +102,10 @@ namespace TagLib {
         void removeUnsupportedProperties(const StringList &props) override;
         PropertyMap setProperties(const PropertyMap &props) override;
 
+        StringList complexPropertyKeys() const override;
+        List<VariantMap> complexProperties(const String &key) const override;
+        bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
       protected:
         /*!
          * Sets the value of \a key to \a value, overwriting any previous value.

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.h
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.h
@@ -27,6 +27,7 @@
 #define TAGLIB_ATTACHEDPICTUREFRAME_H
 
 #include "taglib_export.h"
+#include "tpicturetype.h"
 #include "id3v2frame.h"
 #include "id3v2header.h"
 
@@ -52,50 +53,7 @@ namespace TagLib {
       /*!
        * This describes the function or content of the picture.
        */
-      enum Type {
-        //! A type not enumerated below
-        Other              = 0x00,
-        //! 32x32 PNG image that should be used as the file icon
-        FileIcon           = 0x01,
-        //! File icon of a different size or format
-        OtherFileIcon      = 0x02,
-        //! Front cover image of the album
-        FrontCover         = 0x03,
-        //! Back cover image of the album
-        BackCover          = 0x04,
-        //! Inside leaflet page of the album
-        LeafletPage        = 0x05,
-        //! Image from the album itself
-        Media              = 0x06,
-        //! Picture of the lead artist or soloist
-        LeadArtist         = 0x07,
-        //! Picture of the artist or performer
-        Artist             = 0x08,
-        //! Picture of the conductor
-        Conductor          = 0x09,
-        //! Picture of the band or orchestra
-        Band               = 0x0A,
-        //! Picture of the composer
-        Composer           = 0x0B,
-        //! Picture of the lyricist or text writer
-        Lyricist           = 0x0C,
-        //! Picture of the recording location or studio
-        RecordingLocation  = 0x0D,
-        //! Picture of the artists during recording
-        DuringRecording    = 0x0E,
-        //! Picture of the artists during performance
-        DuringPerformance  = 0x0F,
-        //! Picture from a movie or video related to the track
-        MovieScreenCapture = 0x10,
-        //! Picture of a large, coloured fish
-        ColouredFish       = 0x11,
-        //! Illustration related to the track
-        Illustration       = 0x12,
-        //! Logo of the band or performer
-        BandLogo           = 0x13,
-        //! Logo of the publisher (record company)
-        PublisherLogo      = 0x14
-      };
+      DECLARE_PICTURE_TYPE_ENUM(Type)
 
       /*!
        * Constructs an empty picture frame.  The description, content and text

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -36,6 +36,8 @@
 #include "id3v2footer.h"
 #include "id3v2synchdata.h"
 #include "id3v1genres.h"
+#include "frames/attachedpictureframe.h"
+#include "frames/generalencapsulatedobjectframe.h"
 #include "frames/textidentificationframe.h"
 #include "frames/commentsframe.h"
 #include "frames/urllinkframe.h"
@@ -458,6 +460,84 @@ PropertyMap ID3v2::Tag::setProperties(const PropertyMap &origProps)
   for(const auto &[tag, frames] : std::as_const(properties))
       addFrame(Frame::createTextualFrame(tag, frames));
   return PropertyMap(); // ID3 implements the complete PropertyMap interface, so an empty map is returned
+}
+
+StringList ID3v2::Tag::complexPropertyKeys() const
+{
+  StringList keys;
+  if(d->frameListMap.contains("APIC")) {
+    keys.append("PICTURE");
+  }
+  if(d->frameListMap.contains("GEOB")) {
+    keys.append("GENERALOBJECT");
+  }
+  return keys;
+}
+
+List<VariantMap> ID3v2::Tag::complexProperties(const String &key) const
+{
+  List<VariantMap> properties;
+  const String uppercaseKey = key.upper();
+  if(uppercaseKey == "PICTURE") {
+    const FrameList pictures = d->frameListMap.value("APIC");
+    for(const Frame *frame : pictures) {
+      auto picture = static_cast<const AttachedPictureFrame *>(frame);
+      VariantMap property;
+      property.insert("data", picture->picture());
+      property.insert("mimeType", picture->mimeType());
+      property.insert("description", picture->description());
+      property.insert("pictureType",
+        AttachedPictureFrame::typeToString(picture->type()));
+      properties.append(property);
+    }
+  }
+  else if(uppercaseKey == "GENERALOBJECT") {
+    const FrameList geobs = d->frameListMap.value("GEOB");
+    for(const Frame *frame : geobs) {
+      auto geob = static_cast<const GeneralEncapsulatedObjectFrame *>(frame);
+      VariantMap property;
+      property.insert("data", geob->object());
+      property.insert("mimeType", geob->mimeType());
+      property.insert("description", geob->description());
+      property.insert("fileName", geob->fileName());
+      properties.append(property);
+    }
+  }
+  return properties;
+}
+
+bool ID3v2::Tag::setComplexProperties(const String &key, const List<VariantMap> &value)
+{
+  const String uppercaseKey = key.upper();
+  if(uppercaseKey == "PICTURE") {
+    removeFrames("APIC");
+
+    for(auto property : value) {
+      auto picture = new AttachedPictureFrame;
+      picture->setPicture(property.value("data").value<ByteVector>());
+      picture->setMimeType(property.value("mimeType").value<String>());
+      picture->setDescription(property.value("description").value<String>());
+      picture->setType(AttachedPictureFrame::typeFromString(
+        property.value("pictureType").value<String>()));
+      addFrame(picture);
+    }
+  }
+  else if(uppercaseKey == "GENERALOBJECT") {
+    removeFrames("GEOB");
+
+    for(auto property : value) {
+      auto geob = new GeneralEncapsulatedObjectFrame;
+      geob->setObject(property.value("data").value<ByteVector>());
+      geob->setMimeType(property.value("mimeType").value<String>());
+      geob->setDescription(property.value("description").value<String>());
+      geob->setFileName(property.value("fileName").value<String>());
+      addFrame(geob);
+    }
+  }
+  else {
+    return false;
+  }
+  return true;
 }
 
 ByteVector ID3v2::Tag::render() const

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -329,6 +329,10 @@ namespace TagLib {
        */
       PropertyMap setProperties(const PropertyMap &) override;
 
+      StringList complexPropertyKeys() const override;
+      List<VariantMap> complexProperties(const String &key) const override;
+      bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
       /*!
        * Render the tag back to binary data, suitable to be written to disk.
        */

--- a/taglib/ogg/xiphcomment.h
+++ b/taglib/ogg/xiphcomment.h
@@ -167,6 +167,10 @@ namespace TagLib {
        */
       PropertyMap setProperties(const PropertyMap&) override;
 
+      StringList complexPropertyKeys() const override;
+      List<VariantMap> complexProperties(const String &key) const override;
+      bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
       /*!
        * Check if the given String is a valid Xiph comment key.
        */

--- a/taglib/tag.cpp
+++ b/taglib/tag.cpp
@@ -146,6 +146,21 @@ PropertyMap Tag::setProperties(const PropertyMap &origProps)
   return properties;
 }
 
+StringList Tag::complexPropertyKeys() const
+{
+  return StringList();
+}
+
+List<VariantMap> Tag::complexProperties(const String &) const
+{
+  return {};
+}
+
+bool Tag::setComplexProperties(const String &, const List<VariantMap> &)
+{
+  return false;
+}
+
 void Tag::duplicate(const Tag *source, Tag *target, bool overwrite) // static
 {
   if(overwrite) {

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -28,6 +28,8 @@
 
 #include "taglib_export.h"
 #include "tstring.h"
+#include "tlist.h"
+#include "tvariant.h"
 
 namespace TagLib {
 
@@ -77,6 +79,49 @@ namespace TagLib {
      * in the returned PropertyMap.
      */
     virtual PropertyMap setProperties(const PropertyMap &origProps);
+
+    /*!
+     * Get the keys of complex properties, i.e. properties which cannot be
+     * represented simply by a string.
+     * Because such properties might be expensive to fetch, there are separate
+     * operations to get the available keys - which is expected to be cheap -
+     * and getting and setting the property values.
+     * The default implementation returns only an empty list.  Reimplementations
+     * should provide "PICTURE" if embedded cover art is present, and optionally
+     * support other properties.
+     */
+    virtual StringList complexPropertyKeys() const;
+
+    /*!
+     * Get the complex properties for a given \a key.
+     * In order to be flexible for different metadata formats, the properties
+     * are represented as variant maps.  Despite this dynamic nature, some
+     * degree of standardization should be achieved between formats:
+     *
+     * - PICTURE
+     *   - data: ByteVector with picture data
+     *   - description: String with description
+     *   - pictureType: String with type as specified for ID3v2,
+     *     e.g. "Front Cover", "Back Cover", "Band"
+     *   - mimeType: String with image format, e.g. "image/jpeg"
+     *   - optionally more information found in the tag, such as
+     *     "width", "height", "numColors", "colorDepth" int values
+     *     in FLAC pictures
+     * - GENERALOBJECT
+     *   - data: ByteVector with object data
+     *   - description: String with description
+     *   - fileName: String with file name
+     *   - mimeType: String with MIME type
+     *   - this is currently only implemented for ID3v2 GEOB frames
+     */
+    virtual List<VariantMap> complexProperties(const String &key) const;
+
+    /*!
+     * Set all complex properties for a given \a key using variant maps as
+     * \a value with the same format as returned by complexProperties().
+     * An empty list as \a value to removes all complex properties for \a key.
+     */
+    virtual bool setComplexProperties(const String &key, const List<VariantMap> &value);
 
     /*!
      * Returns the track name; if no track name is present in the tag

--- a/taglib/tagunion.cpp
+++ b/taglib/tagunion.cpp
@@ -124,6 +124,45 @@ void TagUnion::removeUnsupportedProperties(const StringList &unsupported)
   }
 }
 
+StringList TagUnion::complexPropertyKeys() const
+{
+  for(const auto &tag : d->tags) {
+    if(tag) {
+      const StringList keys = tag->complexPropertyKeys();
+      if(!keys.isEmpty()) {
+        return keys;
+      }
+    }
+  }
+  return StringList();
+}
+
+List<VariantMap> TagUnion::complexProperties(const String &key) const
+{
+  for(const auto &tag : d->tags) {
+    if(tag) {
+      const List<VariantMap> props = tag->complexProperties(key);
+      if(!props.isEmpty()) {
+        return props;
+      }
+    }
+  }
+  return List<VariantMap>();
+}
+
+bool TagUnion::setComplexProperties(const String &key, const List<VariantMap> &value)
+{
+  bool combinedResult = false;
+  for(const auto &tag : d->tags) {
+    if(tag) {
+      if(tag->setComplexProperties(key, value)) {
+        combinedResult = true;
+      }
+    }
+  }
+  return combinedResult;
+}
+
 String TagUnion::title() const
 {
   stringUnion(title);

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -62,6 +62,10 @@ namespace TagLib {
     PropertyMap properties() const override;
     void removeUnsupportedProperties(const StringList &unsupported) override;
 
+    StringList complexPropertyKeys() const override;
+    List<VariantMap> complexProperties(const String &key) const override;
+    bool setComplexProperties(const String &key, const List<VariantMap> &value) override;
+
     String title() const override;
     String artist() const override;
     String album() const override;

--- a/taglib/toolkit/tfile.cpp
+++ b/taglib/toolkit/tfile.cpp
@@ -106,6 +106,21 @@ PropertyMap File::setProperties(const PropertyMap &properties)
   return tag()->setProperties(properties);
 }
 
+StringList File::complexPropertyKeys() const
+{
+  return tag()->complexPropertyKeys();
+}
+
+List<VariantMap> File::complexProperties(const String &key) const
+{
+  return tag()->complexProperties(key);
+}
+
+bool File::setComplexProperties(const String &key, const List<VariantMap> &value)
+{
+  return tag()->setComplexProperties(key, value);
+}
+
 ByteVector File::readBlock(size_t length)
 {
   return d->stream->readBlock(length);

--- a/taglib/toolkit/tfile.h
+++ b/taglib/toolkit/tfile.h
@@ -134,6 +134,28 @@ namespace TagLib {
     virtual PropertyMap setProperties(const PropertyMap &properties);
 
     /*!
+     * Get the keys of complex properties, i.e. properties which cannot be
+     * represented simply by a string.
+     * The default implementation calls Tag::complexPropertyKeys().
+     * \see Tag::complexPropertyKeys()
+     */
+    virtual StringList complexPropertyKeys() const;
+
+    /*!
+     * Get the complex properties for a given \a key.
+     * The default implementation calls Tag::complexProperties().
+     * \see Tag::complexProperties()
+     */
+    virtual List<VariantMap> complexProperties(const String &key) const;
+
+    /*!
+     * Set all complex properties for \a key using the variant maps \a value.
+     * The default implementation calls Tag::setComplexProperties().
+     * \see Tag::setComplexProperties()
+     */
+    virtual bool setComplexProperties(const String &key, const List<VariantMap> &value);
+
+    /*!
      * Returns a pointer to this file's audio properties.  This should be
      * reimplemented in the concrete subclasses.  If no audio properties were
      * read then this will return a null pointer.

--- a/taglib/toolkit/tpicturetype.cpp
+++ b/taglib/toolkit/tpicturetype.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "tpicturetype.h"
+
+#include "tstring.h"
+
+using namespace TagLib;
+
+namespace {
+
+  static const char *const typeStrs[] = {
+    "Other",
+    "File Icon",
+    "Other File Icon",
+    "Front Cover",
+    "Back Cover",
+    "Leaflet Page",
+    "Media",
+    "Lead Artist",
+    "Artist",
+    "Conductor",
+    "Band",
+    "Composer",
+    "Lyricist",
+    "Recording Location",
+    "During Recording",
+    "During Performance",
+    "Movie Screen Capture",
+    "Coloured Fish",
+    "Illustration",
+    "Band Logo",
+    "Publisher Logo"
+  };
+
+}  // namespace
+
+String Utils::pictureTypeToString(int type)
+{
+  if(type >= 0 && type < static_cast<int>(std::size(typeStrs))) {
+    return typeStrs[type];
+  }
+  return "";
+}
+
+int Utils::pictureTypeFromString(String str)
+{
+  for(int i = 0; i < static_cast<int>(std::size(typeStrs)); ++i) {
+    if(str == typeStrs[i]) {
+      return i;
+    }
+  }
+  return 0;
+}

--- a/taglib/toolkit/tpicturetype.h
+++ b/taglib/toolkit/tpicturetype.h
@@ -1,0 +1,122 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_PICTURETYPE_H
+#define TAGLIB_PICTURETYPE_H
+
+// THIS FILE IS NOT A PART OF THE TAGLIB API
+
+#ifndef DO_NOT_DOCUMENT  // tell Doxygen not to document this header
+
+#include "taglib_export.h"
+
+/*!
+ * Declare a picture type \a name enumeration inside a class.
+ * Declares a picture type enum according to the ID3v2 specification and
+ * adds methods \c typeToString() and \c typeFromString().
+ *
+ * \code {.cpp}
+ * class MyClass {
+ * public:
+ *   DECLARE_PICTURE_TYPE_ENUM(Type)
+ *   (..)
+ * }
+ * \endcode
+ */
+#define DECLARE_PICTURE_TYPE_ENUM(name)                       \
+enum name {                                                   \
+  /*! A type not enumerated below */                          \
+  Other              = 0x00,                                  \
+  /*! 32x32 PNG image that should be used as the file icon */ \
+  FileIcon           = 0x01,                                  \
+  /*! File icon of a different size or format */              \
+  OtherFileIcon      = 0x02,                                  \
+  /*! Front cover image of the album */                       \
+  FrontCover         = 0x03,                                  \
+  /*! Back cover image of the album */                        \
+  BackCover          = 0x04,                                  \
+  /*! Inside leaflet page of the album */                     \
+  LeafletPage        = 0x05,                                  \
+  /*! Image from the album itself */                          \
+  Media              = 0x06,                                  \
+  /*! Picture of the lead artist or soloist */                \
+  LeadArtist         = 0x07,                                  \
+  /*! Picture of the artist or performer */                   \
+  Artist             = 0x08,                                  \
+  /*! Picture of the conductor */                             \
+  Conductor          = 0x09,                                  \
+  /*! Picture of the band or orchestra */                     \
+  Band               = 0x0A,                                  \
+  /*! Picture of the composer */                              \
+  Composer           = 0x0B,                                  \
+  /*! Picture of the lyricist or text writer */               \
+  Lyricist           = 0x0C,                                  \
+  /*! Picture of the recording location or studio */          \
+  RecordingLocation  = 0x0D,                                  \
+  /*! Picture of the artists during recording */              \
+  DuringRecording    = 0x0E,                                  \
+  /*! Picture of the artists during performance */            \
+  DuringPerformance  = 0x0F,                                  \
+  /*! Picture from a movie or video related to the track */   \
+  MovieScreenCapture = 0x10,                                  \
+  /*! Picture of a large, coloured fish */                    \
+  ColouredFish       = 0x11,                                  \
+  /*! Illustration related to the track */                    \
+  Illustration       = 0x12,                                  \
+  /*! Logo of the band or performer */                        \
+  BandLogo           = 0x13,                                  \
+  /*! Logo of the publisher (record company) */               \
+  PublisherLogo      = 0x14                                   \
+};                                                            \
+static TagLib::String typeToString(name type) {               \
+  return TagLib::Utils::pictureTypeToString(type);            \
+}                                                             \
+static name typeFromString(TagLib::String str) {              \
+  return static_cast<name>(                                   \
+    TagLib::Utils::pictureTypeFromString(str));               \
+}
+
+namespace TagLib {
+
+  class String;
+
+  namespace Utils {
+
+    /*!
+     * Get string representation of picture type.
+     */
+    String TAGLIB_EXPORT pictureTypeToString(int type);
+
+    /*!
+     * Get picture type from string representation.
+     */
+    int TAGLIB_EXPORT pictureTypeFromString(String str);
+
+  }  // namespace Utils
+}  // namespace TagLib
+
+#endif
+
+#endif

--- a/taglib/toolkit/tvariant.cpp
+++ b/taglib/toolkit/tvariant.cpp
@@ -1,0 +1,391 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "tvariant.h"
+
+#include <variant>
+#include <iomanip>
+
+#include "tstring.h"
+#include "tstringlist.h"
+#include "tbytevector.h"
+#include "tbytevectorlist.h"
+
+using namespace TagLib;
+
+namespace {
+
+// The number and order of the template parameters must correspond to the
+// enum values in Variant::Type!
+using StdVariantType = std::variant<
+  std::monostate,
+  bool,
+  int,
+  unsigned int,
+  long long,
+  unsigned long long,
+  double,
+  TagLib::String,
+  TagLib::StringList,
+  TagLib::ByteVector,
+  TagLib::ByteVectorList,
+  List<TagLib::Variant>,
+  Map<TagLib::String, TagLib::Variant>
+>;
+
+template<typename T>
+T getVariantValue(StdVariantType *v, bool *ok)
+{
+  if(const auto valPtr = std::get_if<T>(v)) {
+    if(ok) {
+      *ok = true;
+    }
+    return *valPtr;
+  }
+  if(ok) {
+    *ok = false;
+  }
+  return {};
+}
+
+// Visitor to print a possibly recursive Variant to an ostream.
+// The representation is JSON with hex strings for ByteVector.
+class OStreamVisitor {
+public:
+  OStreamVisitor(std::ostream &os) : s(os)
+  {
+  }
+
+  void operator()(std::monostate v)
+  {
+    s << "null";
+  }
+
+  void operator()(bool v)
+  {
+    s << (v ? "true" : "false");
+  }
+
+  void operator()(int v)
+  {
+    s << v;
+  }
+
+  void operator()(unsigned int v)
+  {
+    s << v;
+  }
+
+  void operator()(long long v)
+  {
+    s << v;
+  }
+
+  void operator()(unsigned long long v)
+  {
+    s << v;
+  }
+
+  void operator()(double v)
+  {
+    s << v;
+  }
+
+  void operator()(const TagLib::String &v)
+  {
+    s << '"';
+    for (char c : v.to8Bit()) {
+      if(c == '"') {
+        s << "\\\"";
+      }
+      else {
+        s << c;
+      }
+    }
+    s << '"';
+  }
+
+  void operator()(const TagLib::StringList &v)
+  {
+    s << '[';
+    for(auto it = v.cbegin(); it != v.cend(); ++it) {
+      if(it != v.cbegin()) {
+        s << ", ";
+      }
+      operator()(*it);
+    }
+    s << ']';
+  }
+
+  void operator()(const TagLib::ByteVector &v)
+  {
+    s << '"';
+    for(char c : v) {
+      s << "\\x" << std::setfill('0') << std::setw(2) << std::right << std::hex
+        << (static_cast<int>(c) & 0xff);
+    }
+    s << std::dec << '"';
+  }
+
+  void operator()(const TagLib::ByteVectorList &v)
+  {
+    s << '[';
+    for(auto it = v.cbegin(); it != v.cend(); ++it) {
+      if(it != v.cbegin()) {
+        s << ", ";
+      }
+      operator()(*it);
+    }
+    s << ']';
+  }
+
+  void operator()(const List<TagLib::Variant> &v) {
+    s << '[';
+    for(auto it = v.cbegin(); it != v.cend(); ++it) {
+      if(it != v.cbegin()) {
+        s << ", ";
+      }
+      s << *it;
+    }
+    s << ']';
+  }
+
+  void operator()(const Map<TagLib::String, TagLib::Variant> &v)
+  {
+    s << '{';
+    for(auto it = v.cbegin(); it != v.cend(); ++it) {
+      if(it != v.cbegin()) {
+        s << ", ";
+      }
+      operator()(it->first);
+      s << ": ";
+      s << it->second;
+    }
+    s << '}';
+  }
+
+private:
+  std::ostream &s;
+};
+
+} // namespace
+
+class Variant::VariantPrivate
+{
+public:
+  VariantPrivate() = default;
+  VariantPrivate(const StdVariantType &v) : data(v) {}
+  StdVariantType data;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// public members
+////////////////////////////////////////////////////////////////////////////////
+
+Variant::Variant() :
+  d(std::make_shared<VariantPrivate>())
+{
+}
+
+Variant::Variant(int val) :
+  d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(unsigned int val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(long long val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(unsigned long long val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(bool val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(double val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const char *val) :
+ d(std::make_shared<VariantPrivate>(TagLib::String(val)))
+{
+}
+
+Variant::Variant(const TagLib::String &val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const TagLib::StringList &val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const TagLib::ByteVector &val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const TagLib::ByteVectorList &val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const TagLib::List<TagLib::Variant> &val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const TagLib::Map<TagLib::String, TagLib::Variant> &val) :
+ d(std::make_shared<VariantPrivate>(val))
+{
+}
+
+Variant::Variant(const Variant &) = default;
+
+////////////////////////////////////////////////////////////////////////////////
+
+Variant::~Variant() = default;
+
+Variant::Type Variant::type() const {
+  return static_cast<Type>(d->data.index());
+}
+
+bool Variant::isEmpty() const
+{
+  return type() == Void;
+}
+
+template<typename T>
+T Variant::value(bool *ok) const
+{
+  return getVariantValue<T>(&d->data, ok);
+}
+
+template bool Variant::value(bool *ok) const;
+template int Variant::value(bool *ok) const;
+template unsigned int Variant::value(bool *ok) const;
+template long long Variant::value(bool *ok) const;
+template unsigned long long Variant::value(bool *ok) const;
+template double Variant::value(bool *ok) const;
+template String Variant::value(bool *ok) const;
+template StringList Variant::value(bool *ok) const;
+template ByteVector Variant::value(bool *ok) const;
+template ByteVectorList Variant::value(bool *ok) const;
+template VariantList Variant::value(bool *ok) const;
+template VariantMap Variant::value(bool *ok) const;
+
+bool Variant::toBool(bool *ok) const
+{
+  return value<bool>(ok);
+}
+
+int Variant::toInt(bool *ok) const
+{
+  return value<int>(ok);
+}
+
+unsigned int Variant::toUInt(bool *ok) const
+{
+  return value<unsigned int>(ok);
+}
+
+long long Variant::toLongLong(bool *ok) const
+{
+  return value<long long>(ok);
+}
+
+unsigned long long Variant::toULongLong(bool *ok) const
+{
+  return value<unsigned long long>(ok);
+}
+
+double Variant::toDouble(bool *ok) const
+{
+  return value<double>(ok);
+}
+
+TagLib::String Variant::toString(bool *ok) const
+{
+  return value<TagLib::String>(ok);
+}
+
+TagLib::StringList Variant::toStringList(bool *ok) const
+{
+  return value<TagLib::StringList>(ok);
+}
+
+TagLib::ByteVector Variant::toByteVector(bool *ok) const
+{
+  return value<TagLib::ByteVector>(ok);
+}
+
+TagLib::ByteVectorList Variant::toByteVectorList(bool *ok) const
+{
+  return value<TagLib::ByteVectorList>(ok);
+}
+
+TagLib::List<TagLib::Variant> Variant::toList(bool *ok) const
+{
+  return value<TagLib::List<TagLib::Variant>>(ok);
+}
+
+TagLib::Map<TagLib::String, TagLib::Variant> Variant::toMap(bool *ok) const
+{
+  return value<TagLib::Map<TagLib::String, TagLib::Variant>>(ok);
+}
+
+bool Variant::operator==(const Variant &v) const
+{
+  return (d == v.d || d->data == v.d->data);
+}
+
+bool Variant::operator!=(const Variant &v) const
+{
+  return !(*this == v);
+}
+
+Variant &Variant::operator=(const Variant &) = default;
+
+////////////////////////////////////////////////////////////////////////////////
+// related non-member functions
+////////////////////////////////////////////////////////////////////////////////
+
+std::ostream &operator<<(std::ostream &s, const TagLib::Variant &v)
+{
+  std::visit(OStreamVisitor(s), v.d->data);
+  return s;
+}

--- a/taglib/toolkit/tvariant.h
+++ b/taglib/toolkit/tvariant.h
@@ -1,0 +1,202 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_VARIANT_H
+#define TAGLIB_VARIANT_H
+
+#include <memory.h>
+#include <iostream>
+
+#include "tlist.h"
+#include "tmap.h"
+#include "taglib_export.h"
+
+// Forward declaration needed for friend function
+namespace TagLib { class Variant; }
+
+/*!
+ * \relates TagLib::Variant
+ *
+ * Send the variant to an output stream.
+ */
+TAGLIB_EXPORT std::ostream &operator<<(std::ostream &s, const TagLib::Variant &v);
+
+namespace TagLib {
+
+  class String;
+  class StringList;
+  class ByteVector;
+  class ByteVectorList;
+
+  /*!
+   * This is an implicitly shared discriminated union.
+   *
+   * The use of implicit sharing means that copying a variant is cheap.
+   * These Variant objects are immutable (have only const methods).
+   */
+  class TAGLIB_EXPORT Variant
+  {
+  public:
+    /*!
+     * Types which can be stored in a variant.
+     */
+    // The number and order of these types must correspond to the template
+    // parameters for StdVariantType in tvariant.cpp!
+    enum Type {
+      Void,
+      Bool,
+      Int,
+      UInt,
+      LongLong,
+      ULongLong,
+      Double,
+      String,
+      StringList,
+      ByteVector,
+      ByteVectorList,
+      VariantList,
+      VariantMap
+    };
+
+    /*!
+     * Constructs an empty Variant.
+     */
+    Variant();
+
+    /*!
+     * Constructs a Variant from an integer value.
+     */
+    Variant(int val);
+
+    Variant(unsigned int val);
+    Variant(long long val);
+    Variant(unsigned long long val);
+    Variant(bool val);
+    Variant(double val);
+    Variant(const char *val);
+    Variant(const TagLib::String &val);
+    Variant(const TagLib::StringList &val);
+    Variant(const TagLib::ByteVector &val);
+    Variant(const TagLib::ByteVectorList &val);
+    Variant(const TagLib::List<TagLib::Variant> &val);
+    Variant(const TagLib::Map<TagLib::String, TagLib::Variant> &val);
+
+    /*!
+     * Make a shallow, implicitly shared, copy of \a v.  Because this is
+     * implicitly shared, this method is lightweight and suitable for
+     * pass-by-value usage.
+     */
+    Variant(const Variant &v);
+
+    /*!
+     * Destroys this Variant instance.
+     */
+    ~Variant();
+
+    /*!
+     * Get the type which is currently stored in this Variant.
+     */
+    Type type() const;
+
+    /*!
+     * Returns true if the Variant is empty.
+     */
+    bool isEmpty() const;
+
+    /*!
+     * Extracts an integer value from the Variant.
+     * If \a ok is passed, its boolean variable will be set to true if the
+     * Variant contains the correct type, and the returned value is the value
+     * of the Variant.  Otherwise, the \a ok variable is set to false and
+     * a dummy default value is returned.
+     */
+    int toInt(bool *ok = nullptr) const;
+
+    unsigned int toUInt(bool *ok = nullptr) const;
+    long long toLongLong(bool *ok = nullptr) const;
+    unsigned long long toULongLong(bool *ok = nullptr) const;
+    bool toBool(bool *ok = nullptr) const;
+    double toDouble(bool *ok = nullptr) const;
+    TagLib::String toString(bool *ok = nullptr) const;
+    TagLib::StringList toStringList(bool *ok = nullptr) const;
+    TagLib::ByteVector toByteVector(bool *ok = nullptr) const;
+    TagLib::ByteVectorList toByteVectorList(bool *ok = nullptr) const;
+    TagLib::List<TagLib::Variant> toList(bool *ok = nullptr) const;
+    TagLib::Map<TagLib::String, TagLib::Variant> toMap(bool *ok = nullptr) const;
+
+    /*!
+     * Extracts value of type \a T from the Variant.
+     * If \a ok is passed, its boolean variable will be set to true if the
+     * Variant contains the correct type, and the returned value is the value
+     * of the Variant.  Otherwise, the \a ok variable is set to false and
+     * a dummy default value is returned.
+     */
+    template<typename T>
+    T value(bool *ok = nullptr) const;
+
+    /*!
+     * Returns true it the Variant and \a v are of the same type and contain the
+     * same value.
+     */
+    bool operator==(const Variant &v) const;
+
+    /*!
+     * Returns true it the Variant and \a v  differ in type or value.
+     */
+    bool operator!=(const Variant &v) const;
+
+    /*!
+     * Performs a shallow, implicitly shared, copy of \a v, overwriting the
+     * Variant's current data.
+     */
+    Variant &operator=(const Variant &v);
+
+  private:
+    friend std::ostream& ::operator<<(std::ostream &s, const TagLib::Variant &v);
+    class VariantPrivate;
+    std::shared_ptr<VariantPrivate> d;
+  };
+
+  /*! A list of Variant elements. */
+  using VariantList = TagLib::List<TagLib::Variant>;
+
+  /*! A map with String keys and Variant values. */
+  using VariantMap = TagLib::Map<TagLib::String, TagLib::Variant>;
+
+  extern template TAGLIB_EXPORT bool Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT int Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT unsigned int Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT long long Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT unsigned long long Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT double Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT String Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT StringList Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT ByteVector Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT ByteVectorList Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT VariantList Variant::value(bool *ok) const;
+  extern template TAGLIB_EXPORT VariantMap Variant::value(bool *ok) const;
+}  // namespace TagLib
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ SET(test_runner_SRCS
   test_string.cpp
   test_propertymap.cpp
   test_variant.cpp
+  test_complexproperties.cpp
   test_file.cpp
   test_fileref.cpp
   test_id3v1.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ SET(test_runner_SRCS
   test_bytevectorstream.cpp
   test_string.cpp
   test_propertymap.cpp
+  test_variant.cpp
   test_file.cpp
   test_fileref.cpp
   test_id3v1.cpp

--- a/tests/test_complexproperties.cpp
+++ b/tests/test_complexproperties.cpp
@@ -1,0 +1,417 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "asfpicture.h"
+#include "flacpicture.h"
+#include "flacfile.h"
+#include "tbytevector.h"
+#include "tvariant.h"
+#include "tzlib.h"
+#include "fileref.h"
+#include "apetag.h"
+#include "asftag.h"
+#include "mp4tag.h"
+#include "xiphcomment.h"
+#include "id3v1tag.h"
+#include "id3v2tag.h"
+#include "attachedpictureframe.h"
+#include "generalencapsulatedobjectframe.h"
+#include <cppunit/extensions/HelperMacros.h>
+#include "utils.h"
+
+using namespace TagLib;
+
+namespace {
+
+const String GEOB_KEY("GENERALOBJECT");
+const String PICTURE_KEY("PICTURE");
+
+const VariantMap TEST_PICTURE {
+  {"data", ByteVector(
+    "\xff\xd8\xff\xe0\x00\x10\x4a\x46\x49\x46\x00\x01\x01\x01\x00\x48\x00\x48"
+    "\x00\x00\xff\xdb\x00\x43\x00\x03\x02\x02\x02\x02\x02\x03\x02\x02\x02\x03"
+    "\x03\x03\x03\x04\x06\x04\x04\x04\x04\x04\x08\x06\x06\x05\x06\x09\x08\x0a"
+    "\x0a\x09\x08\x09\x09\x0a\x0c\x0f\x0c\x0a\x0b\x0e\x0b\x09\x09\x0d\x11\x0d"
+    "\x0e\x0f\x10\x10\x11\x10\x0a\x0c\x12\x13\x12\x10\x13\x0f\x10\x10\x10\xff"
+    "\xc9\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11\x00\xff\xcc\x00\x06\x00\x10"
+    "\x10\x05\xff\xda\x00\x08\x01\x01\x00\x00\x3f\x00\xd2\xcf\x20\xff\xd9",
+    125)},
+  {"mimeType", "image/jpeg"},
+  {"description", "Embedded cover"},
+  {"pictureType", "Front Cover"}
+};
+
+}  // namespace
+
+class TestComplexProperties : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestComplexProperties);
+  CPPUNIT_TEST(testReadMp3Picture);
+  CPPUNIT_TEST(testReadM4aPicture);
+  CPPUNIT_TEST(testReadOggPicture);
+  CPPUNIT_TEST(testReadWriteFlacPicture);
+  CPPUNIT_TEST(testReadWriteMultipleProperties);
+  CPPUNIT_TEST(testSetGetId3Geob);
+  CPPUNIT_TEST(testSetGetId3Picture);
+  CPPUNIT_TEST(testSetGetApePicture);
+  CPPUNIT_TEST(testSetGetAsfPicture);
+  CPPUNIT_TEST(testSetGetMp4Picture);
+  CPPUNIT_TEST(testSetGetXiphPicture);
+  CPPUNIT_TEST(testNonExistent);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void testReadMp3Picture()
+  {
+    if(zlib::isAvailable()) {
+      FileRef f(TEST_FILE_PATH_C("compressed_id3_frame.mp3"), false);
+      CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY),
+        f.file()->complexPropertyKeys());
+      auto pictures = f.file()->complexProperties(PICTURE_KEY);
+      CPPUNIT_ASSERT_EQUAL(1U, pictures.size());
+      auto picture = pictures.front();
+      CPPUNIT_ASSERT_EQUAL(86414U,
+        picture.value("data").value<ByteVector>().size());
+      CPPUNIT_ASSERT_EQUAL(String(""),
+        picture.value("description").value<String>());
+      CPPUNIT_ASSERT_EQUAL(String("image/bmp"),
+        picture.value("mimeType").value<String>());
+      CPPUNIT_ASSERT_EQUAL(String("Other"),
+        picture.value("pictureType").value<String>());
+    }
+  }
+
+  void testReadM4aPicture()
+  {
+    const ByteVector expectedData1(
+      "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a\x00\x00\x00\x0d\x49\x48\x44\x52\x00\x00"
+      "\x00\x02\x00\x00\x00\x02\x08\x02\x00\x00\x00\xfd\xd4\x9a\x73\x00\x00\x00"
+      "\x16\x49\x44\x41\x54\x78\x9c\x63\x7c\x9f\xca\xc0\xc0\xc0\xc0\xc4\xc0\xc0"
+      "\xc0\xc0\xc0\x00\x00\x11\x09\x01\x58\xab\x88\xdb\x6f\x00\x00\x00\x00\x49"
+      "\x45\x4e\x44\xae\x42\x60\x82", 79);
+    const ByteVector expectedData2(
+      "\xff\xd8\xff\xe0\x00\x10\x4a\x46\x49\x46\x00\x01\x01\x01\x00\x64\x00\x64"
+      "\x00\x00\xff\xdb\x00\x43\x00\x09\x06\x07\x08\x07\x06\x09\x08\x08\x08\x0a"
+      "\x0a\x09\x0b\x0e\x17\x0f\x0e\x0d\x0d\x0e\x1c\x14\x15\x11\x17\x22\x1e\x23"
+      "\x23\x21\x1e\x20\x20\x25\x2a\x35\x2d\x25\x27\x32\x28\x20\x20\x2e\x3f\x2f"
+      "\x32\x37\x39\x3c\x3c\x3c\x24\x2d\x42\x46\x41\x3a\x46\x35\x3b\x3c\x39\xff"
+      "\xdb\x00\x43\x01\x0a\x0a\x0a\x0e\x0c\x0e\x1b\x0f\x0f\x1b\x39\x26\x20\x26"
+      "\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39"
+      "\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39"
+      "\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\x39\xff\xc0\x00\x11"
+      "\x08\x00\x02\x00\x02\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01\xff\xc4\x00"
+      "\x15\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      "\x00\x07\xff\xc4\x00\x14\x10\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      "\x00\x00\x00\x00\x00\x00\xff\xc4\x00\x15\x01\x01\x01\x00\x00\x00\x00\x00"
+      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x06\xff\xc4\x00\x14\x11\x01\x00"
+      "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xda\x00"
+      "\x0c\x03\x01\x00\x02\x11\x03\x11\x00\x3f\x00\x8d\x80\xb8\x19\xff\xd9", 287);
+
+    FileRef f(TEST_FILE_PATH_C("has-tags.m4a"), false);
+    CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY),
+      f.file()->complexPropertyKeys());
+    auto pictures = f.file()->complexProperties(PICTURE_KEY);
+    CPPUNIT_ASSERT_EQUAL(2U, pictures.size());
+    auto picture = pictures.front();
+    CPPUNIT_ASSERT_EQUAL(expectedData1,
+      picture.value("data").value<ByteVector>());
+    CPPUNIT_ASSERT_EQUAL(String("image/png"),
+      picture.value("mimeType").value<String>());
+    picture = pictures.back();
+    CPPUNIT_ASSERT_EQUAL(expectedData2,
+      picture.value("data").value<ByteVector>());
+    CPPUNIT_ASSERT_EQUAL(String("image/jpeg"),
+      picture.value("mimeType").value<String>());
+  }
+
+  void testReadOggPicture()
+  {
+    FileRef f(TEST_FILE_PATH_C("lowercase-fields.ogg"), false);
+    CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY),
+      f.file()->complexPropertyKeys());
+    auto pictures = f.file()->complexProperties(PICTURE_KEY);
+    CPPUNIT_ASSERT_EQUAL(1U, pictures.size());
+    auto picture = pictures.front();
+    CPPUNIT_ASSERT_EQUAL(ByteVector("JPEG data"),
+      picture.value("data").value<ByteVector>());
+    CPPUNIT_ASSERT_EQUAL(String("image/jpeg"),
+      picture.value("mimeType").value<String>());
+    CPPUNIT_ASSERT_EQUAL(String("Back Cover"),
+      picture.value("pictureType").value<String>());
+    CPPUNIT_ASSERT_EQUAL(String("new image"),
+      picture.value("description").value<String>());
+    CPPUNIT_ASSERT_EQUAL(16, picture.value("colorDepth").value<int>());
+    CPPUNIT_ASSERT_EQUAL(7, picture.value("numColors").value<int>());
+    CPPUNIT_ASSERT_EQUAL(5, picture.value("width").value<int>());
+    CPPUNIT_ASSERT_EQUAL(6, picture.value("height").value<int>());
+  }
+
+  void testReadWriteFlacPicture()
+  {
+    VariantMap picture(TEST_PICTURE);
+    picture.insert("colorDepth", 8);
+    picture.insert("numColors", 1);
+    picture.insert("width", 1);
+    picture.insert("height", 1);
+
+    ScopedFileCopy copy("no-tags", ".flac");
+
+    {
+      FLAC::File f(copy.fileName().c_str(), false);
+      CPPUNIT_ASSERT(f.complexPropertyKeys().isEmpty());
+      CPPUNIT_ASSERT(f.pictureList().isEmpty());
+      CPPUNIT_ASSERT(f.setComplexProperties(PICTURE_KEY, {picture}));
+      f.save();
+    }
+    {
+      FLAC::File f(copy.fileName().c_str(), false);
+      CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY), f.complexPropertyKeys());
+      CPPUNIT_ASSERT_EQUAL(picture, f.complexProperties(PICTURE_KEY).front());
+      auto flacPictures = f.pictureList();
+      CPPUNIT_ASSERT_EQUAL(1U, flacPictures.size());
+      auto flacPicture = flacPictures.front();
+      CPPUNIT_ASSERT_EQUAL(picture.value("data").value<ByteVector>(),
+        flacPicture->data());
+      CPPUNIT_ASSERT_EQUAL(picture.value("mimeType").value<String>(),
+        flacPicture->mimeType());
+      CPPUNIT_ASSERT_EQUAL(FLAC::Picture::FrontCover, flacPicture->type());
+      CPPUNIT_ASSERT_EQUAL(picture.value("description").value<String>(),
+        flacPicture->description());
+      CPPUNIT_ASSERT_EQUAL(picture.value("colorDepth").value<int>(),
+        flacPicture->colorDepth());
+      CPPUNIT_ASSERT_EQUAL(picture.value("numColors").value<int>(),
+        flacPicture->numColors());
+      CPPUNIT_ASSERT_EQUAL(picture.value("width").value<int>(),
+        flacPicture->width());
+      CPPUNIT_ASSERT_EQUAL(picture.value("height").value<int>(),
+        flacPicture->height());
+
+      CPPUNIT_ASSERT(f.setComplexProperties(PICTURE_KEY, {}));
+      f.save();
+    }
+    {
+      FLAC::File f(copy.fileName().c_str(), false);
+      CPPUNIT_ASSERT(f.complexPropertyKeys().isEmpty());
+      CPPUNIT_ASSERT(f.pictureList().isEmpty());
+    }
+  }
+
+  void testReadWriteMultipleProperties()
+  {
+    const VariantMap picture2 {
+      {"data", ByteVector("PNG data")},
+      {"mimeType", "image/png"},
+      {"description", ""},
+      {"pictureType", "Back Cover"}
+    };
+    const VariantMap geob1 {
+      {"data", ByteVector("First")},
+      {"mimeType", "text/plain"},
+      {"description", "Object 1"},
+      {"fileName", "test1.txt"}
+    };
+    const VariantMap geob2 {
+      {"data", ByteVector("Second")},
+      {"mimeType", "text/plain"},
+      {"description", "Object 2"},
+      {"fileName", "test2.txt"}
+    };
+
+    ScopedFileCopy copy("xing", ".mp3");
+
+    {
+      FileRef f(copy.fileName().c_str(), false);
+      CPPUNIT_ASSERT(f.file()->complexPropertyKeys().isEmpty());
+      f.file()->setComplexProperties(PICTURE_KEY, {TEST_PICTURE, picture2});
+      f.file()->setComplexProperties(GEOB_KEY, {geob1, geob2});
+      f.file()->save();
+    }
+    {
+      FileRef f(copy.fileName().c_str(), false);
+      CPPUNIT_ASSERT_EQUAL(StringList({PICTURE_KEY, GEOB_KEY}),
+        f.file()->complexPropertyKeys());
+      CPPUNIT_ASSERT(List<VariantMap>({TEST_PICTURE, picture2}) ==
+        f.file()->complexProperties(PICTURE_KEY));
+      CPPUNIT_ASSERT(List<VariantMap>({geob1, geob2}) ==
+        f.file()->complexProperties(GEOB_KEY));
+    }
+  }
+
+  void testSetGetId3Geob()
+  {
+    const VariantMap geob {
+      {"data", ByteVector("Just a test")},
+      {"mimeType", "text/plain"},
+      {"description", "Embedded object"},
+      {"fileName", "test.txt"}
+    };
+    ID3v2::Tag tag;
+    CPPUNIT_ASSERT(!tag.frameListMap().contains("GEOB"));
+    CPPUNIT_ASSERT(tag.complexPropertyKeys().isEmpty());
+    CPPUNIT_ASSERT(tag.complexProperties(GEOB_KEY).isEmpty());
+    CPPUNIT_ASSERT(tag.setComplexProperties(GEOB_KEY, {geob}));
+    CPPUNIT_ASSERT_EQUAL(StringList(GEOB_KEY), tag.complexPropertyKeys());
+    CPPUNIT_ASSERT_EQUAL(geob, tag.complexProperties(GEOB_KEY).front());
+    auto frames = tag.frameListMap().value("GEOB");
+    CPPUNIT_ASSERT_EQUAL(1U, frames.size());
+    auto frame =
+      dynamic_cast<ID3v2::GeneralEncapsulatedObjectFrame *>(frames.front());
+    CPPUNIT_ASSERT(frame);
+    CPPUNIT_ASSERT_EQUAL(geob.value("data").value<ByteVector>(), frame->object());
+    CPPUNIT_ASSERT_EQUAL(geob.value("mimeType").value<String>(), frame->mimeType());
+    CPPUNIT_ASSERT_EQUAL(geob.value("description").value<String>(), frame->description());
+    CPPUNIT_ASSERT_EQUAL(geob.value("fileName").value<String>(), frame->fileName());
+  }
+
+  void tagSetGetPicture(Tag &tag, const VariantMap &picture)
+  {
+    CPPUNIT_ASSERT(tag.complexPropertyKeys().isEmpty());
+    CPPUNIT_ASSERT(tag.complexProperties(PICTURE_KEY).isEmpty());
+    CPPUNIT_ASSERT(tag.setComplexProperties(PICTURE_KEY, {picture}));
+    CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY), tag.complexPropertyKeys());
+    CPPUNIT_ASSERT_EQUAL(picture, tag.complexProperties(PICTURE_KEY).front());
+  }
+
+  void testSetGetId3Picture()
+  {
+    const VariantMap picture(TEST_PICTURE);
+    ID3v2::Tag tag;
+    CPPUNIT_ASSERT(!tag.frameListMap().contains("APIC"));
+    tagSetGetPicture(tag, picture);
+    auto frames = tag.frameListMap().value("APIC");
+    CPPUNIT_ASSERT_EQUAL(1U, frames.size());
+    auto frame =
+      dynamic_cast<ID3v2::AttachedPictureFrame *>(frames.front());
+    CPPUNIT_ASSERT(frame);
+    CPPUNIT_ASSERT_EQUAL(picture.value("data").value<ByteVector>(), frame->picture());
+    CPPUNIT_ASSERT_EQUAL(picture.value("mimeType").value<String>(), frame->mimeType());
+    CPPUNIT_ASSERT_EQUAL(picture.value("description").value<String>(), frame->description());
+    CPPUNIT_ASSERT_EQUAL(ID3v2::AttachedPictureFrame::FrontCover, frame->type());
+  }
+
+  void testSetGetApePicture()
+  {
+    const String FRONT_COVER("COVER ART (FRONT)");
+    VariantMap picture(TEST_PICTURE);
+    picture.erase("mimeType");
+    APE::Tag tag;
+    CPPUNIT_ASSERT(!tag.itemListMap().contains(FRONT_COVER));
+    tagSetGetPicture(tag, picture);
+    auto item = tag.itemListMap().value(FRONT_COVER);
+    CPPUNIT_ASSERT_EQUAL(
+      picture.value("description").value<String>().data(String::UTF8)
+      .append('\0')
+      .append(picture.value("data").value<ByteVector>()),
+      item.binaryData());
+  }
+
+  void testSetGetAsfPicture()
+  {
+    VariantMap picture(TEST_PICTURE);
+    ASF::Tag tag;
+    CPPUNIT_ASSERT(!tag.attributeListMap().contains("WM/Picture"));
+    tagSetGetPicture(tag, picture);
+    auto attributes = tag.attribute("WM/Picture");
+    CPPUNIT_ASSERT_EQUAL(1U, attributes.size());
+    auto asfPicture = attributes.front().toPicture();
+    CPPUNIT_ASSERT_EQUAL(picture.value("data").value<ByteVector>(),
+      asfPicture.picture());
+    CPPUNIT_ASSERT_EQUAL(picture.value("mimeType").value<String>(),
+      asfPicture.mimeType());
+    CPPUNIT_ASSERT_EQUAL(picture.value("description").value<String>(),
+      asfPicture.description());
+    CPPUNIT_ASSERT_EQUAL(ASF::Picture::FrontCover, asfPicture.type());
+  }
+
+  void testSetGetMp4Picture()
+  {
+    VariantMap picture(TEST_PICTURE);
+    picture.erase("description");
+    picture.erase("pictureType");
+    MP4::Tag tag;
+    CPPUNIT_ASSERT(!tag.itemMap().contains("covr"));
+    tagSetGetPicture(tag, picture);
+    auto covrs = tag.item("covr").toCoverArtList();
+    CPPUNIT_ASSERT_EQUAL(1U, covrs.size());
+    auto covr = covrs.front();
+    CPPUNIT_ASSERT_EQUAL(picture.value("data").value<ByteVector>(),
+      covr.data());
+    CPPUNIT_ASSERT_EQUAL(MP4::CoverArt::JPEG, covr.format());
+  }
+
+  void testSetGetXiphPicture()
+  {
+    VariantMap picture(TEST_PICTURE);
+    picture.insert("colorDepth", 8);
+    picture.insert("numColors", 1);
+    picture.insert("width", 1);
+    picture.insert("height", 1);
+    Ogg::XiphComment tag;
+    CPPUNIT_ASSERT(tag.pictureList().isEmpty());
+    tagSetGetPicture(tag, picture);
+    auto pics = tag.pictureList();
+    CPPUNIT_ASSERT_EQUAL(1U, pics.size());
+    auto pic = pics.front();
+    CPPUNIT_ASSERT_EQUAL(picture.value("data").value<ByteVector>(),
+      pic->data());
+    CPPUNIT_ASSERT_EQUAL(picture.value("mimeType").value<String>(),
+      pic->mimeType());
+    CPPUNIT_ASSERT_EQUAL(picture.value("description").value<String>(),
+      pic->description());
+    CPPUNIT_ASSERT_EQUAL(FLAC::Picture::FrontCover, pic->type());
+    CPPUNIT_ASSERT_EQUAL(8, pic->colorDepth());
+    CPPUNIT_ASSERT_EQUAL(1, pic->numColors());
+    CPPUNIT_ASSERT_EQUAL(1, pic->width());
+    CPPUNIT_ASSERT_EQUAL(1, pic->height());
+  }
+
+  void testNonExistent()
+  {
+    {
+      ID3v2::Tag tag;
+      CPPUNIT_ASSERT(tag.complexPropertyKeys().isEmpty());
+      CPPUNIT_ASSERT(tag.complexProperties(PICTURE_KEY).isEmpty());
+      CPPUNIT_ASSERT(tag.complexProperties(GEOB_KEY).isEmpty());
+      CPPUNIT_ASSERT(tag.complexProperties("NONEXISTENT").isEmpty());
+      CPPUNIT_ASSERT(!tag.setComplexProperties("NONEXISTENT", {{{"description", "test"}}}));
+      CPPUNIT_ASSERT(tag.complexProperties("NONEXISTENT").isEmpty());
+      CPPUNIT_ASSERT(tag.setComplexProperties(PICTURE_KEY, {TEST_PICTURE}));
+      CPPUNIT_ASSERT(!tag.complexProperties(PICTURE_KEY).isEmpty());
+    }
+    {
+      ID3v1::Tag tag;
+      CPPUNIT_ASSERT(tag.complexPropertyKeys().isEmpty());
+      CPPUNIT_ASSERT(tag.complexProperties(PICTURE_KEY).isEmpty());
+      CPPUNIT_ASSERT(tag.complexProperties(GEOB_KEY).isEmpty());
+      CPPUNIT_ASSERT(tag.complexProperties("NONEXISTENT").isEmpty());
+      CPPUNIT_ASSERT(!tag.setComplexProperties("NONEXISTENT", {{{"description", "test"}}}));
+      CPPUNIT_ASSERT(tag.complexProperties("NONEXISTENT").isEmpty());
+      CPPUNIT_ASSERT(!tag.setComplexProperties(PICTURE_KEY, {TEST_PICTURE}));
+      CPPUNIT_ASSERT(tag.complexProperties(PICTURE_KEY).isEmpty());
+    }
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestComplexProperties);

--- a/tests/test_variant.cpp
+++ b/tests/test_variant.cpp
@@ -1,0 +1,204 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include <array>
+#include "tbytevector.h"
+#include "tvariant.h"
+#include "tstringlist.h"
+#include "tbytevectorlist.h"
+#include <cppunit/extensions/HelperMacros.h>
+#include <sstream>
+#include "utils.h"
+
+using namespace TagLib;
+
+class TestVariant : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestVariant);
+  CPPUNIT_TEST(testVariantTypes);
+  CPPUNIT_TEST(testVariantToOStream);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void testVariantTypes()
+  {
+    ByteVectorList bvl {"first", "second"};
+    StringList sl {"el0", "el"};
+    VariantList vl {"1st", "2nd"};
+    VariantMap vm {{"key1", "value1"}, {"key2", "value2"}};
+
+    Variant varVoid;
+    Variant varBool(true);
+    Variant varInt(-4);
+    Variant varUInt(5U);
+    Variant varLongLong(-6LL);
+    Variant varULongLong(7ULL);
+    Variant varDouble(1.23);
+    Variant varString(String("test"));
+    Variant varString2("charp");
+    Variant varStringList(sl);
+    Variant varByteVector(ByteVector("data"));
+    Variant varByteVectorList(bvl);
+    Variant varVariantList(vl);
+    Variant varVariantMap(vm);
+
+    static const std::array<std::tuple<Variant, Variant::Type>, 14> varTypes {
+      std::tuple{varVoid, Variant::Void},
+      std::tuple{varBool, Variant::Bool},
+      std::tuple{varInt, Variant::Int},
+      std::tuple{varUInt, Variant::UInt},
+      std::tuple{varLongLong, Variant::LongLong},
+      std::tuple{varULongLong, Variant::ULongLong},
+      std::tuple{varDouble, Variant::Double},
+      std::tuple{varString, Variant::String},
+      std::tuple{varString2, Variant::String},
+      std::tuple{varStringList, Variant::StringList},
+      std::tuple{varByteVector, Variant::ByteVector},
+      std::tuple{varByteVectorList, Variant::ByteVectorList},
+      std::tuple{varVariantList, Variant::VariantList},
+      std::tuple{varVariantMap, Variant::VariantMap}
+    };
+
+    for(const auto &t : varTypes) {
+      CPPUNIT_ASSERT_EQUAL(std::get<1>(t), std::get<0>(t).type());
+      if(std::get<0>(t).type() == Variant::Void) {
+        CPPUNIT_ASSERT(std::get<0>(t).isEmpty());
+      }
+      else {
+        CPPUNIT_ASSERT(!std::get<0>(t).isEmpty());
+      }
+    }
+
+    bool ok;
+    CPPUNIT_ASSERT_EQUAL(true, varBool.toBool(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(true, varBool.value<bool>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(-4, varInt.toInt(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(-4, varInt.value<int>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(5U, varUInt.toUInt(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(5U, varUInt.value<unsigned int>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(-6LL, varLongLong.toLongLong(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(-6LL, varLongLong.value<long long>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(7ULL, varULongLong.toULongLong(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(7ULL, varULongLong.value<unsigned long long>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(1.23, varDouble.toDouble(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(1.23, varDouble.value<double>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(String("test"), varString.toString(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(String("test"), varString.value<String>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(String("charp"), varString2.toString(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(String("charp"), varString2.value<String>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(sl, varStringList.toStringList(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(sl, varStringList.value<StringList>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("data"), varByteVector.toByteVector(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(ByteVector("data"), varByteVector.value<ByteVector>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(bvl, varByteVectorList.toByteVectorList(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(bvl, varByteVectorList.value<ByteVectorList>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(vl, varVariantList.toList(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(vl, varVariantList.value<VariantList>(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(vm, varVariantMap.toMap(&ok));
+    CPPUNIT_ASSERT(ok);
+    CPPUNIT_ASSERT_EQUAL(vm, varVariantMap.value<VariantMap>(&ok));
+    CPPUNIT_ASSERT(ok);
+
+    CPPUNIT_ASSERT_EQUAL(0, varBool.toInt(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(0U, varInt.toUInt(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(0LL, varUInt.toLongLong(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(0ULL, varLongLong.toULongLong(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(0.0, varULongLong.toDouble(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(String(), varDouble.toString(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(StringList(), varString.toStringList(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(ByteVector(), varStringList.toByteVector(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT(varByteVector.toByteVectorList(&ok).isEmpty());
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(VariantList(), varByteVectorList.toList(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(VariantMap(), varVariantList.toMap(&ok));
+    CPPUNIT_ASSERT(!ok);
+    CPPUNIT_ASSERT_EQUAL(false, varVariantMap.toBool(&ok));
+    CPPUNIT_ASSERT(!ok);
+
+    CPPUNIT_ASSERT(varUInt == varUInt);
+    CPPUNIT_ASSERT(varUInt == Variant(5U));
+    CPPUNIT_ASSERT(varUInt != Variant(6U));
+    CPPUNIT_ASSERT(varUInt != Variant(5));
+    CPPUNIT_ASSERT(varUInt != varInt);
+
+    Variant varUInt2(varUInt);
+    CPPUNIT_ASSERT(varUInt == varUInt2);
+    varUInt2 = 6U;
+    CPPUNIT_ASSERT(varUInt != varUInt2);
+    CPPUNIT_ASSERT_EQUAL(5U, varUInt.toUInt());
+    CPPUNIT_ASSERT_EQUAL(6U, varUInt2.toUInt());
+  }
+
+  void testVariantToOStream()
+  {
+    std::stringstream ss;
+    VariantMap vm {
+      {"strlist", StringList {"first", "second"}},
+      {"varlist", VariantList {Variant(), 1U, -10LL, 4.32, false}},
+      {"data", ByteVector("\xa9\x01\x7f", 3)}
+    };
+    ss << vm;
+
+    CPPUNIT_ASSERT_EQUAL(
+      R"({"data": "\xa9\x01\x7f", "strlist": ["first", "second"],)"
+      R"( "varlist": [null, 1, -10, 4.32, false]})"s,
+    ss.str());
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestVariant);


### PR DESCRIPTION
Provides a dynamic interface for properties which cannot be represented with simple strings, e.g. pictures. The keys of such properties can be queried using `complexPropertyKeys()`, which could return for example ["PICTURE"]. The property can then be read using `complexProperties("PICTURE")`, which will return a list of variant maps containing the picture data and attributes. Adding a picture is as easy as

    t->setComplexProperties("PICTURE", {
      {
        {"data", data},
        {"pictureType", "Front Cover"},
        {"mimeType", "image/jpeg"}
      }
    });

Complex properties are flexible enough for most frames. At the moment they are implemented for pictures in APE, ASF, MP4, ID3v2, Vorbis and FLAC. For ID3v2, GEOB frames are supported too. Embedded pictures can be tested using the _tagreader_ and _tagwriter_ examples.

Related issues and pull requests are #94, #397, #666, #773, #951, #952, #953. When this PR is merged, it should be easy to implement a replacement for #956.
