### PR TITLE
C bindings for complex properties like pictures (#953)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,9 @@ jobs:
     - name: Test Windows
       working-directory: ${{github.workspace}}/build
       run: |
-        $env:Path += ";$env:VCPKG_INSTALLATION_ROOT\packages\cppunit_x64-windows\bin;$PWD\taglib\Release"
-        $env:Path += ";$env:VCPKG_INSTALLATION_ROOT\packages\utfcpp_x64-windows\bin;$PWD\taglib\Release"
-        $env:Path += ";$env:VCPKG_INSTALLATION_ROOT\packages\zlib_x64-windows\bin;$PWD\taglib\Release"
+        $env:Path += ";$PWD\taglib\Release;$PWD\bindings\c\Release"
+        $env:Path += ";$env:VCPKG_INSTALLATION_ROOT\packages\cppunit_x64-windows\bin"
+        $env:Path += ";$env:VCPKG_INSTALLATION_ROOT\packages\utfcpp_x64-windows\bin"
+        $env:Path += ";$env:VCPKG_INSTALLATION_ROOT\packages\zlib_x64-windows\bin"
         ctest -C ${{env.BUILD_TYPE}} -V --no-tests=error
       if: matrix.os == 'windows-latest'

--- a/bindings/c/tag_c.cpp
+++ b/bindings/c/tag_c.cpp
@@ -23,11 +23,14 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <sstream>
 #include <utility>
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"
 #endif
+#include "tstringlist.h"
+#include "tbytevectorlist.h"
 #include "tfile.h"
 #include "tpropertymap.h"
 #include "fileref.h"
@@ -412,7 +415,320 @@ void taglib_property_free(char **props)
 
   char **p = props;
   while(*p) {
-      free(*p++);
+    free(*p++);
+  }
+  free(props);
+}
+
+
+/******************************************************************************
+ * Complex Properties API
+ ******************************************************************************/
+
+namespace {
+
+bool _taglib_complex_property_set(
+  TagLib_File *file, const char *key,
+  const TagLib_Complex_Property_Attribute **value, bool append)
+{
+  if(file == NULL || key == NULL)
+    return false;
+
+  auto tfile = reinterpret_cast<File *>(file);
+
+  if(value == NULL) {
+    return tfile->setComplexProperties(key, {});
+  }
+
+  VariantMap map;
+  const TagLib_Complex_Property_Attribute** attrPtr = value;
+  while(*attrPtr) {
+    const TagLib_Complex_Property_Attribute *attr = *attrPtr;
+    String attrKey(attr->key);
+    TagLib_Variant_Type type = attr->value.type;
+    switch(type) {
+    case TagLib_Variant_Void:
+      map.insert(attrKey, Variant());
+      break;
+    case TagLib_Variant_Bool:
+      map.insert(attrKey, attr->value.value.boolValue != 0);
+      break;
+    case TagLib_Variant_Int:
+      map.insert(attrKey, attr->value.value.intValue);
+      break;
+    case TagLib_Variant_UInt:
+      map.insert(attrKey, attr->value.value.uIntValue);
+      break;
+    case TagLib_Variant_LongLong:
+      map.insert(attrKey, attr->value.value.longLongValue);
+      break;
+    case TagLib_Variant_ULongLong:
+      map.insert(attrKey, attr->value.value.uLongLongValue);
+      break;
+    case TagLib_Variant_Double:
+      map.insert(attrKey, attr->value.value.doubleValue);
+      break;
+    case TagLib_Variant_String:
+      map.insert(attrKey, attr->value.value.stringValue);
+      break;
+    case TagLib_Variant_StringList: {
+      StringList strs;
+      if(attr->value.value.stringListValue) {
+        char **s = attr->value.value.stringListValue;;
+        while(*s) {
+          strs.append(*s++);
+        }
+      }
+      map.insert(attrKey, strs);
+      break;
+    }
+    case TagLib_Variant_ByteVector:
+      map.insert(attrKey, ByteVector(attr->value.value.byteVectorValue,
+                                     attr->value.size));
+      break;
+    }
+    ++attrPtr;
+  }
+
+  return append ? tfile->setComplexProperties(key, tfile->complexProperties(key).append(map))
+                : tfile->setComplexProperties(key, {map});
+}
+
+}  // namespace
+
+BOOL taglib_complex_property_set(
+  TagLib_File *file, const char *key,
+  const TagLib_Complex_Property_Attribute **value)
+{
+  return _taglib_complex_property_set(file, key, value, false);
+}
+
+BOOL taglib_complex_property_set_append(
+  TagLib_File *file, const char *key,
+  const TagLib_Complex_Property_Attribute **value)
+{
+  return _taglib_complex_property_set(file, key, value, true);
+}
+
+char** taglib_complex_property_keys(TagLib_File *file)
+{
+  if(file == NULL) {
+    return NULL;
+  }
+
+  const StringList strs = reinterpret_cast<const File *>(file)->complexPropertyKeys();
+  if(strs.isEmpty()) {
+    return NULL;
+  }
+
+  auto keys = static_cast<char **>(malloc(sizeof(char *) * (strs.size() + 1)));
+  char **keyPtr = keys;
+
+  for(const auto &str : strs) {
+    *keyPtr++ = stringToCharArray(str);
+  }
+  *keyPtr = NULL;
+
+  return keys;
+}
+
+TagLib_Complex_Property_Attribute*** taglib_complex_property_get(
+  TagLib_File *file, const char *key)
+{
+  if(file == NULL || key == NULL) {
+    return NULL;
+  }
+
+  const auto variantMaps = reinterpret_cast<const File *>(file)->complexProperties(key);
+  if(variantMaps.isEmpty()) {
+    return NULL;
+  }
+
+  TagLib_Complex_Property_Attribute ***props = static_cast<TagLib_Complex_Property_Attribute ***>(
+    malloc(sizeof(TagLib_Complex_Property_Attribute **) * (variantMaps.size() + 1)));
+  TagLib_Complex_Property_Attribute ***propPtr = props;
+
+  for(const auto &variantMap : variantMaps) {
+    TagLib_Complex_Property_Attribute **attrs = static_cast<TagLib_Complex_Property_Attribute **>(
+      malloc(sizeof(TagLib_Complex_Property_Attribute *) * (variantMap.size() + 1)));
+    TagLib_Complex_Property_Attribute *attr = static_cast<TagLib_Complex_Property_Attribute *>(
+      malloc(sizeof(TagLib_Complex_Property_Attribute) * variantMap.size()));
+    TagLib_Complex_Property_Attribute **attrPtr = attrs;
+    for (const auto &[k, v] : variantMap) {
+      attr->key = stringToCharArray(k);
+      attr->value.size = 0;
+      switch(v.type()) {
+      case Variant::Void:
+        attr->value.type = TagLib_Variant_Void;
+        attr->value.value.stringValue = NULL;
+        break;
+      case Variant::Bool:
+        attr->value.type = TagLib_Variant_Bool;
+        attr->value.value.boolValue = v.value<bool>();
+        break;
+      case Variant::Int:
+        attr->value.type = TagLib_Variant_Int;
+        attr->value.value.intValue = v.value<int>();
+        break;
+      case Variant::UInt:
+        attr->value.type = TagLib_Variant_UInt;
+        attr->value.value.uIntValue = v.value<unsigned int>();
+        break;
+      case Variant::LongLong:
+        attr->value.type = TagLib_Variant_LongLong;
+        attr->value.value.longLongValue = v.value<long long>();
+        break;
+      case Variant::ULongLong:
+        attr->value.type = TagLib_Variant_ULongLong;
+        attr->value.value.uLongLongValue = v.value<unsigned long long>();
+        break;
+      case Variant::Double:
+        attr->value.type = TagLib_Variant_Double;
+        attr->value.value.doubleValue = v.value<double>();
+        break;
+      case Variant::String: {
+        attr->value.type = TagLib_Variant_String;
+        auto str = v.value<String>();
+        attr->value.value.stringValue = stringToCharArray(str);
+        attr->value.size = str.size();
+        break;
+      }
+      case Variant::StringList: {
+        attr->value.type = TagLib_Variant_StringList;
+        StringList strs = v.value<StringList>();
+        auto strPtr = static_cast<char **>(malloc(sizeof(char *) * (strs.size() + 1)));
+        attr->value.value.stringListValue = strPtr;
+        attr->value.size = strs.size();
+        for(const auto &str : strs) {
+          *strPtr++ = stringToCharArray(str);
+        }
+        *strPtr = NULL;
+        break;
+      }
+      case Variant::ByteVector: {
+        attr->value.type = TagLib_Variant_ByteVector;
+        const ByteVector data = v.value<ByteVector>();
+        auto bytePtr = static_cast<char *>(malloc(data.size()));
+        attr->value.value.byteVectorValue = bytePtr;
+        attr->value.size = data.size();
+        ::memcpy(bytePtr, data.data(), data.size());
+        break;
+      }
+      case Variant::ByteVectorList:
+      case Variant::VariantList:
+      case Variant::VariantMap: {
+        attr->value.type = TagLib_Variant_String;
+        std::stringstream ss;
+        ss << v;
+        attr->value.value.stringValue = stringToCharArray(ss.str());
+        break;
+      }
+      }
+      *attrPtr++ = attr++;
+    }
+    *attrPtr++ = NULL;
+    *propPtr++ = attrs;
+  }
+  *propPtr = NULL;
+  return props;
+}
+
+void taglib_picture_from_complex_property(
+  TagLib_Complex_Property_Attribute*** properties,
+  TagLib_Complex_Property_Picture_Data *picture)
+{
+  if(!properties || !picture) {
+    return;
+  }
+  std::memset(picture, 0, sizeof(*picture));
+  TagLib_Complex_Property_Attribute*** propPtr = properties;
+  while(!picture->data && *propPtr) {
+    TagLib_Complex_Property_Attribute** attrPtr = *propPtr;
+    while(*attrPtr) {
+      TagLib_Complex_Property_Attribute *attr = *attrPtr;
+      TagLib_Variant_Type type = attr->value.type;
+      switch(type) {
+      case TagLib_Variant_String:
+        if(strcmp("mimeType", attr->key) == 0) {
+          picture->mimeType = attr->value.value.stringValue;
+        }
+        else if(strcmp("description", attr->key) == 0) {
+          picture->description = attr->value.value.stringValue;
+        }
+        else if(strcmp("pictureType", attr->key) == 0) {
+          picture->pictureType = attr->value.value.stringValue;
+        }
+        break;
+      case TagLib_Variant_ByteVector:
+        if(strcmp("data", attr->key) == 0) {
+          picture->data = attr->value.value.byteVectorValue;
+          picture->size = attr->value.size;
+        }
+        break;
+      default:
+        break;
+      }
+      ++attrPtr;
+    }
+    ++propPtr;
+  }
+}
+
+void taglib_complex_property_free_keys(char **keys)
+{
+  if(keys == NULL) {
+    return;
+  }
+
+  char **k = keys;
+  while(*k) {
+    free(*k++);
+  }
+  free(keys);
+}
+
+void taglib_complex_property_free(
+  TagLib_Complex_Property_Attribute ***props)
+{
+  if(props == NULL) {
+    return;
+  }
+  TagLib_Complex_Property_Attribute*** propPtr = props;
+  while(*propPtr) {
+    TagLib_Complex_Property_Attribute** attrPtr = *propPtr;
+    while(*attrPtr) {
+      TagLib_Complex_Property_Attribute *attr = *attrPtr;
+      TagLib_Variant_Type type = attr->value.type;
+      switch(type) {
+      case TagLib_Variant_String:
+        free(attr->value.value.stringValue);
+        break;
+      case TagLib_Variant_StringList:
+        if(attr->value.value.stringListValue) {
+          char **s = attr->value.value.stringListValue;
+          while(*s) {
+            free(*s++);
+          }
+          free(attr->value.value.stringListValue);
+        }
+        break;
+      case TagLib_Variant_ByteVector:
+        free(attr->value.value.byteVectorValue);
+        break;
+      case TagLib_Variant_Void:
+      case TagLib_Variant_Bool:
+      case TagLib_Variant_Int:
+      case TagLib_Variant_UInt:
+      case TagLib_Variant_LongLong:
+      case TagLib_Variant_ULongLong:
+      case TagLib_Variant_Double:
+        break;
+      }
+      free(attr->key);
+      ++attrPtr;
+    }
+    free(**propPtr);
+    free(*propPtr++);
   }
   free(props);
 }

