### PR TITLE
Add ByteVector Conversion Functions, Tests

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -292,7 +292,17 @@ ByteVector ByteVector::fromShort(short value, bool mostSignificantByteFirst)
   return fromNumber<unsigned short>(value, mostSignificantByteFirst);
 }
 
+ByteVector ByteVector::fromUShort(unsigned short value, bool mostSignificantByteFirst)
+{
+  return fromNumber<unsigned short>(value, mostSignificantByteFirst);
+}
+
 ByteVector ByteVector::fromLongLong(long long value, bool mostSignificantByteFirst)
+{
+  return fromNumber<unsigned long long>(value, mostSignificantByteFirst);
+}
+
+ByteVector ByteVector::fromULongLong(unsigned long long value, bool mostSignificantByteFirst)
 {
   return fromNumber<unsigned long long>(value, mostSignificantByteFirst);
 }
@@ -689,6 +699,16 @@ long long ByteVector::toLongLong(bool mostSignificantByteFirst) const
 }
 
 long long ByteVector::toLongLong(unsigned int offset, bool mostSignificantByteFirst) const
+{
+  return toNumber<unsigned long long>(*this, offset, mostSignificantByteFirst);
+}
+
+unsigned long long ByteVector::toULongLong(bool mostSignificantByteFirst) const
+{
+  return toNumber<unsigned long long>(*this, 0, mostSignificantByteFirst);
+}
+
+unsigned long long ByteVector::toULongLong(unsigned int offset, bool mostSignificantByteFirst) const
 {
   return toNumber<unsigned long long>(*this, offset, mostSignificantByteFirst);
 }

