### PR TITLE
Improve FileRef, C bindings to read file from memory (#987)

### DIFF
--- a/bindings/c/tag_c.cpp
+++ b/bindings/c/tag_c.cpp
@@ -92,67 +92,79 @@ void taglib_free(void* pointer)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// TagLib::File wrapper
+// TagLib::FileRef wrapper
 ////////////////////////////////////////////////////////////////////////////////
 
 TagLib_File *taglib_file_new(const char *filename)
 {
-  return reinterpret_cast<TagLib_File *>(FileRef::create(filename));
+  return reinterpret_cast<TagLib_File *>(new FileRef(filename));
 }
 
 TagLib_File *taglib_file_new_type(const char *filename, TagLib_File_Type type)
 {
+  File *file = NULL;
   switch(type) {
   case TagLib_File_MPEG:
-    return reinterpret_cast<TagLib_File *>(new MPEG::File(filename));
+    file = new MPEG::File(filename);
+      break;
   case TagLib_File_OggVorbis:
-    return reinterpret_cast<TagLib_File *>(new Ogg::Vorbis::File(filename));
+    file = new Ogg::Vorbis::File(filename);
+    break;
   case TagLib_File_FLAC:
-    return reinterpret_cast<TagLib_File *>(new FLAC::File(filename));
+    file = new FLAC::File(filename);
+    break;
   case TagLib_File_MPC:
-    return reinterpret_cast<TagLib_File *>(new MPC::File(filename));
+    file = new MPC::File(filename);
+    break;
   case TagLib_File_OggFlac:
-    return reinterpret_cast<TagLib_File *>(new Ogg::FLAC::File(filename));
+    file = new Ogg::FLAC::File(filename);
+    break;
   case TagLib_File_WavPack:
-    return reinterpret_cast<TagLib_File *>(new WavPack::File(filename));
+    file = new WavPack::File(filename);
+    break;
   case TagLib_File_Speex:
-    return reinterpret_cast<TagLib_File *>(new Ogg::Speex::File(filename));
+    file = new Ogg::Speex::File(filename);
+    break;
   case TagLib_File_TrueAudio:
-    return reinterpret_cast<TagLib_File *>(new TrueAudio::File(filename));
+    file = new TrueAudio::File(filename);
+    break;
   case TagLib_File_MP4:
-    return reinterpret_cast<TagLib_File *>(new MP4::File(filename));
+    file = new MP4::File(filename);
+    break;
   case TagLib_File_ASF:
-    return reinterpret_cast<TagLib_File *>(new ASF::File(filename));
+    file = new ASF::File(filename);
+    break;
   default:
-    return 0;
+    break;
   }
+  return file ? reinterpret_cast<TagLib_File *>(new FileRef(file)) : NULL;
 }
 
 void taglib_file_free(TagLib_File *file)
 {
-  delete reinterpret_cast<File *>(file);
+  delete reinterpret_cast<FileRef *>(file);
 }
 
 BOOL taglib_file_is_valid(const TagLib_File *file)
 {
-  return reinterpret_cast<const File *>(file)->isValid();
+  return !reinterpret_cast<const FileRef *>(file)->isNull();
 }
 
 TagLib_Tag *taglib_file_tag(const TagLib_File *file)
 {
-  auto f = reinterpret_cast<const File *>(file);
+  auto f = reinterpret_cast<const FileRef *>(file);
   return reinterpret_cast<TagLib_Tag *>(f->tag());
 }
 
 const TagLib_AudioProperties *taglib_file_audioproperties(const TagLib_File *file)
 {
-  auto f = reinterpret_cast<const File *>(file);
+  auto f = reinterpret_cast<const FileRef *>(file);
   return reinterpret_cast<const TagLib_AudioProperties *>(f->audioProperties());
 }
 
 BOOL taglib_file_save(TagLib_File *file)
 {
-  return reinterpret_cast<File *>(file)->save();
+  return reinterpret_cast<FileRef *>(file)->save();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -330,7 +342,7 @@ void _taglib_property_set(TagLib_File *file, const char* prop, const char* value
   if(file == NULL || prop == NULL)
     return;
 
-  auto tfile = reinterpret_cast<File *>(file);
+  auto tfile = reinterpret_cast<FileRef *>(file);
   PropertyMap map = tfile->tag()->properties();
 
   if(value) {
@@ -371,7 +383,7 @@ char** taglib_property_keys(TagLib_File *file)
   if(file == NULL)
     return NULL;
 
-  const PropertyMap map = reinterpret_cast<const File *>(file)->properties();
+  const PropertyMap map = reinterpret_cast<const FileRef *>(file)->properties();
   if(map.isEmpty())
     return NULL;
 
@@ -391,7 +403,7 @@ char **taglib_property_get(TagLib_File *file, const char *prop)
   if(file == NULL || prop == NULL)
     return NULL;
 
-  const PropertyMap map = reinterpret_cast<const File *>(file)->properties();
+  const PropertyMap map = reinterpret_cast<const FileRef *>(file)->properties();
 
   auto property = map.find(prop);
   if(property == map.end())
@@ -434,7 +446,7 @@ bool _taglib_complex_property_set(
   if(file == NULL || key == NULL)
     return false;
 
-  auto tfile = reinterpret_cast<File *>(file);
+  auto tfile = reinterpret_cast<FileRef *>(file);
 
   if(value == NULL) {
     return tfile->setComplexProperties(key, {});
@@ -516,7 +528,7 @@ char** taglib_complex_property_keys(TagLib_File *file)
     return NULL;
   }
 
-  const StringList strs = reinterpret_cast<const File *>(file)->complexPropertyKeys();
+  const StringList strs = reinterpret_cast<const FileRef *>(file)->complexPropertyKeys();
   if(strs.isEmpty()) {
     return NULL;
   }
@@ -539,7 +551,7 @@ TagLib_Complex_Property_Attribute*** taglib_complex_property_get(
     return NULL;
   }
 
-  const auto variantMaps = reinterpret_cast<const File *>(file)->complexProperties(key);
+  const auto variantMaps = reinterpret_cast<const FileRef *>(file)->complexProperties(key);
   if(variantMaps.isEmpty()) {
     return NULL;
   }

--- a/bindings/c/tag_c.cpp
+++ b/bindings/c/tag_c.cpp
@@ -31,6 +31,8 @@
 #endif
 #include "tstringlist.h"
 #include "tbytevectorlist.h"
+#include "tbytevectorstream.h"
+#include "tiostream.h"
 #include "tfile.h"
 #include "tpropertymap.h"
 #include "fileref.h"
@@ -92,6 +94,21 @@ void taglib_free(void* pointer)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// TagLib::IOStream wrapper
+////////////////////////////////////////////////////////////////////////////////
+
+TagLib_IOStream *taglib_memory_iostream_new(const char *data, unsigned int size)
+{
+  return reinterpret_cast<TagLib_IOStream *>(
+    new ByteVectorStream(ByteVector(data, size)));
+}
+
+void taglib_iostream_free(TagLib_IOStream *stream)
+{
+  delete reinterpret_cast<IOStream *>(stream);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // TagLib::FileRef wrapper
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -138,6 +155,12 @@ TagLib_File *taglib_file_new_type(const char *filename, TagLib_File_Type type)
     break;
   }
   return file ? reinterpret_cast<TagLib_File *>(new FileRef(file)) : NULL;
+}
+
+TagLib_File *taglib_file_new_iostream(TagLib_IOStream *stream)
+{
+  return reinterpret_cast<TagLib_File *>(
+    new FileRef(reinterpret_cast<IOStream *>(stream)));
 }
 
 void taglib_file_free(TagLib_File *file)

--- a/bindings/c/tag_c.h
+++ b/bindings/c/tag_c.h
@@ -68,6 +68,7 @@ extern "C" {
 typedef struct { int dummy; } TagLib_File;
 typedef struct { int dummy; } TagLib_Tag;
 typedef struct { int dummy; } TagLib_AudioProperties;
+typedef struct { int dummy; } TagLib_IOStream;
 
 /*!
  * By default all strings coming into or out of TagLib's C API are in UTF8.
@@ -88,6 +89,22 @@ TAGLIB_C_EXPORT void taglib_set_string_management_enabled(BOOL management);
  * Explicitly free a string returned from TagLib
  */
 TAGLIB_C_EXPORT void taglib_free(void* pointer);
+
+/*******************************************************************************
+ * Stream API
+ ******************************************************************************/
+
+/*!
+ * Creates a byte vector stream from \a size bytes of \a data.
+ * Such a stream can be used with taglib_file_new_iostream() to create a file
+ * from memory.
+ */
+TAGLIB_C_EXPORT TagLib_IOStream *taglib_memory_iostream_new(const char *data, unsigned int size);
+
+/*!
+ * Frees and closes the stream.
+ */
+TAGLIB_C_EXPORT void taglib_iostream_free(TagLib_IOStream *stream);
 
 /*******************************************************************************
  * File API
@@ -120,6 +137,16 @@ TAGLIB_C_EXPORT TagLib_File *taglib_file_new(const char *filename);
  * the type, it will use the one specified by \a type.
  */
 TAGLIB_C_EXPORT TagLib_File *taglib_file_new_type(const char *filename, TagLib_File_Type type);
+
+/*!
+ * Creates a TagLib file from a \a stream.
+ * A byte vector stream can be used to read a file from memory and write to
+ * memory, e.g. when fetching network data.
+ * The stream has to be created using taglib_memory_iostream_new() and shall be
+ * freed using taglib_iostream_free() \e after this file is freed with
+ * taglib_file_free().
+ */
+TAGLIB_C_EXPORT TagLib_File *taglib_file_new_iostream(TagLib_IOStream *stream);
 
 /*!
  * Frees and closes the file.

--- a/examples/tagreader.cpp
+++ b/examples/tagreader.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
       cout << "track   - \"" << tag->track()   << "\"" << endl;
       cout << "genre   - \"" << tag->genre()   << "\"" << endl;
 
-      TagLib::PropertyMap tags = f.file()->properties();
+      TagLib::PropertyMap tags = f.properties();
 
       unsigned int longest = 0;
       for(auto i = tags.cbegin(); i != tags.cend(); ++i) {
@@ -71,9 +71,9 @@ int main(int argc, char *argv[])
         }
       }
 
-      TagLib::StringList names = f.file()->complexPropertyKeys();
+      TagLib::StringList names = f.complexPropertyKeys();
       for(const auto &name : names) {
-        const auto& properties = f.file()->complexProperties(name);
+        const auto& properties = f.complexProperties(name);
         for(const auto &property : properties) {
           cout << name << ":" << endl;
           for(const auto &[key, value] : property) {

--- a/examples/tagreader.cpp
+++ b/examples/tagreader.cpp
@@ -56,18 +56,19 @@ int main(int argc, char *argv[])
       cout << "genre   - \"" << tag->genre()   << "\"" << endl;
 
       TagLib::PropertyMap tags = f.properties();
-
-      unsigned int longest = 0;
-      for(auto i = tags.cbegin(); i != tags.cend(); ++i) {
-        if (i->first.size() > longest) {
-          longest = i->first.size();
+      if(!tags.isEmpty()) {
+        unsigned int longest = 0;
+        for(auto i = tags.cbegin(); i != tags.cend(); ++i) {
+          if (i->first.size() > longest) {
+            longest = i->first.size();
+          }
         }
-      }
 
-      cout << "-- TAG (properties) --" << endl;
-      for(auto i = tags.cbegin(); i != tags.cend(); ++i) {
-        for(auto j = i->second.begin(); j != i->second.end(); ++j) {
-          cout << left << std::setfill(' ') << std::setw(longest) << i->first << " - " << '"' << *j << '"' << endl;
+        cout << "-- TAG (properties) --" << endl;
+        for(auto i = tags.cbegin(); i != tags.cend(); ++i) {
+          for(auto j = i->second.begin(); j != i->second.end(); ++j) {
+            cout << left << std::setfill(' ') << std::setw(longest) << i->first << " - " << '"' << *j << '"' << endl;
+          }
         }
       }
 
@@ -113,7 +114,7 @@ int main(int argc, char *argv[])
       cout << "bitrate     - " << properties->bitrate() << endl;
       cout << "sample rate - " << properties->sampleRate() << endl;
       cout << "channels    - " << properties->channels() << endl;
-      cout << "length      - " << minutes << ":" << setfill('0') << setw(2) << seconds << endl;
+      cout << "length      - " << minutes << ":" << setfill('0') << setw(2) << right << seconds << endl;
     }
   }
   return 0;

--- a/examples/tagreader_c.c
+++ b/examples/tagreader_c.c
@@ -98,11 +98,11 @@ int main(int argc, char *argv[])
       while(*keyPtr) {
         TagLib_Complex_Property_Attribute*** properties =
           taglib_complex_property_get(file, *keyPtr);
-        printf("%s:\n", *keyPtr);
         if(properties != NULL) {
           TagLib_Complex_Property_Attribute*** propPtr = properties;
           while(*propPtr) {
             TagLib_Complex_Property_Attribute** attrPtr = *propPtr;
+            printf("%s:\n", *keyPtr);
             while(*attrPtr) {
               TagLib_Complex_Property_Attribute *attr = *attrPtr;
               TagLib_Variant_Type type = attr->value.type;
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
                 printf("%f\n", attr->value.value.doubleValue);
                 break;
               case TagLib_Variant_String:
-                printf("%s\n", attr->value.value.stringValue);
+                printf("\"%s\"\n", attr->value.value.stringValue);
                 break;
               case TagLib_Variant_StringList:
                 if(attr->value.value.stringListValue) {

--- a/examples/tagwriter.cpp
+++ b/examples/tagwriter.cpp
@@ -122,10 +122,9 @@ int main(int argc, char *argv[])
       TagLib::String value = argv[i + 1];
       int numArgsConsumed = 2;
 
-      TagLib::List<TagLib::FileRef>::ConstIterator it;
-      for(it = fileList.cbegin(); it != fileList.cend(); ++it) {
+      for(auto &f : fileList) {
 
-        TagLib::Tag *t = (*it).tag();
+        TagLib::Tag *t = f.tag();
 
         switch (field) {
         case 't':
@@ -152,7 +151,7 @@ int main(int argc, char *argv[])
         case 'R':
         case 'I':
           if(i + 2 < argc) {
-            TagLib::PropertyMap map = (*it).file()->properties ();
+            TagLib::PropertyMap map = f.properties();
             if(field == 'R') {
               map.replace(value, TagLib::String(argv[i + 2]));
             }
@@ -160,16 +159,16 @@ int main(int argc, char *argv[])
               map.insert(value, TagLib::String(argv[i + 2]));
             }
             numArgsConsumed = 3;
-            checkForRejectedProperties((*it).file()->setProperties(map));
+            checkForRejectedProperties(f.setProperties(map));
           }
           else {
             usage();
           }
           break;
         case 'D': {
-          TagLib::PropertyMap map = (*it).file()->properties();
+          TagLib::PropertyMap map = f.properties();
           map.erase(value);
-          checkForRejectedProperties((*it).file()->setProperties(map));
+          checkForRejectedProperties(f.setProperties(map));
           break;
         }
         case 'p': {
@@ -190,7 +189,7 @@ int main(int argc, char *argv[])
               TagLib::String mimeType = data.startsWith("\x89PNG\x0d\x0a\x1a\x0a")
                 ? "image/png" : "image/jpeg";
               TagLib::String description(argv[i + 2]);
-              it->file()->setComplexProperties("PICTURE", {
+              f.setComplexProperties("PICTURE", {
                 {
                   {"data", data},
                   {"pictureType", "Front Cover"},
@@ -201,7 +200,7 @@ int main(int argc, char *argv[])
             }
             else {
               // empty value, remove pictures
-              it->file()->setComplexProperties("PICTURE", {});
+              f.setComplexProperties("PICTURE", {});
             }
           }
           else {
@@ -220,9 +219,8 @@ int main(int argc, char *argv[])
       usage();
   }
 
-  TagLib::List<TagLib::FileRef>::ConstIterator it;
-  for(it = fileList.cbegin(); it != fileList.cend(); ++it)
-    (*it).file()->save();
+  for(auto &f : fileList)
+    f.save();
 
   return 0;
 }

--- a/taglib/fileref.cpp
+++ b/taglib/fileref.cpp
@@ -33,6 +33,9 @@
 #include <utility>
 
 #include "tfilestream.h"
+#include "tpropertymap.h"
+#include "tstringlist.h"
+#include "tvariant.h"
 #include "tdebug.h"
 #include "aifffile.h"
 #include "apefile.h"
@@ -322,6 +325,20 @@ public:
   FileRefPrivate(const FileRefPrivate &) = delete;
   FileRefPrivate &operator=(const FileRefPrivate &) = delete;
 
+  bool isNull() const
+  {
+    return !file || !file->isValid();
+  }
+
+  bool isNullWithDebugMessage(const String &methodName) const
+  {
+    if(isNull()) {
+      debug("FileRef::" + methodName + "() - Called without a valid file.");
+      return true;
+    }
+    return false;
+  }
+
   File *file { nullptr };
   IOStream *stream { nullptr };
 };
@@ -360,17 +377,63 @@ FileRef::~FileRef() = default;
 
 Tag *FileRef::tag() const
 {
-  if(isNull()) {
-    debug("FileRef::tag() - Called without a valid file.");
+  if(d->isNullWithDebugMessage(__func__)) {
     return nullptr;
   }
   return d->file->tag();
 }
 
+PropertyMap FileRef::properties() const
+{
+  if(d->isNullWithDebugMessage(__func__)) {
+    return PropertyMap();
+  }
+  return d->file->properties();
+}
+
+void FileRef::removeUnsupportedProperties(const StringList& properties)
+{
+  if(d->isNullWithDebugMessage(__func__)) {
+    return;
+  }
+  return d->file->removeUnsupportedProperties(properties);
+}
+
+PropertyMap FileRef::setProperties(const PropertyMap &properties)
+{
+  if(d->isNullWithDebugMessage(__func__)) {
+    return PropertyMap();
+  }
+  return d->file->setProperties(properties);
+}
+
+StringList FileRef::complexPropertyKeys() const
+{
+  if(d->isNullWithDebugMessage(__func__)) {
+    return StringList();
+  }
+  return d->file->complexPropertyKeys();
+}
+
+List<VariantMap> FileRef::complexProperties(const String &key) const
+{
+  if(d->isNullWithDebugMessage(__func__)) {
+    return List<VariantMap>();
+  }
+  return d->file->complexProperties(key);
+}
+
+bool FileRef::setComplexProperties(const String &key, const List<VariantMap> &value)
+{
+  if(d->isNullWithDebugMessage(__func__)) {
+    return false;
+  }
+  return d->file->setComplexProperties(key, value);
+}
+
 AudioProperties *FileRef::audioProperties() const
 {
-  if(isNull()) {
-    debug("FileRef::audioProperties() - Called without a valid file.");
+  if(d->isNullWithDebugMessage(__func__)) {
     return nullptr;
   }
   return d->file->audioProperties();
@@ -383,8 +446,7 @@ File *FileRef::file() const
 
 bool FileRef::save()
 {
-  if(isNull()) {
-    debug("FileRef::save() - Called without a valid file.");
+  if(d->isNullWithDebugMessage(__func__)) {
     return false;
   }
   return d->file->save();
@@ -445,7 +507,7 @@ StringList FileRef::defaultFileExtensions()
 
 bool FileRef::isNull() const
 {
-  return (!d->file || !d->file->isValid());
+  return d->isNull();
 }
 
 FileRef &FileRef::operator=(const FileRef &) = default;

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -63,7 +63,7 @@ namespace TagLib {
   //! A class for pluggable file type resolution.
 
   /*!
-   * This class is used to add extend TagLib's very basic file name based file
+   * This class is used to extend TagLib's very basic file name based file
    * type resolution.
    *
    * This can be accomplished with:
@@ -104,7 +104,7 @@ namespace TagLib {
       /*!
        * This method must be overridden to provide an additional file type
        * resolver.  If the resolver is able to determine the file type it should
-       * return a valid File object; if not it should return 0.
+       * return a valid File object; if not it should return nullptr.
        *
        * \note The created file is then owned by the FileRef and should not be
        * deleted.  Deletion will happen automatically when the FileRef passes
@@ -373,22 +373,6 @@ namespace TagLib {
      * object.
      */
     bool operator!=(const FileRef &ref) const;
-
-    /*!
-     * A simple implementation of file type guessing.  If \a readAudioProperties
-     * is true then the audio properties will be read using
-     * \a audioPropertiesStyle.  If \a readAudioProperties is false then
-     * \a audioPropertiesStyle will be ignored.
-     *
-     * \note You generally shouldn't use this method, but instead the constructor
-     * directly.
-     *
-     * \deprecated Use FileRef(FileName, bool, AudioProperties::ReadStyle).
-     */
-     // Kept because it is used for the C bindings
-    static File *create(FileName fileName,
-                        bool readAudioProperties = true,
-                        AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
 
   private:
     void parse(FileName fileName, bool readAudioProperties, AudioProperties::ReadStyle audioPropertiesStyle);

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -190,7 +190,7 @@ namespace TagLib {
     /*!
      * Destroys this FileRef instance.
      */
-    virtual ~FileRef();
+    ~FileRef();
 
     /*!
      * Returns a pointer to represented file's tag.
@@ -204,6 +204,84 @@ namespace TagLib {
      * \see File::tag()
      */
     Tag *tag() const;
+
+    /*!
+     * Exports the tags of the file as dictionary mapping (human readable) tag
+     * names (uppercase Strings) to StringLists of tag values. Calls this
+     * method on the wrapped File instance.
+     * For each metadata object of the file that could not be parsed into the PropertyMap
+     * format, the returned map's unsupportedData() list will contain one entry identifying
+     * that object (e.g. the frame type for ID3v2 tags). Use removeUnsupportedProperties()
+     * to remove (a subset of) them.
+     * For files that contain more than one tag (e.g. an MP3 with both an ID3v1 and an ID3v2
+     * tag) only the most "modern" one will be exported (ID3v2 in this case).
+     */
+    PropertyMap properties() const;
+
+    /*!
+     * Removes unsupported properties, or a subset of them, from the file's metadata.
+     * The parameter \a properties must contain only entries from
+     * properties().unsupportedData().
+     */
+    void removeUnsupportedProperties(const StringList& properties);
+
+    /*!
+     * Sets the tags of the wrapped File to those specified in \a properties.
+     * If some value(s) could not be written to the specific metadata format,
+     * the returned PropertyMap will contain those value(s). Otherwise it will be empty,
+     * indicating that no problems occurred.
+     * With file types that support several tag formats (for instance, MP3 files can have
+     * ID3v1, ID3v2, and APEv2 tags), this function will create the most appropriate one
+     * (ID3v2 for MP3 files). Older formats will be updated as well, if they exist, but won't
+     * be taken into account for the return value of this function.
+     * See the documentation of the subclass implementations for detailed descriptions.
+     */
+    PropertyMap setProperties(const PropertyMap &properties);
+
+    /*!
+     * Get the keys of complex properties, i.e. properties which cannot be
+     * represented simply by a string.
+     * Because such properties might be expensive to fetch, there are separate
+     * operations to get the available keys - which is expected to be cheap -
+     * and getting and setting the property values.
+     * Calls the method on the wrapped File, which collects the keys from one
+     * or more of its tags.
+     */
+    StringList complexPropertyKeys() const;
+
+    /*!
+     * Get the complex properties for a given \a key.
+     * In order to be flexible for different metadata formats, the properties
+     * are represented as variant maps.  Despite this dynamic nature, some
+     * degree of standardization should be achieved between formats:
+     *
+     * - PICTURE
+     *   - data: ByteVector with picture data
+     *   - description: String with description
+     *   - pictureType: String with type as specified for ID3v2,
+     *     e.g. "Front Cover", "Back Cover", "Band"
+     *   - mimeType: String with image format, e.g. "image/jpeg"
+     *   - optionally more information found in the tag, such as
+     *     "width", "height", "numColors", "colorDepth" int values
+     *     in FLAC pictures
+     * - GENERALOBJECT
+     *   - data: ByteVector with object data
+     *   - description: String with description
+     *   - fileName: String with file name
+     *   - mimeType: String with MIME type
+     *   - this is currently only implemented for ID3v2 GEOB frames
+     *
+     * Calls the method on the wrapped File, which gets the properties from one
+     * or more of its tags.
+     */
+    List<VariantMap> complexProperties(const String &key) const;
+
+    /*!
+     * Set all complex properties for a given \a key using variant maps as
+     * \a value with the same format as returned by complexProperties().
+     * An empty list as \a value removes all complex properties for \a key.
+     */
+    bool setComplexProperties(const String &key, const List<VariantMap> &value);
 
     /*!
      * Returns the audio properties for this FileRef.  If no audio properties

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -119,7 +119,7 @@ namespace TagLib {
     /*!
      * Set all complex properties for a given \a key using variant maps as
      * \a value with the same format as returned by complexProperties().
-     * An empty list as \a value to removes all complex properties for \a key.
+     * An empty list as \a value removes all complex properties for \a key.
      */
     virtual bool setComplexProperties(const String &key, const List<VariantMap> &value);
 

--- a/taglib/toolkit/tfile.h
+++ b/taglib/toolkit/tfile.h
@@ -122,7 +122,7 @@ namespace TagLib {
      * Sets the tags of this File to those specified in \a properties. Calls the
      * according specialization method in the subclasses of File to do the translation
      * into the format-specific details.
-     * If some value(s) could not be written imported to the specific metadata format,
+     * If some value(s) could not be written to the specific metadata format,
      * the returned PropertyMap will contain those value(s). Otherwise it will be empty,
      * indicating that no problems occurred.
      * With file types that support several tag formats (for instance, MP3 files can have

--- a/taglib/toolkit/tstring.cpp
+++ b/taglib/toolkit/tstring.cpp
@@ -706,6 +706,6 @@ TagLib::String operator+(const TagLib::String &s1, const char *s2)
 
 std::ostream &operator<<(std::ostream &s, const TagLib::String &str)
 {
-  s << str.to8Bit();
+  s << str.to8Bit(true);
   return s;
 }

--- a/taglib/toolkit/tvariant.cpp
+++ b/taglib/toolkit/tvariant.cpp
@@ -116,7 +116,7 @@ public:
   void operator()(const TagLib::String &v)
   {
     s << '"';
-    for (char c : v.to8Bit()) {
+    for (char c : v.to8Bit(true)) {
       if(c == '"') {
         s << "\\\"";
       }

--- a/tests/test_complexproperties.cpp
+++ b/tests/test_complexproperties.cpp
@@ -88,8 +88,8 @@ public:
     if(zlib::isAvailable()) {
       FileRef f(TEST_FILE_PATH_C("compressed_id3_frame.mp3"), false);
       CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY),
-        f.file()->complexPropertyKeys());
-      auto pictures = f.file()->complexProperties(PICTURE_KEY);
+        f.complexPropertyKeys());
+      auto pictures = f.complexProperties(PICTURE_KEY);
       CPPUNIT_ASSERT_EQUAL(1U, pictures.size());
       auto picture = pictures.front();
       CPPUNIT_ASSERT_EQUAL(86414U,
@@ -131,8 +131,8 @@ public:
 
     FileRef f(TEST_FILE_PATH_C("has-tags.m4a"), false);
     CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY),
-      f.file()->complexPropertyKeys());
-    auto pictures = f.file()->complexProperties(PICTURE_KEY);
+      f.complexPropertyKeys());
+    auto pictures = f.complexProperties(PICTURE_KEY);
     CPPUNIT_ASSERT_EQUAL(2U, pictures.size());
     auto picture = pictures.front();
     CPPUNIT_ASSERT_EQUAL(expectedData1,
@@ -150,8 +150,8 @@ public:
   {
     FileRef f(TEST_FILE_PATH_C("lowercase-fields.ogg"), false);
     CPPUNIT_ASSERT_EQUAL(StringList(PICTURE_KEY),
-      f.file()->complexPropertyKeys());
-    auto pictures = f.file()->complexProperties(PICTURE_KEY);
+      f.complexPropertyKeys());
+    auto pictures = f.complexProperties(PICTURE_KEY);
     CPPUNIT_ASSERT_EQUAL(1U, pictures.size());
     auto picture = pictures.front();
     CPPUNIT_ASSERT_EQUAL(ByteVector("JPEG data"),
@@ -243,19 +243,19 @@ public:
 
     {
       FileRef f(copy.fileName().c_str(), false);
-      CPPUNIT_ASSERT(f.file()->complexPropertyKeys().isEmpty());
-      f.file()->setComplexProperties(PICTURE_KEY, {TEST_PICTURE, picture2});
-      f.file()->setComplexProperties(GEOB_KEY, {geob1, geob2});
-      f.file()->save();
+      CPPUNIT_ASSERT(f.complexPropertyKeys().isEmpty());
+      f.setComplexProperties(PICTURE_KEY, {TEST_PICTURE, picture2});
+      f.setComplexProperties(GEOB_KEY, {geob1, geob2});
+      f.save();
     }
     {
       FileRef f(copy.fileName().c_str(), false);
       CPPUNIT_ASSERT_EQUAL(StringList({PICTURE_KEY, GEOB_KEY}),
-        f.file()->complexPropertyKeys());
+        f.complexPropertyKeys());
       CPPUNIT_ASSERT(List<VariantMap>({TEST_PICTURE, picture2}) ==
-        f.file()->complexProperties(PICTURE_KEY));
+        f.complexProperties(PICTURE_KEY));
       CPPUNIT_ASSERT(List<VariantMap>({geob1, geob2}) ==
-        f.file()->complexProperties(GEOB_KEY));
+        f.complexProperties(GEOB_KEY));
     }
   }
 

--- a/tests/test_fileref.cpp
+++ b/tests/test_fileref.cpp
@@ -104,7 +104,6 @@ class TestFileRef : public CppUnit::TestFixture
   CPPUNIT_TEST(testDSF);
   CPPUNIT_TEST(testDSDIFF);
   CPPUNIT_TEST(testUnsupported);
-  CPPUNIT_TEST(testCreate);
   CPPUNIT_TEST(testAudioProperties);
   CPPUNIT_TEST(testDefaultFileExtensions);
   CPPUNIT_TEST(testFileResolver);
@@ -352,23 +351,6 @@ public:
 
     FileRef f2(TEST_FILE_PATH_C("unsupported-extension.xx"));
     CPPUNIT_ASSERT(f2.isNull());
-  }
-
-  void testCreate()
-  {
-    // This is deprecated. But worth it to test.
-
-    File *f = FileRef::create(TEST_FILE_PATH_C("empty_vorbis.oga"));
-    CPPUNIT_ASSERT(dynamic_cast<Ogg::Vorbis::File*>(f));
-    delete f;
-
-    f = FileRef::create(TEST_FILE_PATH_C("xing.mp3"));
-    CPPUNIT_ASSERT(dynamic_cast<MPEG::File*>(f));
-    delete f;
-
-    f = FileRef::create(TEST_FILE_PATH_C("test.xm"));
-    CPPUNIT_ASSERT(dynamic_cast<XM::File*>(f));
-    delete f;
   }
 
   void testAudioProperties()

--- a/tests/test_sizes.cpp
+++ b/tests/test_sizes.cpp
@@ -172,7 +172,7 @@ public:
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::FLAC::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::FLAC::UnknownMetadataBlock));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::File));
-        CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::FileRef));
+        CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::FileRef));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::FileRef::FileTypeResolver));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::FileRef::StreamTypeResolver));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::FileStream));


### PR DESCRIPTION
Use `FileRef` for `TagLib_File` (C bindings), which allows to drop its deprecated `create()` method and delete duplicated code. It also allows to easily provide a feature to access files from memory with the C bindings (#987).
`FileRef` now has all the property methods, so that it is possible to do without its `file()` method, the use of which is discouraged in the documentation.
Noteworthy changes: `FileRef` is no longer virtual (the destructor was the only virtual method), and printing a `String` to `cout` will now use UTF-8 instead of ISO-8859-1 encoding.