### PR TITLE
GitHub Actions: Update Homebrew utfcpp to 4.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: Set up macOS
-      run: brew install cppunit utf8cpp
+      run: |
+        brew update
+        brew install cppunit utf8cpp
       if: matrix.os == 'macos-latest'
 
     - name: Set up Windows

--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -343,16 +343,6 @@ add_library(tag ${tag_LIB_SRCS} ${tag_HDRS})
 target_link_libraries(tag $<$<TARGET_EXISTS:utf8::cpp>:utf8::cpp>)
 target_link_libraries(tag $<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>)
 
-# Homebrew utf8cpp 4.0.1 seems to have issues. utf8.h is not found because
-# imported target utf8::cpp does not exist. The imported target utf8cpp::utf8cpp
-# includes non-existent path /usr/local/include/utf8cpp and cannot be used.
-# Therefore the following (temporary) hack is used to find the utf8cpp includes.
-if(APPLE)
-  if(EXISTS /usr/local/include/utf8.h)
-    include_directories(/usr/local/include)
-  endif()
-endif()
-
 set_target_properties(tag PROPERTIES
   VERSION ${TAGLIB_SOVERSION_MAJOR}.${TAGLIB_SOVERSION_MINOR}.${TAGLIB_SOVERSION_PATCH}
   SOVERSION ${TAGLIB_SOVERSION_MAJOR}


### PR DESCRIPTION
Revert "Fix build on Mac with Homebrew utf8cpp"
This reverts commit 70b4ce79fb493e45ae8884389ed146cf334a0369.

Is now fixed upstream
https://github.com/nemtrif/utfcpp/pull/113
https://github.com/nemtrif/utfcpp/releases/tag/v4.0.2 https://github.com/Homebrew/homebrew-core/pull/153333