### PR TITLE
Clients can control supported MP4 atoms using an ItemFactory

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -126,6 +126,7 @@ set(tag_HDRS
   mp4/mp4item.h
   mp4/mp4properties.h
   mp4/mp4coverart.h
+  mp4/mp4itemfactory.h
   mod/modfilebase.h
   mod/modfile.h
   mod/modtag.h
@@ -221,6 +222,7 @@ set(mp4_SRCS
   mp4/mp4item.cpp
   mp4/mp4properties.cpp
   mp4/mp4coverart.cpp
+  mp4/mp4itemfactory.cpp
 )
 
 set(ape_SRCS

--- a/taglib/mp4/mp4file.h
+++ b/taglib/mp4/mp4file.h
@@ -36,6 +36,8 @@ namespace TagLib {
   //! An implementation of MP4 (AAC, ALAC, ...) metadata
   namespace MP4 {
     class Atoms;
+    class ItemFactory;
+
 
     /*!
      * This implements and provides an interface for MP4 files to the
@@ -64,9 +66,12 @@ namespace TagLib {
        * file's audio properties will also be read.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
+       *
+       * The items will be created using \a itemFactory (default if null).
        */
       File(FileName file, bool readProperties = true,
-           Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+           Properties::ReadStyle audioPropertiesStyle = Properties::Average,
+           ItemFactory *itemFactory = nullptr);
 
       /*!
        * Constructs an MP4 file from \a stream.  If \a readProperties is true the
@@ -76,9 +81,12 @@ namespace TagLib {
        * responsible for deleting it after the File object.
        *
        * \note In the current implementation, \a propertiesStyle is ignored.
+       *
+       * The items will be created using \a itemFactory (default if null).
        */
       File(IOStream *stream, bool readProperties = true,
-           Properties::ReadStyle audioPropertiesStyle = Properties::Average);
+           Properties::ReadStyle audioPropertiesStyle = Properties::Average,
+           ItemFactory *itemFactory = nullptr);
 
       /*!
        * Destroys this instance of the File.

--- a/taglib/mp4/mp4item.h
+++ b/taglib/mp4/mp4item.h
@@ -83,6 +83,8 @@ namespace TagLib {
       class ItemPrivate;
       std::shared_ptr<ItemPrivate> d;
     };
+
+    using ItemMap = TagLib::Map<String, Item>;
   }  // namespace MP4
 }  // namespace TagLib
 #endif

--- a/taglib/mp4/mp4itemfactory.cpp
+++ b/taglib/mp4/mp4itemfactory.cpp
@@ -1,0 +1,577 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include "mp4itemfactory.h"
+
+#include "tbytevector.h"
+#include "tdebug.h"
+
+#include "id3v1genres.h"
+
+using namespace TagLib;
+using namespace MP4;
+
+class ItemFactory::ItemFactoryPrivate
+{
+public:
+  NameHandlerMap handlerTypeForName;
+};
+
+ItemFactory ItemFactory::factory;
+
+////////////////////////////////////////////////////////////////////////////////
+// public members
+////////////////////////////////////////////////////////////////////////////////
+
+ItemFactory *ItemFactory::instance()
+{
+  return &factory;
+}
+
+ItemFactory::NameHandlerMap ItemFactory::nameHandlerMap() const
+{
+  return {
+    {"----", ItemHandlerType::FreeForm},
+    {"trkn", ItemHandlerType::IntPair},
+    {"disk", ItemHandlerType::IntPairNoTrailing},
+    {"cpil", ItemHandlerType::Bool},
+    {"pgap", ItemHandlerType::Bool},
+    {"pcst", ItemHandlerType::Bool},
+    {"shwm", ItemHandlerType::Bool},
+    {"tmpo", ItemHandlerType::Int},
+    {"\251mvi", ItemHandlerType::Int},
+    {"\251mvc", ItemHandlerType::Int},
+    {"hdvd", ItemHandlerType::Int},
+    {"rate", ItemHandlerType::TextOrInt},
+    {"tvsn", ItemHandlerType::UInt},
+    {"tves", ItemHandlerType::UInt},
+    {"cnID", ItemHandlerType::UInt},
+    {"sfID", ItemHandlerType::UInt},
+    {"atID", ItemHandlerType::UInt},
+    {"geID", ItemHandlerType::UInt},
+    {"cmID", ItemHandlerType::UInt},
+    {"plID", ItemHandlerType::LongLong},
+    {"stik", ItemHandlerType::Byte},
+    {"rtng", ItemHandlerType::Byte},
+    {"akID", ItemHandlerType::Byte},
+    {"gnre", ItemHandlerType::Gnre},
+    {"covr", ItemHandlerType::Covr},
+    {"purl", ItemHandlerType::TextImplicit},
+    {"egid", ItemHandlerType::TextImplicit},
+  };
+}
+
+ItemFactory::ItemHandlerType ItemFactory::handlerTypeForName(
+  const ByteVector &name) const
+{
+  if(d->handlerTypeForName.isEmpty()) {
+    d->handlerTypeForName = nameHandlerMap();
+  }
+  auto type = d->handlerTypeForName.value(name, ItemHandlerType::Unknown);
+  if (type == ItemHandlerType::Unknown && name.size() == 4) {
+    type = ItemHandlerType::Text;
+  }
+  return type;
+}
+
+std::pair<String, Item> ItemFactory::parseItem(
+  const Atom *atom, const ByteVector &data) const
+{
+  auto handlerType = handlerTypeForName(atom->name);
+  switch(handlerType) {
+  case ItemHandlerType::Unknown:
+    break;
+  case ItemHandlerType::FreeForm:
+    return parseFreeForm(atom, data);
+  case ItemHandlerType::IntPair:
+  case ItemHandlerType::IntPairNoTrailing:
+    return parseIntPair(atom, data);
+  case ItemHandlerType::Bool:
+    return parseBool(atom, data);
+  case ItemHandlerType::Int:
+    return parseInt(atom, data);
+  case ItemHandlerType::TextOrInt:
+    return parseTextOrInt(atom, data);
+  case ItemHandlerType::UInt:
+    return parseUInt(atom, data);
+  case ItemHandlerType::LongLong:
+    return parseLongLong(atom, data);
+  case ItemHandlerType::Byte:
+    return parseByte(atom, data);
+  case ItemHandlerType::Gnre:
+    return parseGnre(atom, data);
+  case ItemHandlerType::Covr:
+    return parseCovr(atom, data);
+  case ItemHandlerType::TextImplicit:
+    return parseText(atom, data, -1);
+  case ItemHandlerType::Text:
+    return parseText(atom, data);
+  }
+  return {atom->name, Item()};
+}
+
+ByteVector ItemFactory::renderItem(
+  const String &itemName, const Item &item) const
+{
+  if(itemName.startsWith("----")) {
+    return renderFreeForm(itemName, item);
+  }
+  else {
+    const ByteVector name = itemName.data(String::Latin1);
+    auto handlerType = handlerTypeForName(name);
+    switch(handlerType) {
+    case ItemHandlerType::Unknown:
+      debug("MP4: Unknown item name \"" + name + "\"");
+      break;
+    case ItemHandlerType::FreeForm:
+      return renderFreeForm(name, item);
+    case ItemHandlerType::IntPair:
+      return renderIntPair(name, item);
+    case ItemHandlerType::IntPairNoTrailing:
+      return renderIntPairNoTrailing(name, item);
+    case ItemHandlerType::Bool:
+      return renderBool(name, item);
+    case ItemHandlerType::Int:
+      return renderInt(name, item);
+    case ItemHandlerType::TextOrInt:
+      return renderTextOrInt(name, item);
+    case ItemHandlerType::UInt:
+      return renderUInt(name, item);
+    case ItemHandlerType::LongLong:
+      return renderLongLong(name, item);
+    case ItemHandlerType::Byte:
+      return renderByte(name, item);
+    case ItemHandlerType::Gnre:
+      return renderInt(name, item);
+    case ItemHandlerType::Covr:
+      return renderCovr(name, item);
+    case ItemHandlerType::TextImplicit:
+      return renderText(name, item, TypeImplicit);
+    case ItemHandlerType::Text:
+      return renderText(name, item);
+    }
+  }
+  return ByteVector();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// protected members
+////////////////////////////////////////////////////////////////////////////////
+
+ItemFactory::ItemFactory() :
+  d(std::make_unique<ItemFactoryPrivate>())
+{
+}
+
+ItemFactory::~ItemFactory() = default;
+
+MP4::AtomDataList ItemFactory::parseData2(
+  const MP4::Atom *atom, const ByteVector &data, int expectedFlags,
+  bool freeForm)
+{
+  AtomDataList result;
+  int i = 0;
+  unsigned int pos = 0;
+  while(pos < data.size()) {
+    const auto length = static_cast<int>(data.toUInt(pos));
+    if(length < 12) {
+      debug("MP4: Too short atom");
+      return result;
+    }
+
+    const ByteVector name = data.mid(pos + 4, 4);
+    const auto flags = static_cast<int>(data.toUInt(pos + 8));
+    if(freeForm && i < 2) {
+      if(i == 0 && name != "mean") {
+        debug("MP4: Unexpected atom \"" + name + "\", expecting \"mean\"");
+        return result;
+      }
+      if(i == 1 && name != "name") {
+        debug("MP4: Unexpected atom \"" + name + "\", expecting \"name\"");
+        return result;
+      }
+      result.append(AtomData(static_cast<AtomDataType>(flags),
+                    data.mid(pos + 12, length - 12)));
+    }
+    else {
+      if(name != "data") {
+        debug("MP4: Unexpected atom \"" + name + "\", expecting \"data\"");
+        return result;
+      }
+      if(expectedFlags == -1 || flags == expectedFlags) {
+        result.append(AtomData(static_cast<AtomDataType>(flags),
+                      data.mid(pos + 16, length - 16)));
+      }
+    }
+    pos += length;
+    i++;
+  }
+  return result;
+}
+
+ByteVectorList ItemFactory::parseData(
+  const MP4::Atom *atom, const ByteVector &bytes, int expectedFlags,
+  bool freeForm)
+{
+  const AtomDataList data = parseData2(atom, bytes, expectedFlags, freeForm);
+  ByteVectorList result;
+  for(const auto &atom : data) {
+    result.append(atom.data);
+  }
+  return result;
+}
+
+std::pair<String, Item> ItemFactory::parseInt(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  return {
+    atom->name,
+    !data.isEmpty() ? Item(static_cast<int>(data[0].toShort())) : Item()
+  };
+}
+
+std::pair<String, Item> ItemFactory::parseTextOrInt(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  AtomDataList data = parseData2(atom, bytes);
+  if(!data.isEmpty()) {
+    AtomData val = data[0];
+    return {
+      atom->name,
+       val.type == TypeUTF8 ? Item(StringList(String(val.data, String::UTF8)))
+                            : Item(static_cast<int>(val.data.toShort()))
+    };
+  }
+  return {atom->name, Item()};
+}
+
+std::pair<String, Item> ItemFactory::parseUInt(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  return {
+    atom->name,
+    !data.isEmpty() ? Item(data[0].toUInt()) : Item()
+  };
+}
+
+std::pair<String, Item> ItemFactory::parseLongLong(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  return {
+    atom->name,
+    !data.isEmpty() ?Item (data[0].toLongLong()) : Item()
+  };
+}
+
+std::pair<String, Item> ItemFactory::parseByte(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  return {
+    atom->name,
+    !data.isEmpty() ? Item(static_cast<unsigned char>(data[0].at(0))) : Item()
+  };
+}
+
+std::pair<String, Item> ItemFactory::parseGnre(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  if(!data.isEmpty()) {
+    int idx = static_cast<int>(data[0].toShort());
+    if(idx > 0) {
+      return {
+        "\251gen",
+        Item(StringList(ID3v1::genre(idx - 1)))
+      };
+    }
+  }
+  return {"\251gen", Item()};
+}
+
+std::pair<String, Item> ItemFactory::parseIntPair(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  if(!data.isEmpty()) {
+    const int a = data[0].toShort(2U);
+    const int b = data[0].toShort(4U);
+    return {atom->name, Item(a, b)};
+  }
+  return {atom->name, Item()};
+}
+
+std::pair<String, Item> ItemFactory::parseBool(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  ByteVectorList data = parseData(atom, bytes);
+  if(!data.isEmpty()) {
+    bool value = !data[0].isEmpty() && data[0][0] != '\0';
+    return {atom->name, Item(value)};
+  }
+  return {atom->name, Item()};
+}
+
+std::pair<String, Item> ItemFactory::parseText(
+  const MP4::Atom *atom, const ByteVector &bytes, int expectedFlags)
+{
+  const ByteVectorList data = parseData(atom, bytes, expectedFlags);
+  if(!data.isEmpty()) {
+    StringList value;
+    for(const auto &byte : data) {
+      value.append(String(byte, String::UTF8));
+    }
+    return {atom->name, Item(value)};
+  }
+  return {atom->name, Item()};
+}
+
+std::pair<String, Item> ItemFactory::parseFreeForm(
+  const MP4::Atom *atom, const ByteVector &bytes)
+{
+  const AtomDataList data = parseData2(atom, bytes, -1, true);
+  if(data.size() > 2) {
+    auto itBegin = data.begin();
+
+    String name = "----:";
+    name += String((itBegin++)->data, String::UTF8);  // data[0].data
+    name += ':';
+    name += String((itBegin++)->data, String::UTF8);  // data[1].data
+
+    AtomDataType type = itBegin->type; // data[2].type
+
+    for(auto it = itBegin; it != data.end(); ++it) {
+      if(it->type != type) {
+        debug("MP4: We currently don't support values with multiple types");
+        break;
+      }
+    }
+    if(type == TypeUTF8) {
+      StringList value;
+      for(auto it = itBegin; it != data.end(); ++it) {
+        value.append(String(it->data, String::UTF8));
+      }
+      Item item(value);
+      item.setAtomDataType(type);
+      return {name, item};
+    }
+    else {
+      ByteVectorList value;
+      for(auto it = itBegin; it != data.end(); ++it) {
+        value.append(it->data);
+      }
+      Item item(value);
+      item.setAtomDataType(type);
+      return {name, item};
+    }
+  }
+  return {atom->name, Item()};
+}
+
+std::pair<String, Item> ItemFactory::parseCovr(
+  const MP4::Atom *atom, const ByteVector &data)
+{
+  MP4::CoverArtList value;
+  unsigned int pos = 0;
+  while(pos < data.size()) {
+    const int length = static_cast<int>(data.toUInt(pos));
+    if(length < 12) {
+      debug("MP4: Too short atom");
+      break;
+    }
+
+    const ByteVector name = data.mid(pos + 4, 4);
+    const int flags = static_cast<int>(data.toUInt(pos + 8));
+    if(name != "data") {
+      debug("MP4: Unexpected atom \"" + name + "\", expecting \"data\"");
+      break;
+    }
+    if(flags == TypeJPEG || flags == TypePNG || flags == TypeBMP ||
+       flags == TypeGIF || flags == TypeImplicit) {
+      value.append(MP4::CoverArt(static_cast<MP4::CoverArt::Format>(flags),
+                                 data.mid(pos + 16, length - 16)));
+    }
+    else {
+      debug("MP4: Unknown covr format " + String::number(flags));
+    }
+    pos += length;
+  }
+  return {
+    atom->name,
+    !value.isEmpty() ? Item(value) : Item()
+  };
+}
+
+
+ByteVector ItemFactory::renderAtom(
+  const ByteVector &name, const ByteVector &data)
+{
+  return ByteVector::fromUInt(data.size() + 8) + name + data;
+}
+
+ByteVector ItemFactory::renderData(
+  const ByteVector &name, int flags, const ByteVectorList &data)
+{
+  ByteVector result;
+  for(const auto &byte : data) {
+    result.append(renderAtom("data", ByteVector::fromUInt(flags) +
+                                     ByteVector(4, '\0') + byte));
+  }
+  return renderAtom(name, result);
+}
+
+ByteVector ItemFactory::renderBool(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector(1, item.toBool() ? '\1' : '\0'));
+  return renderData(name, TypeInteger, data);
+}
+
+ByteVector ItemFactory::renderInt(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector::fromShort(item.toInt()));
+  return renderData(name, TypeInteger, data);
+}
+
+ByteVector ItemFactory::renderTextOrInt(
+  const ByteVector &name, const MP4::Item &item)
+{
+  StringList value = item.toStringList();
+  return value.isEmpty() ? renderInt(name, item) : renderText(name, item);
+}
+
+ByteVector ItemFactory::renderUInt(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector::fromUInt(item.toUInt()));
+  return renderData(name, TypeInteger, data);
+}
+
+ByteVector ItemFactory::renderLongLong(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector::fromLongLong(item.toLongLong()));
+  return renderData(name, TypeInteger, data);
+}
+
+ByteVector ItemFactory::renderByte(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector(1, item.toByte()));
+  return renderData(name, TypeInteger, data);
+}
+
+ByteVector ItemFactory::renderIntPair(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector(2, '\0') +
+              ByteVector::fromShort(item.toIntPair().first) +
+              ByteVector::fromShort(item.toIntPair().second) +
+              ByteVector(2, '\0'));
+  return renderData(name, TypeImplicit, data);
+}
+
+ByteVector ItemFactory::renderIntPairNoTrailing(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVectorList data;
+  data.append(ByteVector(2, '\0') +
+              ByteVector::fromShort(item.toIntPair().first) +
+              ByteVector::fromShort(item.toIntPair().second));
+  return renderData(name, TypeImplicit, data);
+}
+
+ByteVector ItemFactory::renderText(
+  const ByteVector &name, const MP4::Item &item, int flags)
+{
+  ByteVectorList data;
+  const StringList values = item.toStringList();
+  for(const auto &value : values) {
+    data.append(value.data(String::UTF8));
+  }
+  return renderData(name, flags, data);
+}
+
+ByteVector ItemFactory::renderCovr(
+  const ByteVector &name, const MP4::Item &item)
+{
+  ByteVector data;
+  const MP4::CoverArtList values = item.toCoverArtList();
+  for(const auto &value : values) {
+    data.append(renderAtom("data", ByteVector::fromUInt(value.format()) +
+                                   ByteVector(4, '\0') + value.data()));
+  }
+  return renderAtom(name, data);
+}
+
+ByteVector ItemFactory::renderFreeForm(
+  const String &name, const MP4::Item &item)
+{
+  StringList header = StringList::split(name, ":");
+  if(header.size() != 3) {
+    debug("MP4: Invalid free-form item name \"" + name + "\"");
+    return ByteVector();
+  }
+  ByteVector data;
+  data.append(renderAtom("mean", ByteVector::fromUInt(0) +
+                                 header[1].data(String::UTF8)));
+  data.append(renderAtom("name", ByteVector::fromUInt(0) +
+                                 header[2].data(String::UTF8)));
+  AtomDataType type = item.atomDataType();
+  if(type == TypeUndefined) {
+    if(!item.toStringList().isEmpty()) {
+      type = TypeUTF8;
+    }
+    else {
+      type = TypeImplicit;
+    }
+  }
+  if(type == TypeUTF8) {
+    const StringList values = item.toStringList();
+    for(const auto &value : values) {
+      data.append(renderAtom("data", ByteVector::fromUInt(type) +
+                                     ByteVector(4, '\0') +
+                                     value.data(String::UTF8)));
+    }
+  }
+  else {
+    const ByteVectorList values = item.toByteVectorList();
+    for(const auto &value : values) {
+      data.append(renderAtom("data", ByteVector::fromUInt(type) +
+                                     ByteVector(4, '\0') + value));
+    }
+  }
+  return renderAtom("----", data);
+}

--- a/taglib/mp4/mp4itemfactory.h
+++ b/taglib/mp4/mp4itemfactory.h
@@ -1,0 +1,211 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_MP4ITEMFACTORY_H
+#define TAGLIB_MP4ITEMFACTORY_H
+
+#include <memory>
+#include "taglib_export.h"
+#include "mp4item.h"
+
+namespace TagLib {
+
+  namespace MP4 {
+
+    //! A factory for creating MP4 items during parsing
+
+    /*!
+     * This factory abstracts away the parsing and rendering between atom data
+     * and MP4 items.
+     *
+     * Reimplementing this factory is the key to adding support for atom types
+     * not directly supported by TagLib to your application.  To do so you would
+     * subclass this factory and reimplement nameHandlerMap() to add support
+     * for new atoms.  If the new atoms do not have the same behavior as
+     * other supported atoms, it may be necessary to reimplement parseItem() and
+     * renderItem().  Then by setting your factory in the MP4::Tag constructor
+     * you can implement behavior that will allow for new atom types to be used.
+     *
+     * A custom item factory adding support for a "tsti" integer atom and a
+     * "tstt" text atom can be implemented like this:
+     *
+     * \code
+     * class CustomItemFactory : public MP4::ItemFactory {
+     * protected:
+     *   NameHandlerMap nameHandlerMap() const override
+     *   {
+     *     return MP4::ItemFactory::nameHandlerMap()
+     *       .insert("tsti", ItemHandlerType::Int)
+     *       .insert("tstt", ItemHandlerType::Text);
+     *   }
+     * };
+     * \endcode
+     */
+    class TAGLIB_EXPORT ItemFactory
+    {
+    public:
+      ItemFactory(const ItemFactory &) = delete;
+      ItemFactory &operator=(const ItemFactory &) = delete;
+
+      static ItemFactory *instance();
+
+      /*!
+       * Create an MP4 item from the \a data bytes of an \a atom.
+       * Returns the name (in most cases atom->name) and an item,
+       * an invalid item on failure.
+       * The default implementation uses the map returned by nameHandlerMap().
+       */
+      virtual std::pair<String, Item> parseItem(
+        const Atom *atom, const ByteVector &data) const;
+
+      /*!
+       * Render an MP4 \a item to the data bytes of an atom \a itemName.
+       * An empty byte vector is returned if the item is invalid or unknown.
+       * The default implementation uses the map returned by nameHandlerMap().
+       */
+      virtual ByteVector renderItem(
+        const String &itemName, const Item &item) const;
+
+    protected:
+      /*!
+       * Type that determines the parsing and rendering between the data and
+       * the item representation of an atom.
+       */
+      enum class ItemHandlerType {
+        Unknown,
+        FreeForm,
+        IntPair,
+        IntPairNoTrailing,
+        Bool,
+        Int,
+        TextOrInt,
+        UInt,
+        LongLong,
+        Byte,
+        Gnre,
+        Covr,
+        TextImplicit,
+        Text
+      };
+
+      /*! Mapping of atom name to handler type. */
+      using NameHandlerMap = Map<ByteVector, ItemHandlerType>;
+
+      /*!
+       * Constructs an item factory.  Because this is a singleton this method is
+       * protected, but may be used for subclasses.
+       */
+      ItemFactory();
+
+      /*!
+       * Destroys the frame factory.
+       */
+      virtual ~ItemFactory();
+
+      /*!
+       * Returns mapping between atom names and handler types.
+       * This method is called once by handlerTypeForName() to initialize its
+       * internal cache.
+       * To add support for a new atom, it is sufficient in most cases to just
+       * reimplement this method and add new entries.
+       */
+      virtual NameHandlerMap nameHandlerMap() const;
+
+      /*!
+       * Returns handler type for atom \a name.
+       * The default method looks up the map created by nameHandlerMap() and
+       * should be enough for most uses.
+       */
+      virtual ItemHandlerType handlerTypeForName(const ByteVector &name) const;
+
+      // Functions used by parseItem() to create items from atom data.
+      static MP4::AtomDataList parseData2(
+        const MP4::Atom *atom, const ByteVector &data, int expectedFlags = -1,
+        bool freeForm = false);
+      static ByteVectorList parseData(
+        const MP4::Atom *atom, const ByteVector &bytes, int expectedFlags = -1,
+        bool freeForm = false);
+      static std::pair<String, Item> parseText(
+        const MP4::Atom *atom, const ByteVector &bytes, int expectedFlags = 1);
+      static std::pair<String, Item> parseFreeForm(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseInt(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseByte(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseTextOrInt(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseUInt(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseLongLong(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseGnre(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseIntPair(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseBool(
+        const MP4::Atom *atom, const ByteVector &bytes);
+      static std::pair<String, Item> parseCovr(
+        const MP4::Atom *atom, const ByteVector &data);
+
+      // Functions used by renderItem() to render atom data for items.
+      static ByteVector renderAtom(
+        const ByteVector &name, const ByteVector &data);
+      static ByteVector renderData(
+        const ByteVector &name, int flags, const ByteVectorList &data);
+      static ByteVector renderText(
+        const ByteVector &name, const MP4::Item &item, int flags = TypeUTF8);
+      static ByteVector renderFreeForm(
+        const String &name, const MP4::Item &item);
+      static ByteVector renderBool(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderInt(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderTextOrInt(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderByte(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderUInt(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderLongLong(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderIntPair(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderIntPairNoTrailing(
+        const ByteVector &name, const MP4::Item &item);
+      static ByteVector renderCovr(
+        const ByteVector &name, const MP4::Item &item);
+
+    private:
+      static ItemFactory factory;
+
+      class ItemFactoryPrivate;
+      std::unique_ptr<ItemFactoryPrivate> d;
+    };
+
+  }  // namespace MP4
+}  // namespace TagLib
+
+#endif

--- a/taglib/mp4/mp4itemfactory.h
+++ b/taglib/mp4/mp4itemfactory.h
@@ -62,6 +62,9 @@ namespace TagLib {
      *   }
      * };
      * \endcode
+     *
+     * If the custom item shall also be accessible via a property,
+     * namePropertyMap() can be overridden in the same way.
      */
     class TAGLIB_EXPORT ItemFactory
     {
@@ -87,6 +90,39 @@ namespace TagLib {
        */
       virtual ByteVector renderItem(
         const String &itemName, const Item &item) const;
+
+      /*!
+       * Create an MP4 item from a property with \a key and \a values.
+       * If the property is not supported, an invalid item is returned.
+       * The default implementation uses the map returned by namePropertyMap().
+       */
+      virtual std::pair<ByteVector, Item> itemFromProperty(
+        const String &key, const StringList &values) const;
+
+      /*!
+       * Get an MP4 item as a property.
+       * If no property exists for \a itemName, an empty string is returned as
+       * the property key.
+       * The default implementation uses the map returned by namePropertyMap().
+       */
+      virtual std::pair<String, StringList> itemToProperty(
+        const ByteVector &itemName, const Item &item) const;
+
+      /*!
+       * Returns property key for atom \a name, empty if no property exists for
+       * this atom.
+       * The default method looks up the map created by namePropertyMap() and
+       * should be enough for most uses.
+       */
+      virtual String propertyKeyForName(const ByteVector &name) const;
+
+      /*!
+       * Returns atom name for property \a key, empty if no property is
+       * supported for this key.
+       * The default method uses the reverse mapping of propertyKeyForName()
+       * and should be enough for most uses.
+       */
+      virtual ByteVector nameForPropertyKey(const String &key) const;
 
     protected:
       /*!
@@ -139,6 +175,15 @@ namespace TagLib {
        * should be enough for most uses.
        */
       virtual ItemHandlerType handlerTypeForName(const ByteVector &name) const;
+
+      /*!
+       * Returns mapping between atom names and property keys.
+       * This method is called once by propertyKeyForName() to initialize its
+       * internal cache.
+       * To add support for a new atom with a property, it is sufficient in most
+       * cases to just reimplement this method and add new entries.
+       */
+      virtual Map<ByteVector, String> namePropertyMap() const;
 
       // Functions used by parseItem() to create items from atom data.
       static MP4::AtomDataList parseData2(

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -30,7 +30,7 @@
 
 #include "tdebug.h"
 #include "tpropertymap.h"
-#include "id3v1genres.h"
+#include "mp4itemfactory.h"
 #include "mp4atom.h"
 #include "mp4coverart.h"
 
@@ -39,18 +39,28 @@ using namespace TagLib;
 class MP4::Tag::TagPrivate
 {
 public:
+  TagPrivate(const ItemFactory *itemFactory) :
+    factory(itemFactory ? itemFactory
+                        : ItemFactory::instance())
+  {
+  }
+
+  ~TagPrivate() = default;
+
+  const ItemFactory *factory;
   TagLib::File *file { nullptr };
   Atoms *atoms { nullptr };
   ItemMap items;
 };
 
 MP4::Tag::Tag() :
-  d(std::make_unique<TagPrivate>())
+  d(std::make_unique<TagPrivate>(ItemFactory::instance()))
 {
 }
 
-MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms) :
-  d(std::make_unique<TagPrivate>())
+MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms,
+              const MP4::ItemFactory *factory) :
+  d(std::make_unique<TagPrivate>(factory))
 {
   d->file = file;
   d->atoms = atoms;
@@ -63,267 +73,15 @@ MP4::Tag::Tag(TagLib::File *file, MP4::Atoms *atoms) :
 
   for(const auto &atom : std::as_const(ilst->children)) {
     file->seek(atom->offset + 8);
-    if(atom->name == "----") {
-      parseFreeForm(atom);
-    }
-    else if(atom->name == "trkn" || atom->name == "disk") {
-      parseIntPair(atom);
-    }
-    else if(atom->name == "cpil" || atom->name == "pgap" || atom->name == "pcst" ||
-            atom->name == "shwm") {
-      parseBool(atom);
-    }
-    else if(atom->name == "tmpo" || atom->name == "\251mvi" || atom->name == "\251mvc" ||
-            atom->name == "hdvd") {
-      parseInt(atom);
-    }
-    else if(atom->name == "rate") {
-      AtomDataList data = parseData2(atom);
-      if(!data.isEmpty()) {
-        AtomData val = data[0];
-        if (val.type == TypeUTF8) {
-          addItem(atom->name, StringList(String(val.data, String::UTF8)));
-        } else {
-          addItem(atom->name, static_cast<int>(val.data.toShort()));
-        }
-      }
-    }
-    else if(atom->name == "tvsn" || atom->name == "tves" || atom->name == "cnID" ||
-            atom->name == "sfID" || atom->name == "atID" || atom->name == "geID" ||
-            atom->name == "cmID") {
-      parseUInt(atom);
-    }
-    else if(atom->name == "plID") {
-      parseLongLong(atom);
-    }
-    else if(atom->name == "stik" || atom->name == "rtng" || atom->name == "akID") {
-      parseByte(atom);
-    }
-    else if(atom->name == "gnre") {
-      parseGnre(atom);
-    }
-    else if(atom->name == "covr") {
-      parseCovr(atom);
-    }
-    else if(atom->name == "purl" || atom->name == "egid") {
-      parseText(atom, -1);
-    }
-    else {
-      parseText(atom);
+    ByteVector data = d->file->readBlock(atom->length - 8);
+    const auto &[name, item] = d->factory->parseItem(atom, data);
+    if (item.isValid()) {
+      addItem(name, item);
     }
   }
 }
 
 MP4::Tag::~Tag() = default;
-
-MP4::AtomDataList
-MP4::Tag::parseData2(const MP4::Atom *atom, int expectedFlags, bool freeForm)
-{
-  AtomDataList result;
-  ByteVector data = d->file->readBlock(atom->length - 8);
-  int i = 0;
-  unsigned int pos = 0;
-  while(pos < data.size()) {
-    const auto length = static_cast<int>(data.toUInt(pos));
-    if(length < 12) {
-      debug("MP4: Too short atom");
-      return result;
-    }
-
-    const ByteVector name = data.mid(pos + 4, 4);
-    const auto flags = static_cast<int>(data.toUInt(pos + 8));
-    if(freeForm && i < 2) {
-      if(i == 0 && name != "mean") {
-        debug("MP4: Unexpected atom \"" + name + "\", expecting \"mean\"");
-        return result;
-      }
-      if(i == 1 && name != "name") {
-        debug("MP4: Unexpected atom \"" + name + "\", expecting \"name\"");
-        return result;
-      }
-      result.append(AtomData(static_cast<AtomDataType>(flags), data.mid(pos + 12, length - 12)));
-    }
-    else {
-      if(name != "data") {
-        debug("MP4: Unexpected atom \"" + name + "\", expecting \"data\"");
-        return result;
-      }
-      if(expectedFlags == -1 || flags == expectedFlags) {
-        result.append(AtomData(static_cast<AtomDataType>(flags), data.mid(pos + 16, length - 16)));
-      }
-    }
-    pos += length;
-    i++;
-  }
-  return result;
-}
-
-ByteVectorList
-MP4::Tag::parseData(const MP4::Atom *atom, int expectedFlags, bool freeForm)
-{
-  const AtomDataList data = parseData2(atom, expectedFlags, freeForm);
-  ByteVectorList result;
-  for(const auto &atom : data) {
-    result.append(atom.data);
-  }
-  return result;
-}
-
-void
-MP4::Tag::parseInt(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    addItem(atom->name, static_cast<int>(data[0].toShort()));
-  }
-}
-
-void
-MP4::Tag::parseUInt(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    addItem(atom->name, data[0].toUInt());
-  }
-}
-
-void
-MP4::Tag::parseLongLong(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    addItem(atom->name, data[0].toLongLong());
-  }
-}
-
-void
-MP4::Tag::parseByte(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    addItem(atom->name, static_cast<unsigned char>(data[0].at(0)));
-  }
-}
-
-void
-MP4::Tag::parseGnre(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    int idx = static_cast<int>(data[0].toShort());
-    if(idx > 0) {
-      addItem("\251gen", StringList(ID3v1::genre(idx - 1)));
-    }
-  }
-}
-
-void
-MP4::Tag::parseIntPair(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    const int a = data[0].toShort(2U);
-    const int b = data[0].toShort(4U);
-    addItem(atom->name, MP4::Item(a, b));
-  }
-}
-
-void
-MP4::Tag::parseBool(const MP4::Atom *atom)
-{
-  ByteVectorList data = parseData(atom);
-  if(!data.isEmpty()) {
-    bool value = !data[0].isEmpty() && data[0][0] != '\0';
-    addItem(atom->name, value);
-  }
-}
-
-void
-MP4::Tag::parseText(const MP4::Atom *atom, int expectedFlags)
-{
-  const ByteVectorList data = parseData(atom, expectedFlags);
-  if(!data.isEmpty()) {
-    StringList value;
-    for(const auto &byte : data) {
-      value.append(String(byte, String::UTF8));
-    }
-    addItem(atom->name, value);
-  }
-}
-
-void
-MP4::Tag::parseFreeForm(const MP4::Atom *atom)
-{
-  const AtomDataList data = parseData2(atom, -1, true);
-  if(data.size() > 2) {
-    auto itBegin = data.begin();
-
-    String name = "----:";
-    name += String((itBegin++)->data, String::UTF8);  // data[0].data
-    name += ':';
-    name += String((itBegin++)->data, String::UTF8);  // data[1].data
-
-    AtomDataType type = itBegin->type; // data[2].type
-
-    for(auto it = itBegin; it != data.end(); ++it) {
-      if(it->type != type) {
-        debug("MP4: We currently don't support values with multiple types");
-        break;
-      }
-    }
-    if(type == TypeUTF8) {
-      StringList value;
-      for(auto it = itBegin; it != data.end(); ++it) {
-        value.append(String(it->data, String::UTF8));
-      }
-      Item item(value);
-      item.setAtomDataType(type);
-      addItem(name, item);
-    }
-    else {
-      ByteVectorList value;
-      for(auto it = itBegin; it != data.end(); ++it) {
-        value.append(it->data);
-      }
-      Item item(value);
-      item.setAtomDataType(type);
-      addItem(name, item);
-    }
-  }
-}
-
-void
-MP4::Tag::parseCovr(const MP4::Atom *atom)
-{
-  MP4::CoverArtList value;
-  ByteVector data = d->file->readBlock(atom->length - 8);
-  unsigned int pos = 0;
-  while(pos < data.size()) {
-    const int length = static_cast<int>(data.toUInt(pos));
-    if(length < 12) {
-      debug("MP4: Too short atom");
-      break;
-    }
-
-    const ByteVector name = data.mid(pos + 4, 4);
-    const int flags = static_cast<int>(data.toUInt(pos + 8));
-    if(name != "data") {
-      debug("MP4: Unexpected atom \"" + name + "\", expecting \"data\"");
-      break;
-    }
-    if(flags == TypeJPEG || flags == TypePNG || flags == TypeBMP ||
-       flags == TypeGIF || flags == TypeImplicit) {
-      value.append(MP4::CoverArt(static_cast<MP4::CoverArt::Format>(flags),
-                                 data.mid(pos + 16, length - 16)));
-    }
-    else {
-      debug("MP4: Unknown covr format " + String::number(flags));
-    }
-    pos += length;
-  }
-  if(!value.isEmpty())
-    addItem(atom->name, value);
-}
 
 ByteVector
 MP4::Tag::padIlst(const ByteVector &data, int length) const
@@ -340,191 +98,12 @@ MP4::Tag::renderAtom(const ByteVector &name, const ByteVector &data) const
   return ByteVector::fromUInt(data.size() + 8) + name + data;
 }
 
-ByteVector
-MP4::Tag::renderData(const ByteVector &name, int flags, const ByteVectorList &data) const
-{
-  ByteVector result;
-  for(const auto &byte : data) {
-    result.append(renderAtom("data", ByteVector::fromUInt(flags) + ByteVector(4, '\0') + byte));
-  }
-  return renderAtom(name, result);
-}
-
-ByteVector
-MP4::Tag::renderBool(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector(1, item.toBool() ? '\1' : '\0'));
-  return renderData(name, TypeInteger, data);
-}
-
-ByteVector
-MP4::Tag::renderInt(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector::fromShort(item.toInt()));
-  return renderData(name, TypeInteger, data);
-}
-
-ByteVector
-MP4::Tag::renderUInt(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector::fromUInt(item.toUInt()));
-  return renderData(name, TypeInteger, data);
-}
-
-ByteVector
-MP4::Tag::renderLongLong(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector::fromLongLong(item.toLongLong()));
-  return renderData(name, TypeInteger, data);
-}
-
-ByteVector
-MP4::Tag::renderByte(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector(1, item.toByte()));
-  return renderData(name, TypeInteger, data);
-}
-
-ByteVector
-MP4::Tag::renderIntPair(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector(2, '\0') +
-              ByteVector::fromShort(item.toIntPair().first) +
-              ByteVector::fromShort(item.toIntPair().second) +
-              ByteVector(2, '\0'));
-  return renderData(name, TypeImplicit, data);
-}
-
-ByteVector
-MP4::Tag::renderIntPairNoTrailing(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVectorList data;
-  data.append(ByteVector(2, '\0') +
-              ByteVector::fromShort(item.toIntPair().first) +
-              ByteVector::fromShort(item.toIntPair().second));
-  return renderData(name, TypeImplicit, data);
-}
-
-ByteVector
-MP4::Tag::renderText(const ByteVector &name, const MP4::Item &item, int flags) const
-{
-  ByteVectorList data;
-  const StringList values = item.toStringList();
-  for(const auto &value : values) {
-    data.append(value.data(String::UTF8));
-  }
-  return renderData(name, flags, data);
-}
-
-ByteVector
-MP4::Tag::renderCovr(const ByteVector &name, const MP4::Item &item) const
-{
-  ByteVector data;
-  const MP4::CoverArtList values = item.toCoverArtList();
-  for(const auto &value : values) {
-    data.append(renderAtom("data", ByteVector::fromUInt(value.format()) +
-                                   ByteVector(4, '\0') + value.data()));
-  }
-  return renderAtom(name, data);
-}
-
-ByteVector
-MP4::Tag::renderFreeForm(const String &name, const MP4::Item &item) const
-{
-  StringList header = StringList::split(name, ":");
-  if(header.size() != 3) {
-    debug("MP4: Invalid free-form item name \"" + name + "\"");
-    return ByteVector();
-  }
-  ByteVector data;
-  data.append(renderAtom("mean", ByteVector::fromUInt(0) + header[1].data(String::UTF8)));
-  data.append(renderAtom("name", ByteVector::fromUInt(0) + header[2].data(String::UTF8)));
-  AtomDataType type = item.atomDataType();
-  if(type == TypeUndefined) {
-    if(!item.toStringList().isEmpty()) {
-      type = TypeUTF8;
-    }
-    else {
-      type = TypeImplicit;
-    }
-  }
-  if(type == TypeUTF8) {
-    const StringList values = item.toStringList();
-    for(const auto &value : values) {
-      data.append(renderAtom("data", ByteVector::fromUInt(type) +
-                                     ByteVector(4, '\0') + value.data(String::UTF8)));
-    }
-  }
-  else {
-    const ByteVectorList values = item.toByteVectorList();
-    for(const auto &value : values) {
-      data.append(renderAtom("data", ByteVector::fromUInt(type) +
-                                     ByteVector(4, '\0') + value));
-    }
-  }
-  return renderAtom("----", data);
-}
-
 bool
 MP4::Tag::save()
 {
   ByteVector data;
   for(const auto &[name, item] : std::as_const(d->items)) {
-    if(name.startsWith("----")) {
-      data.append(renderFreeForm(name, item));
-    }
-    else if(name == "trkn") {
-      data.append(renderIntPair(name.data(String::Latin1), item));
-    }
-    else if(name == "disk") {
-      data.append(renderIntPairNoTrailing(name.data(String::Latin1), item));
-    }
-    else if(name == "cpil" || name == "pgap" || name == "pcst" ||
-            name == "shwm") {
-      data.append(renderBool(name.data(String::Latin1), item));
-    }
-    else if(name == "tmpo" || name == "\251mvi" || name == "\251mvc" ||
-            name == "hdvd") {
-      data.append(renderInt(name.data(String::Latin1), item));
-    }
-    else if(name == "rate") {
-      StringList value = item.toStringList();
-      if (value.isEmpty()) {
-        data.append(renderInt(name.data(String::Latin1), item));
-      }
-      else {
-        data.append(renderText(name.data(String::Latin1), item));
-      }
-    }
-    else if(name == "tvsn" || name == "tves" || name == "cnID" ||
-            name == "sfID" || name == "atID" || name == "geID" ||
-            name == "cmID") {
-      data.append(renderUInt(name.data(String::Latin1), item));
-    }
-    else if(name == "plID") {
-      data.append(renderLongLong(name.data(String::Latin1), item));
-    }
-    else if(name == "stik" || name == "rtng" || name == "akID") {
-      data.append(renderByte(name.data(String::Latin1), item));
-    }
-    else if(name == "covr") {
-      data.append(renderCovr(name.data(String::Latin1), item));
-    }
-    else if(name == "purl" || name == "egid") {
-      data.append(renderText(name.data(String::Latin1), item, TypeImplicit));
-    }
-    else if(name.size() == 4){
-      data.append(renderText(name.data(String::Latin1), item));
-    }
-    else {
-      debug("MP4: Unknown item name \"" + name + "\"");
-    }
+    data.append(d->factory->renderItem(name, item));
   }
   data = renderAtom("ilst", data);
 

--- a/taglib/mp4/mp4tag.h
+++ b/taglib/mp4/mp4tag.h
@@ -37,13 +37,15 @@
 
 namespace TagLib {
   namespace MP4 {
-    using ItemMap = TagLib::Map<String, Item>;
+
+    class ItemFactory;
 
     class TAGLIB_EXPORT Tag: public TagLib::Tag
     {
     public:
         Tag();
-        Tag(TagLib::File *file, Atoms *atoms);
+        Tag(TagLib::File *file, Atoms *atoms,
+            const ItemFactory *factory = nullptr);
         ~Tag() override;
         Tag(const Tag &) = delete;
         Tag &operator=(const Tag &) = delete;
@@ -114,36 +116,9 @@ namespace TagLib {
         void setTextItem(const String &key, const String &value);
 
     private:
-        AtomDataList parseData2(const Atom *atom, int expectedFlags = -1,
-                                bool freeForm = false);
-        ByteVectorList parseData(const Atom *atom, int expectedFlags = -1,
-                                 bool freeForm = false);
-        void parseText(const Atom *atom, int expectedFlags = 1);
-        void parseFreeForm(const Atom *atom);
-        void parseInt(const Atom *atom);
-        void parseByte(const Atom *atom);
-        void parseUInt(const Atom *atom);
-        void parseLongLong(const Atom *atom);
-        void parseGnre(const Atom *atom);
-        void parseIntPair(const Atom *atom);
-        void parseBool(const Atom *atom);
-        void parseCovr(const Atom *atom);
-
         ByteVector padIlst(const ByteVector &data, int length = -1) const;
         ByteVector renderAtom(const ByteVector &name, const ByteVector &data) const;
-        ByteVector renderData(const ByteVector &name, int flags,
-                              const ByteVectorList &data) const;
-        ByteVector renderText(const ByteVector &name, const Item &item,
-                              int flags = TypeUTF8) const;
-        ByteVector renderFreeForm(const String &name, const Item &item) const;
-        ByteVector renderBool(const ByteVector &name, const Item &item) const;
-        ByteVector renderInt(const ByteVector &name, const Item &item) const;
-        ByteVector renderByte(const ByteVector &name, const Item &item) const;
-        ByteVector renderUInt(const ByteVector &name, const Item &item) const;
-        ByteVector renderLongLong(const ByteVector &name, const Item &item) const;
-        ByteVector renderIntPair(const ByteVector &name, const Item &item) const;
-        ByteVector renderIntPairNoTrailing(const ByteVector &name, const Item &item) const;
-        ByteVector renderCovr(const ByteVector &name, const Item &item) const;
+
 
         void updateParents(const AtomList &path, offset_t delta, int ignore = 0);
         void updateOffsets(offset_t delta, offset_t offset);

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -748,6 +748,12 @@ public:
           .insert("tsti", ItemHandlerType::Int)
           .insert("tstt", ItemHandlerType::Text);
       }
+
+      Map<ByteVector, String> namePropertyMap() const override
+      {
+        return MP4::ItemFactory::namePropertyMap()
+          .insert("tsti", "TESTINTEGER");
+      }
     };
 
     CustomItemFactory factory;
@@ -810,6 +816,24 @@ public:
       CPPUNIT_ASSERT_EQUAL(80, tag->item("rate").toInt());
       CPPUNIT_ASSERT_EQUAL(1540934238LL, tag->item("plID").toLongLong());
       CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(2), tag->item("rtng").toByte());
+      PropertyMap properties = tag->properties();
+      CPPUNIT_ASSERT_EQUAL(StringList("123"), properties.value("TESTINTEGER"));
+      CPPUNIT_ASSERT_EQUAL(StringList("2/10"), properties.value("TRACKNUMBER"));
+      properties["TESTINTEGER"] = StringList("456");
+      tag->setProperties(properties);
+      f.save();
+    }
+    {
+      MP4::File f(copy.fileName().c_str(),
+                  true, MP4::Properties::Average, &factory);
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.hasMP4Tag());
+      MP4::Tag *tag = f.tag();
+      MP4::Item item = tag->item("tsti");
+      CPPUNIT_ASSERT(item.isValid());
+      CPPUNIT_ASSERT_EQUAL(456, item.toInt());
+      PropertyMap properties = tag->properties();
+      CPPUNIT_ASSERT_EQUAL(StringList("456"), properties.value("TESTINTEGER"));
     }
   }
 };


### PR DESCRIPTION
Refactored the _mp4tag.cpp_ code to extract an `MP4::ItemFactory`, which lets the client add new atom types in the same way as with `ID3v2::FrameFactory` for ID3v2 tags.

A custom item factory adding support for a "tsti" integer atom and a "tstt" text atom can be implemented like this:
```
class CustomItemFactory : public MP4::ItemFactory {
protected:
  NameHandlerMap nameHandlerMap() const override
  {
    return MP4::ItemFactory::nameHandlerMap()
      .insert("tsti", ItemHandlerType::Int)
      .insert("tstt", ItemHandlerType::Text);
  }
};
```