--- a/bindings/c/tag_c.h
+++ b/bindings/c/tag_c.h
@@ -43,7 +43,10 @@ extern "C" {
 #define TAGLIB_C_EXPORT
 #endif
 
-#ifndef BOOL
+#ifdef _MSC_VER
+/* minwindef.h contains typedef int BOOL */
+#include <windows.h>
+#elif !defined BOOL
 #define BOOL int
 #endif
 

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -389,6 +389,11 @@ const FileRef::FileTypeResolver *FileRef::addFileTypeResolver(const FileRef::Fil
   return resolver;
 }
 
+void FileRef::clearFileTypeResolvers() // static
+{
+  fileTypeResolvers.clear();
+}
+
 StringList FileRef::defaultFileExtensions()
 {
   StringList l;

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -248,6 +248,11 @@ namespace TagLib {
     static const FileTypeResolver *addFileTypeResolver(const FileTypeResolver *resolver);
 
     /*!
+     * Remove all resolvers added by addFileTypeResolver().
+     */
+    static void clearFileTypeResolvers();
+
+    /*!
      * As is mentioned elsewhere in this class's documentation, the default file
      * type resolution code provided by TagLib only works by comparing file
      * extensions.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/toolkit
+  ${CMAKE_CURRENT_SOURCE_DIR}/../bindings/c
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/ape
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/asf
   ${CMAKE_CURRENT_SOURCE_DIR}/../taglib/mpeg/id3v1
@@ -72,12 +73,13 @@ SET(test_runner_SRCS
   test_dsf.cpp
   test_sizes.cpp
   test_versionnumber.cpp
+  test_tag_c.cpp
 )
 
 INCLUDE_DIRECTORIES(${CPPUNIT_INCLUDE_DIR})
 
 ADD_EXECUTABLE(test_runner ${test_runner_SRCS})
-TARGET_LINK_LIBRARIES(test_runner tag ${CPPUNIT_LIBRARIES})
+TARGET_LINK_LIBRARIES(test_runner tag tag_c ${CPPUNIT_LIBRARIES})
 
 ADD_TEST(test_runner test_runner)
 ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND} -V

--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -419,6 +419,8 @@ public:
       FileRef f(&s);
       CPPUNIT_ASSERT(dynamic_cast<MP4::File *>(f.file()) != nullptr);
     }
+
+    FileRef::clearFileTypeResolvers();
   }
 
 };

--- a/tests/test_tag_c.cpp
+++ b/tests/test_tag_c.cpp
@@ -1,0 +1,148 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include <string>
+#include <unordered_map>
+#include <list>
+
+#include "tag_c.h"
+#include "tbytevector.h"
+#include "tstring.h"
+#include <cppunit/extensions/HelperMacros.h>
+#include "utils.h"
+
+using namespace TagLib;
+
+class TestTagC : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestTagC);
+  CPPUNIT_TEST(testMp3);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void testMp3()
+  {
+    ScopedFileCopy copy("xing", ".mp3");
+
+    {
+      TagLib_File *file = taglib_file_new(copy.fileName().c_str());
+      CPPUNIT_ASSERT(taglib_file_is_valid(file));
+      const TagLib_AudioProperties *audioProperties = taglib_file_audioproperties(file);
+      CPPUNIT_ASSERT_EQUAL(32, taglib_audioproperties_bitrate(audioProperties));
+      CPPUNIT_ASSERT_EQUAL(2, taglib_audioproperties_channels(audioProperties));
+      CPPUNIT_ASSERT_EQUAL(2, taglib_audioproperties_length(audioProperties));
+      CPPUNIT_ASSERT_EQUAL(44100, taglib_audioproperties_samplerate(audioProperties));
+
+      TagLib_Tag *tag = taglib_file_tag(file);
+      CPPUNIT_ASSERT_EQUAL(""s, std::string(taglib_tag_album(tag)));
+      taglib_tag_set_album(tag, "Album");
+      taglib_tag_set_artist(tag, "Artist");
+      taglib_tag_set_comment(tag, "Comment");
+      taglib_tag_set_genre(tag, "Genre");
+      taglib_tag_set_title(tag, "Title");
+      taglib_tag_set_track(tag, 2);
+      taglib_tag_set_year(tag, 2023);
+
+      taglib_property_set(file, "COMPOSER", "Composer 1");
+      taglib_property_set_append(file, "COMPOSER", "Composer 2");
+      taglib_property_set(file, "ALBUMARTIST", "Album Artist");
+
+      TAGLIB_COMPLEX_PROPERTY_PICTURE(props, "JPEG Data", 9, "Written by TagLib",
+                                      "image/jpeg", "Front Cover");
+      taglib_complex_property_set(file, "PICTURE", props);
+
+      taglib_file_save(file);
+      taglib_file_free(file);
+    }
+    {
+      TagLib_File *file = taglib_file_new(copy.fileName().c_str());
+      CPPUNIT_ASSERT(taglib_file_is_valid(file));
+
+      TagLib_Tag *tag = taglib_file_tag(file);
+      CPPUNIT_ASSERT_EQUAL("Album"s, std::string(taglib_tag_album(tag)));
+      CPPUNIT_ASSERT_EQUAL("Artist"s, std::string(taglib_tag_artist(tag)));
+      CPPUNIT_ASSERT_EQUAL("Comment"s, std::string(taglib_tag_comment(tag)));
+      CPPUNIT_ASSERT_EQUAL("Genre"s, std::string(taglib_tag_genre(tag)));
+      CPPUNIT_ASSERT_EQUAL("Title"s, std::string(taglib_tag_title(tag)));
+      CPPUNIT_ASSERT_EQUAL(2U, taglib_tag_track(tag));
+      CPPUNIT_ASSERT_EQUAL(2023U, taglib_tag_year(tag));
+
+      char **keys = taglib_property_keys(file);
+      CPPUNIT_ASSERT(keys);
+      std::unordered_map<std::string, std::list<std::string>> propertyMap;
+      char **keyPtr = keys;
+      while(*keyPtr) {
+        char **values = taglib_property_get(file, *keyPtr);
+        char **valuePtr = values;
+        std::list<std::string> valueList;
+        while(*valuePtr) {
+          valueList.push_back(*valuePtr++);
+        }
+        taglib_property_free(values);
+        propertyMap[*keyPtr++] = valueList;
+      }
+      taglib_property_free(keys);
+      const std::unordered_map<std::string, std::list<std::string>> expected {
+        {"TRACKNUMBER"s, {"2"s}},
+        {"TITLE"s, {"Title"s}},
+        {"GENRE"s, {"Genre"s}},
+        {"DATE"s, {"2023"s}},
+        {"COMPOSER"s, {"Composer 1"s, "Composer 2"s}},
+        {"COMMENT"s, {"Comment"s}},
+        {"ARTIST"s, {"Artist"s}},
+        {"ALBUMARTIST"s, {"Album Artist"s}},
+        {"ALBUM"s, {"Album"s}}
+      };
+      CPPUNIT_ASSERT(expected == propertyMap);
+
+      char **complexKeys = taglib_complex_property_keys(file);
+      CPPUNIT_ASSERT(complexKeys);
+      std::list<std::string> keyList;
+      char **complexKeyPtr = complexKeys;
+      while(*complexKeyPtr) {
+        keyList.push_back(*complexKeyPtr++);
+      }
+      taglib_complex_property_free_keys(complexKeys);
+      CPPUNIT_ASSERT(std::list{"PICTURE"s} == keyList);
+
+      TagLib_Complex_Property_Attribute*** properties =
+        taglib_complex_property_get(file, "PICTURE");
+      TagLib_Complex_Property_Picture_Data picture;
+      taglib_picture_from_complex_property(properties, &picture);
+      CPPUNIT_ASSERT_EQUAL("image/jpeg"s, std::string(picture.mimeType));
+      CPPUNIT_ASSERT_EQUAL("Written by TagLib"s, std::string(picture.description));
+      CPPUNIT_ASSERT_EQUAL("Front Cover"s, std::string(picture.pictureType));
+      CPPUNIT_ASSERT_EQUAL(ByteVector("JPEG Data"), ByteVector(picture.data, 9));
+      CPPUNIT_ASSERT_EQUAL(9U, picture.size);
+      taglib_complex_property_free(properties);
+
+      taglib_file_free(file);
+    }
+
+    taglib_tag_free_strings();
+  }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestTagC);


### PR DESCRIPTION
Provides a unified API for complex properties in the same way as the Properties API in the C bindings. Since constructing and traversing complex properties in C is a bit complicated, there are convenience functions for the most common use case of getting or setting a single picture.

    TAGLIB_COMPLEX_PROPERTY_PICTURE(props, data, size, "Written by TagLib",
                                    "image/jpeg", "Front Cover");
    taglib_complex_property_set(file, "PICTURE", props);

and

    TagLib_Complex_Property_Attribute*** properties =
      taglib_complex_property_get(file, "PICTURE");
    TagLib_Complex_Property_Picture_Data picture;
    taglib_picture_from_complex_property(properties, &picture);