--- a/taglib/toolkit/tbytevector.h
+++ b/taglib/toolkit/tbytevector.h
@@ -349,24 +349,24 @@ namespace TagLib {
     short toShort(unsigned int offset, bool mostSignificantByteFirst = true) const;
 
     /*!
-     * Converts the first 2 bytes of the vector to a unsigned short.
+     * Converts the first 2 bytes of the vector to an unsigned short.
      *
      * If \a mostSignificantByteFirst is true this will operate left to right
      * evaluating the integer.  For example if \a mostSignificantByteFirst is
      * true then $00 $01 == 0x0001 == 1, if false, $01 00 == 0x01000000 == 1.
      *
-     * \see fromShort()
+     * \see fromUShort()
      */
     unsigned short toUShort(bool mostSignificantByteFirst = true) const;
 
     /*!
-     * Converts the 2 bytes at \a offset of the vector to a unsigned short.
+     * Converts the 2 bytes at \a offset of the vector to an unsigned short.
      *
      * If \a mostSignificantByteFirst is true this will operate left to right
      * evaluating the integer.  For example if \a mostSignificantByteFirst is
      * true then $00 $01 == 0x0001 == 1, if false, $01 00 == 0x01000000 == 1.
      *
-     * \see fromShort()
+     * \see fromUShort()
      */
     unsigned short toUShort(unsigned int offset, bool mostSignificantByteFirst = true) const;
 
@@ -378,7 +378,7 @@ namespace TagLib {
      * true then $00 00 00 00 00 00 00 01 == 0x0000000000000001 == 1,
      * if false, $01 00 00 00 00 00 00 00 == 0x0100000000000000 == 1.
      *
-     * \see fromUInt()
+     * \see fromLongLong()
      */
     long long toLongLong(bool mostSignificantByteFirst = true) const;
 
@@ -390,9 +390,33 @@ namespace TagLib {
      * true then $00 00 00 00 00 00 00 01 == 0x0000000000000001 == 1,
      * if false, $01 00 00 00 00 00 00 00 == 0x0100000000000000 == 1.
      *
-     * \see fromUInt()
+     * \see fromLongLong()
      */
     long long toLongLong(unsigned int offset, bool mostSignificantByteFirst = true) const;
+
+    /*!
+     * Converts the first 8 bytes of the vector to an unsigned long long.
+     *
+     * If \a mostSignificantByteFirst is true this will operate left to right
+     * evaluating the integer.  For example if \a mostSignificantByteFirst is
+     * true then $00 00 00 00 00 00 00 01 == 0x0000000000000001 == 1,
+     * if false, $01 00 00 00 00 00 00 00 == 0x0100000000000000 == 1.
+     *
+     * \see fromULongLong()
+     */
+    unsigned long long toULongLong(bool mostSignificantByteFirst = true) const;
+
+    /*!
+     * Converts the 8 bytes at \a offset of the vector to an unsigned long long.
+     *
+     * If \a mostSignificantByteFirst is true this will operate left to right
+     * evaluating the integer.  For example if \a mostSignificantByteFirst is
+     * true then $00 00 00 00 00 00 00 01 == 0x0000000000000001 == 1,
+     * if false, $01 00 00 00 00 00 00 00 == 0x0100000000000000 == 1.
+     *
+     * \see fromULongLong()
+     */
+    unsigned long long toULongLong(unsigned int offset, bool mostSignificantByteFirst = true) const;
 
     /*
      * Converts the 4 bytes at \a offset of the vector to a float as an IEEE754
@@ -456,6 +480,16 @@ namespace TagLib {
     static ByteVector fromShort(short value, bool mostSignificantByteFirst = true);
 
     /*!
+     * Creates a 2 byte ByteVector based on \a value.  If
+     * \a mostSignificantByteFirst is true, then this will operate left to right
+     * in building the ByteVector.  For example if \a mostSignificantByteFirst is
+     * true then $00 01 == 0x0001 == 1, if false, $01 00 == 0x0100 == 1.
+     *
+     * \see toUShort()
+     */
+    static ByteVector fromUShort(unsigned short value, bool mostSignificantByteFirst = true);
+
+    /*!
      * Creates a 8 byte ByteVector based on \a value.  If
      * \a mostSignificantByteFirst is true, then this will operate left to right
      * in building the ByteVector.  For example if \a mostSignificantByteFirst is
@@ -465,6 +499,17 @@ namespace TagLib {
      * \see toLongLong()
      */
     static ByteVector fromLongLong(long long value, bool mostSignificantByteFirst = true);
+
+    /*!
+     * Creates a 8 byte ByteVector based on \a value.  If
+     * \a mostSignificantByteFirst is true, then this will operate left to right
+     * in building the ByteVector.  For example if \a mostSignificantByteFirst is
+     * true then $00 00 00 01 == 0x0000000000000001 == 1, if false,
+     * $01 00 00 00 00 00 00 00 == 0x0100000000000000 == 1.
+     *
+     * \see toULongLong()
+     */
+    static ByteVector fromULongLong(unsigned long long value, bool mostSignificantByteFirst = true);
 
     /*!
      * Creates a 4 byte ByteVector based on \a value as an IEEE754 32-bit

--- a/tests/test_bytevector.cpp
+++ b/tests/test_bytevector.cpp
@@ -189,6 +189,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(static_cast<short>(0x01ff), data.toShort(5U, false));
     CPPUNIT_ASSERT_EQUAL(static_cast<short>(0xff), data.toShort(13U));
     CPPUNIT_ASSERT_EQUAL(static_cast<short>(0xff), data.toShort(13U, false));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromShort(0x00ff), ByteVector("\x00\xff", 2));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromShort(0x00ff, false), ByteVector("\xff\x00", 2));
 
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned short>(0x00ff), data.toUShort());
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned short>(0xff00), data.toUShort(false));
@@ -196,6 +198,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned short>(0x01ff), data.toUShort(5U, false));
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned short>(0xff), data.toUShort(13U));
     CPPUNIT_ASSERT_EQUAL(static_cast<unsigned short>(0xff), data.toUShort(13U, false));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromUShort(0xff00), ByteVector("\xff\x00", 2));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromUShort(0xff00, false), ByteVector("\x00\xff", 2));
 
     CPPUNIT_ASSERT_EQUAL(0x00ff01ffU, data.toUInt());
     CPPUNIT_ASSERT_EQUAL(0xff01ff00U, data.toUInt(false));
@@ -210,6 +214,8 @@ public:
     CPPUNIT_ASSERT_EQUAL(0xff01ffU, data.toUInt(5U, 3U, false));
     CPPUNIT_ASSERT_EQUAL(0x00ffU, data.toUInt(12U, 3U));
     CPPUNIT_ASSERT_EQUAL(0xff00U, data.toUInt(12U, 3U, false));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromUInt(0xff00ff00), ByteVector("\xff\x00\xff\x00", 4));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromUInt(0xff00ff00, false), ByteVector("\x00\xff\x00\xff", 4));
 
     CPPUNIT_ASSERT_EQUAL(static_cast<long long>(0x00ff01ff00ff01ffULL), data.toLongLong());
     CPPUNIT_ASSERT_EQUAL(static_cast<long long>(0xff01ff00ff01ff00ULL), data.toLongLong(false));
@@ -217,7 +223,20 @@ public:
     CPPUNIT_ASSERT_EQUAL(static_cast<long long>(0x00ff01ff00ff01ffULL), data.toLongLong(5U, false));
     CPPUNIT_ASSERT_EQUAL(static_cast<long long>(0x00ffU), data.toLongLong(12U));
     CPPUNIT_ASSERT_EQUAL(static_cast<long long>(0xff00U), data.toLongLong(12U, false));
-}
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromLongLong(0x00ff01ff00ff01ff), ByteVector("\x00\xff\x01\xff\x00\xff\x01\xff", 8));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromLongLong(0x00ff01ff00ff01ff, false), ByteVector("\xff\x01\xff\x00\xff\x01\xff\x00", 8));
+
+    const ByteVector data2("\xff\x01\xff\x00\xff\x01\xff\x00\xff\x01\xff\x00\xff\x01", 14);
+    CPPUNIT_ASSERT_EQUAL(0xff01ff00ff01ff00ULL, data2.toULongLong());
+    CPPUNIT_ASSERT_EQUAL(0x00ff01ff00ff01ffULL, data2.toULongLong(false));
+    CPPUNIT_ASSERT_EQUAL(0x01ff00ff01ff00ffULL, data2.toULongLong(5U));
+    CPPUNIT_ASSERT_EQUAL(0xff00ff01ff00ff01ULL, data2.toULongLong(5U, false));
+    CPPUNIT_ASSERT_EQUAL(0xff01ULL, data2.toULongLong(12U));
+    CPPUNIT_ASSERT_EQUAL(0x01ffULL, data2.toULongLong(12U, false));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromULongLong(0xff01ff00ff01ff00ULL), ByteVector("\xff\x01\xff\x00\xff\x01\xff\x00", 8));
+    CPPUNIT_ASSERT_EQUAL(ByteVector::fromULongLong(0xff01ff00ff01ff00ULL, false), ByteVector("\x00\xff\x01\xff\x00\xff\x01\xff", 8));
+  }
+
 
   void testFloatingPointConversion()
   {


### PR DESCRIPTION
I'm currently working on #1149. In Matroska, some elements have a UID which is implemented as a 64 bit unsigned integer. `ByteVector` currently does not have conversions for `ULongLong`, only `LongLong`. Casting an unsigned integer type to a signed integer type is implementation-defined if the value is higher than the max value of the signed type, so I would like to have a `ULongLong` function available to avoid the cast.

While looking at the code, I made some other improvements as well. Here is a summary of the changes:
- Added `ByteVector::toULongLong`, `ByteVector::fromULongLong`, and tests for both
- Added `ByteVector::fromUShort`, and tests
- Added tests for all existing integer-based `ByteVector::from*` functions. Currently, there are no tests for these functions
- Fixed a function reference in the documentation for `ByteVector::toLongLong` (I presume this was a copy/paste error)
