### PR TITLE
List: Add Sort Functions

### DIFF
--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -277,7 +277,7 @@ namespace TagLib {
     bool operator!=(const List<T> &l) const;
 
     /*!
-     * Sorts this list in ascending order using operator< of T
+     * Sorts this list in ascending order using operator< of T.
      */
     void sort();
 

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -276,6 +276,19 @@ namespace TagLib {
      */
     bool operator!=(const List<T> &l) const;
 
+    /*!
+     * Sorts this list in ascending order using operator< of T
+     */
+    void sort();
+
+    /*!
+     * Sorts this list in ascending order using using the comparison
+     * function object \a comp which returns true if the first argument is
+     * less than the second.
+     */
+    template<class Compare>
+    void sort(Compare&& comp);
+
   protected:
     /*
      * If this List is being shared via implicit sharing, do a deep copy of the

--- a/taglib/toolkit/tlist.h
+++ b/taglib/toolkit/tlist.h
@@ -282,7 +282,7 @@ namespace TagLib {
     void sort();
 
     /*!
-     * Sorts this list in ascending order using using the comparison
+     * Sorts this list in ascending order using the comparison
      * function object \a comp which returns true if the first argument is
      * less than the second.
      */

--- a/taglib/toolkit/tlist.tcc
+++ b/taglib/toolkit/tlist.tcc
@@ -330,6 +330,21 @@ bool List<T>::operator!=(const List<T> &l) const
   return d->list != l.d->list;
 }
 
+template <class T>
+void List<T>::sort()
+{
+  detach();
+  d->list.sort();
+}
+
+template <class T>
+template <class Compare>
+void List<T>::sort(Compare&& comp)
+{
+  detach();
+  d->list.sort(std::forward<Compare>(comp));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // protected members
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/test_list.cpp
+++ b/tests/test_list.cpp
@@ -35,6 +35,7 @@ class TestList : public CppUnit::TestFixture
   CPPUNIT_TEST(testAppend);
   CPPUNIT_TEST(testDetach);
   CPPUNIT_TEST(bracedInit);
+  CPPUNIT_TEST(testSort);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -120,6 +121,29 @@ public:
     CPPUNIT_ASSERT_EQUAL(4, *l4[0]);
     CPPUNIT_ASSERT_EQUAL(5, *l4[1]);
     CPPUNIT_ASSERT_EQUAL(6, *l4[2]);
+  }
+
+  void testSort()
+  {
+    List<int> list1 {
+      3,
+      2,
+      1
+    };
+    list1.sort();
+    CPPUNIT_ASSERT_EQUAL(list1[0], 1);
+    CPPUNIT_ASSERT_EQUAL(list1[1], 2);
+    CPPUNIT_ASSERT_EQUAL(list1[2], 3);
+
+    List<int> list2 {
+      1,
+      2,
+      3
+    };
+    list2.sort([](const auto &a, const auto &b) { return a > b; });
+    CPPUNIT_ASSERT_EQUAL(list2[0], 3);
+    CPPUNIT_ASSERT_EQUAL(list2[1], 2);
+    CPPUNIT_ASSERT_EQUAL(list2[2], 1);
   }
 
 };


### PR DESCRIPTION
I would like to be able to sort the objects contained in a `List`. We cannot use `std::sort()` on `List` because the iterators do not support random access. The underlying STL class `std::list` does have a sort function, however. This PR adds sort functions to `List` based on `std::list::sort()`. See the [Cppreference page](https://en.cppreference.com/w/cpp/container/list/sort) for more information.

The basic function without arguments will sort the `List` in ascending order. The class contained in `List` needs to support the `<` operator.

Additionally, there is an overload which takes a function object `Comp`. You can use this to provide custom sorting logic to the function. For example, a lambda based on some attribute of a class that can be accessed through a getter function:
```C++
list.sort([](const auto a, const auto b){ return a.getter() < b.getter(); }); 
``` 

Tests have been added for the basic sorting function and for the overload.