### PR TITLE
Fix extensibility of ID3v2 FrameFactory

### DIFF
--- a/taglib/dsdiff/dsdifffile.cpp
+++ b/taglib/dsdiff/dsdifffile.cpp
@@ -166,7 +166,7 @@ TagLib::Tag *DSDIFF::File::tag() const
 
 ID3v2::Tag *DSDIFF::File::ID3v2Tag(bool create) const
 {
-  return d->tag.access<ID3v2::Tag>(ID3v2Index, create);
+  return d->tag.access<ID3v2::Tag>(ID3v2Index, create, d->ID3v2FrameFactory);
 }
 
 bool DSDIFF::File::hasID3v2Tag() const
@@ -294,7 +294,7 @@ void DSDIFF::File::strip(int tags)
     removeChildChunk("ID3 ", PROPChunk);
     removeChildChunk("id3 ", PROPChunk);
     d->hasID3v2 = false;
-    d->tag.set(ID3v2Index, new ID3v2::Tag);
+    d->tag.set(ID3v2Index, new ID3v2::Tag(nullptr, 0, d->ID3v2FrameFactory));
     d->duplicateID3V2chunkIndex = -1;
     d->isID3InPropChunk = false;
     d->id3v2TagChunkID.setData("ID3 ");
@@ -909,7 +909,7 @@ void DSDIFF::File::read(bool readProperties, Properties::ReadStyle propertiesSty
   }
 
   if(!ID3v2Tag()) {
-    d->tag.access<ID3v2::Tag>(ID3v2Index, true);
+    d->tag.access<ID3v2::Tag>(ID3v2Index, true, d->ID3v2FrameFactory);
     // By default, ID3 chunk is at root level
     d->isID3InPropChunk = false;
     d->hasID3v2 = false;

--- a/taglib/dsf/dsffile.cpp
+++ b/taglib/dsf/dsffile.cpp
@@ -225,7 +225,7 @@ void DSF::File::read(AudioProperties::ReadStyle propertiesStyle)
 
   // A metadata offset of 0 indicates the absence of an ID3v2 tag
   if(d->metadataOffset == 0)
-    d->tag = std::make_unique<ID3v2::Tag>();
+    d->tag = std::make_unique<ID3v2::Tag>(nullptr, 0, d->ID3v2FrameFactory);
   else
     d->tag = std::make_unique<ID3v2::Tag>(this, d->metadataOffset,
                                           d->ID3v2FrameFactory);

--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -360,7 +360,8 @@ bool FLAC::File::save()
 
 ID3v2::Tag *FLAC::File::ID3v2Tag(bool create)
 {
-  return d->tag.access<ID3v2::Tag>(FlacID3v2Index, create);
+  return d->tag.access<ID3v2::Tag>(FlacID3v2Index, create,
+                                   d->ID3v2FrameFactory);
 }
 
 ID3v1::Tag *FLAC::File::ID3v1Tag(bool create)

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -135,6 +135,21 @@ namespace
     std::pair("DJ-MIX", "DJMIXER"),
     std::pair("MIX", "MIXER"),
   };
+
+  constexpr std::array txxxFrameTranslation {
+    std::pair("MUSICBRAINZ ALBUM ID", "MUSICBRAINZ_ALBUMID"),
+    std::pair("MUSICBRAINZ ARTIST ID", "MUSICBRAINZ_ARTISTID"),
+    std::pair("MUSICBRAINZ ALBUM ARTIST ID", "MUSICBRAINZ_ALBUMARTISTID"),
+    std::pair("MUSICBRAINZ ALBUM RELEASE COUNTRY", "RELEASECOUNTRY"),
+    std::pair("MUSICBRAINZ ALBUM STATUS", "RELEASESTATUS"),
+    std::pair("MUSICBRAINZ ALBUM TYPE", "RELEASETYPE"),
+    std::pair("MUSICBRAINZ RELEASE GROUP ID", "MUSICBRAINZ_RELEASEGROUPID"),
+    std::pair("MUSICBRAINZ RELEASE TRACK ID", "MUSICBRAINZ_RELEASETRACKID"),
+    std::pair("MUSICBRAINZ WORK ID", "MUSICBRAINZ_WORKID"),
+    std::pair("ACOUSTID ID", "ACOUSTID_ID"),
+    std::pair("ACOUSTID FINGERPRINT", "ACOUSTID_FINGERPRINT"),
+    std::pair("MUSICIP PUID", "MUSICIP_PUID"),
+  };
 }  // namespace
 
 const KeyConversionMap &TextIdentificationFrame::involvedPeopleMap() // static
@@ -430,6 +445,26 @@ UserTextIdentificationFrame *UserTextIdentificationFrame::find(
       return f;
   }
   return nullptr;
+}
+
+String UserTextIdentificationFrame::txxxToKey(const String &description)
+{
+  const String d = description.upper();
+  for(const auto &[o, t] : txxxFrameTranslation) {
+    if(d == o)
+      return t;
+  }
+  return d;
+}
+
+String UserTextIdentificationFrame::keyToTXXX(const String &s)
+{
+  const String key = s.upper();
+  for(const auto &[o, t] : txxxFrameTranslation) {
+    if(key == t)
+      return o;
+  }
+  return s;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.h
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.h
@@ -301,6 +301,16 @@ namespace TagLib {
        */
       static UserTextIdentificationFrame *find(Tag *tag, const String &description);
 
+      /*!
+       * Returns an appropriate TXXX frame description for the given free-form tag key.
+       */
+      static String keyToTXXX(const String &);
+
+      /*!
+       * Returns a free-form tag name for the given ID3 frame description.
+       */
+      static String txxxToKey(const String &);
+
     private:
       UserTextIdentificationFrame(const ByteVector &data, Header *h);
       UserTextIdentificationFrame(const TextIdentificationFrame &);

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -54,18 +54,9 @@ namespace TagLib {
     class TAGLIB_EXPORT Frame
     {
       friend class Tag;
-      friend class FrameFactory;
-      friend class TableOfContentsFrame;
-      friend class ChapterFrame;
 
     public:
-
-      /*!
-       * Creates a textual frame which corresponds to a single key in the PropertyMap
-       * interface. These are all (User)TextIdentificationFrames except TIPL and TMCL,
-       * all (User)URLLinkFrames, CommentsFrames, and UnsynchronizedLyricsFrame.
-       */
-      static Frame *createTextualFrame(const String &key, const StringList &values);
+      class Header;
 
       /*!
        * Destroys this Frame instance.
@@ -123,10 +114,27 @@ namespace TagLib {
       ByteVector render() const;
 
       /*!
+       * Returns a pointer to the frame header.
+       */
+      Header *header() const;
+
+      /*!
        * Returns the text delimiter that is used between fields for the string
        * type \a t.
        */
       static ByteVector textDelimiter(String::Type t);
+
+      /*!
+       * Returns an appropriate ID3 frame ID for the given free-form tag key. This method
+       * will return an empty ByteVector if no specialized translation is found.
+       */
+      static ByteVector keyToFrameID(const String &);
+
+      /*!
+       * Returns a free-form tag name for the given ID3 frame ID. Note that this does not work
+       * for general frame IDs such as TXXX or WXXX; in such a case an empty string is returned.
+       */
+      static String frameIDToKey(const ByteVector &);
 
       /*!
        * The string with which an instrument name is prefixed to build a key in a PropertyMap;
@@ -151,8 +159,6 @@ namespace TagLib {
       static const String urlPrefix;
 
     protected:
-      class Header;
-
       /*!
        * Constructs an ID3v2 frame using \a data to read the header information.
        * All other processing of \a data should be handled in a subclass.
@@ -169,11 +175,6 @@ namespace TagLib {
        * header will be deleted when the frame is destroyed.
        */
       Frame(Header *h);
-
-      /*!
-       * Returns a pointer to the frame header.
-       */
-      Header *header() const;
 
       /*!
        * Sets the header to \a h.  If \a deleteCurrent is true, this will free
@@ -235,28 +236,6 @@ namespace TagLib {
        * ID.
        */
       virtual PropertyMap asProperties() const;
-
-      /*!
-       * Returns an appropriate ID3 frame ID for the given free-form tag key. This method
-       * will return an empty ByteVector if no specialized translation is found.
-       */
-      static ByteVector keyToFrameID(const String &);
-
-      /*!
-       * Returns a free-form tag name for the given ID3 frame ID. Note that this does not work
-       * for general frame IDs such as TXXX or WXXX; in such a case an empty string is returned.
-       */
-      static String frameIDToKey(const ByteVector &);
-
-      /*!
-       * Returns an appropriate TXXX frame description for the given free-form tag key.
-       */
-      static String keyToTXXX(const String &);
-
-      /*!
-       * Returns a free-form tag name for the given ID3 frame description.
-       */
-      static String txxxToKey(const String &);
 
       /*!
        * This helper function splits the PropertyMap \a original into three ProperytMaps

--- a/taglib/mpeg/id3v2/id3v2framefactory.h
+++ b/taglib/mpeg/id3v2/id3v2framefactory.h
@@ -50,10 +50,11 @@ namespace TagLib {
      * factory to be the default factory in ID3v2::Tag constructor you can
      * implement behavior that will allow for new ID3v2::Frame subclasses (also
      * provided by you) to be used.
+     * See \c testFrameFactory() in \e tests/test_mpeg.cpp for an example.
      *
      * This implements both <i>abstract factory</i> and <i>singleton</i> patterns
      * of which more information is available on the web and in software design
-     * textbooks (Notably <i>Design Patters</i>).
+     * textbooks (Notably <i>Design Patterns</i>).
      *
      * \note You do not need to use this factory to create new frames to add to
      * an ID3v2::Tag.  You can instantiate frame subclasses directly (with new)
@@ -75,6 +76,14 @@ namespace TagLib {
        * ID3v2::Header instance.
        */
       virtual Frame *createFrame(const ByteVector &data, const Header *tagHeader) const;
+
+      /*!
+       * Creates a textual frame which corresponds to a single key in the
+       * PropertyMap interface.  TIPL and TMCL do not belong to this category
+       * and are thus handled explicitly in the Frame class.
+       */
+      virtual Frame *createFrameForProperty(
+        const String &key, const StringList &values) const;
 
       /*!
        * After a tag has been read, this tries to rebuild some of them
@@ -104,6 +113,18 @@ namespace TagLib {
        * \see defaultTextEncoding()
        */
       void setDefaultTextEncoding(String::Type encoding);
+
+      /*!
+       * Returns true if defaultTextEncoding() is used.
+       * The default text encoding is used when setDefaultTextEncoding() has
+       * been called.  In this case, reimplementations of FrameFactory should
+       * use defaultTextEncoding() on the frames (having a text encoding field)
+       * they create.
+       *
+       * \see defaultTextEncoding()
+       * \see setDefaultTextEncoding()
+       */
+      bool isUsingDefaultTextEncoding() const;
 
     protected:
       /*!

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -443,13 +443,13 @@ PropertyMap ID3v2::Tag::setProperties(const PropertyMap &origProps)
   // now create remaining frames:
   // start with the involved people list (TIPL)
   if(!tiplProperties.isEmpty())
-      addFrame(TextIdentificationFrame::createTIPLFrame(tiplProperties));
+    addFrame(TextIdentificationFrame::createTIPLFrame(tiplProperties));
   // proceed with the musician credit list (TMCL)
   if(!tmclProperties.isEmpty())
-      addFrame(TextIdentificationFrame::createTMCLFrame(tmclProperties));
+    addFrame(TextIdentificationFrame::createTMCLFrame(tmclProperties));
   // now create the "one key per frame" frames
   for(const auto &[tag, frames] : std::as_const(properties))
-      addFrame(Frame::createTextualFrame(tag, frames));
+    addFrame(d->factory->createFrameForProperty(tag, frames));
   return PropertyMap(); // ID3 implements the complete PropertyMap interface, so an empty map is returned
 }
 

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -297,7 +297,7 @@ bool MPEG::File::save(int tags, StripTags strip, ID3v2::Version version, Duplica
 
 ID3v2::Tag *MPEG::File::ID3v2Tag(bool create)
 {
-  return d->tag.access<ID3v2::Tag>(ID3v2Index, create);
+  return d->tag.access<ID3v2::Tag>(ID3v2Index, create, d->ID3v2FrameFactory);
 }
 
 ID3v1::Tag *MPEG::File::ID3v1Tag(bool create)

--- a/taglib/riff/aiff/aifffile.cpp
+++ b/taglib/riff/aiff/aifffile.cpp
@@ -167,7 +167,7 @@ void RIFF::AIFF::File::read(bool readProperties)
   }
 
   if(!d->tag)
-    d->tag = std::make_unique<ID3v2::Tag>();
+    d->tag = std::make_unique<ID3v2::Tag>(nullptr, 0, d->ID3v2FrameFactory);
 
   if(readProperties)
     d->properties = std::make_unique<Properties>(this, Properties::Average);

--- a/taglib/riff/aiff/aifffile.h
+++ b/taglib/riff/aiff/aifffile.h
@@ -62,9 +62,13 @@ namespace TagLib {
          * file's audio properties will also be read.
          *
          * \note In the current implementation, \a propertiesStyle is ignored.
+         *
+         * If this file contains an ID3v2 tag, the frames will be created using
+         * \a frameFactory (default if null).
          */
         File(FileName file, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             Properties::ReadStyle propertiesStyle = Properties::Average,
+             ID3v2::FrameFactory *frameFactory = nullptr);
 
         /*!
          * Constructs an AIFF file from \a stream.  If \a readProperties is true the
@@ -74,9 +78,13 @@ namespace TagLib {
          * responsible for deleting it after the File object.
          *
          * \note In the current implementation, \a propertiesStyle is ignored.
+         *
+         * If this file contains an ID3v2 tag, the frames will be created using
+         * \a frameFactory (default if null).
          */
         File(IOStream *stream, bool readProperties = true,
-             Properties::ReadStyle propertiesStyle = Properties::Average);
+             Properties::ReadStyle propertiesStyle = Properties::Average,
+             ID3v2::FrameFactory *frameFactory = nullptr);
 
         /*!
          * Destroys this instance of the File.

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -113,7 +113,7 @@ void RIFF::WAV::File::strip(TagTypes tags)
   removeTagChunks(tags);
 
   if(tags & ID3v2)
-    d->tag.set(ID3v2Index, new ID3v2::Tag());
+    d->tag.set(ID3v2Index, new ID3v2::Tag(nullptr, 0, d->ID3v2FrameFactory));
 
   if(tags & Info)
     d->tag.set(InfoIndex, new RIFF::Info::Tag());
@@ -224,7 +224,7 @@ void RIFF::WAV::File::read(bool readProperties)
   }
 
   if(!d->tag[ID3v2Index])
-    d->tag.set(ID3v2Index, new ID3v2::Tag());
+    d->tag.set(ID3v2Index, new ID3v2::Tag(nullptr, 0, d->ID3v2FrameFactory));
 
   if(!d->tag[InfoIndex])
     d->tag.set(InfoIndex, new RIFF::Info::Tag());

--- a/taglib/tagunion.h
+++ b/taglib/tagunion.h
@@ -92,6 +92,15 @@ namespace TagLib {
       return static_cast<T *>(tag(index));
     }
 
+    template <class T, class F> T *access(int index, bool create, const F *factory)
+    {
+      if(!create || tag(index))
+        return static_cast<T *>(tag(index));
+
+      set(index, new T(nullptr, 0, factory));
+      return static_cast<T *>(tag(index));
+    }
+
   private:
     TagUnion(const Tag &);
     TagUnion &operator=(const Tag &);

--- a/taglib/trueaudio/trueaudiofile.cpp
+++ b/taglib/trueaudio/trueaudiofile.cpp
@@ -217,7 +217,8 @@ ID3v1::Tag *TrueAudio::File::ID3v1Tag(bool create)
 
 ID3v2::Tag *TrueAudio::File::ID3v2Tag(bool create)
 {
-  return d->tag.access<ID3v2::Tag>(TrueAudioID3v2Index, create);
+  return d->tag.access<ID3v2::Tag>(TrueAudioID3v2Index, create,
+                                   d->ID3v2FrameFactory);
 }
 
 void TrueAudio::File::strip(int tags)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ SET(test_runner_SRCS
   test_fileref.cpp
   test_id3v1.cpp
   test_id3v2.cpp
+  test_id3v2framefactory.cpp
   test_xiphcomment.cpp
   test_aiff.cpp
   test_riff.cpp

--- a/tests/test_id3v2framefactory.cpp
+++ b/tests/test_id3v2framefactory.cpp
@@ -1,0 +1,379 @@
+/***************************************************************************
+    copyright            : (C) 2023 by Urs Fleisch
+    email                : ufleisch@users.sourceforge.net
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#include <functional>
+#include <memory>
+
+#include "tbytevector.h"
+#include "tpropertymap.h"
+#include "mpegfile.h"
+#include "flacfile.h"
+#include "trueaudiofile.h"
+#include "wavfile.h"
+#include "aifffile.h"
+#include "dsffile.h"
+#include "dsdifffile.h"
+#include "id3v2tag.h"
+#include "id3v2frame.h"
+#include "id3v2framefactory.h"
+#include <cppunit/extensions/HelperMacros.h>
+#include "utils.h"
+
+using namespace std;
+using namespace TagLib;
+
+namespace
+{
+
+  class CustomFrameFactory;
+
+  // Just a silly example of a custom frame holding a number.
+  class CustomFrame : public ID3v2::Frame
+  {
+    friend class CustomFrameFactory;
+  public:
+    explicit CustomFrame(unsigned int value = 0)
+      : Frame("CUST"), m_value(value) {}
+    CustomFrame(const CustomFrame &) = delete;
+    CustomFrame &operator=(const CustomFrame &) = delete;
+    ~CustomFrame() override = default;
+    String toString() const override { return String::number(m_value); }
+    PropertyMap asProperties() const override {
+      return SimplePropertyMap{{"CUSTOM", StringList(String::number(m_value))}};
+    }
+    unsigned int value() const { return m_value; }
+
+  protected:
+    void parseFields(const ByteVector &data) override {
+      m_value = data.toUInt();
+    }
+    ByteVector renderFields() const override {
+      return ByteVector::fromUInt(m_value);
+    }
+
+  private:
+    CustomFrame(const ByteVector &data, Header *h) : Frame(h) {
+      parseFields(fieldData(data));
+    }
+    unsigned int m_value;
+  };
+
+  // Example for frame factory with support for CustomFrame.
+  class CustomFrameFactory : public ID3v2::FrameFactory {
+  public:
+    ID3v2::Frame *createFrameForProperty(
+        const String &key, const StringList &values) const override {
+      if(key == "CUSTOM") {
+        return new CustomFrame(!values.isEmpty() ? values.front().toInt() : 0);
+      }
+      return ID3v2::FrameFactory::createFrameForProperty(key, values);
+    }
+
+  protected:
+    ID3v2::Frame *createFrame(const ByteVector &data, ID3v2::Frame::Header *header,
+                        const ID3v2::Header *tagHeader) const override {
+      if(header->frameID() == "CUST") {
+        return new CustomFrame(data, header);
+      }
+      return ID3v2::FrameFactory::createFrame(data, header, tagHeader);
+    }
+  };
+
+}  // namespace
+
+class TestId3v2FrameFactory : public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(TestId3v2FrameFactory);
+  CPPUNIT_TEST(testMPEG);
+  CPPUNIT_TEST(testFLAC);
+  CPPUNIT_TEST(testTrueAudio);
+  CPPUNIT_TEST(testWAV);
+  CPPUNIT_TEST(testAIFF);
+  CPPUNIT_TEST(testDSF);
+  CPPUNIT_TEST(testDSDIFF);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+
+  void testGenericFrameFactory(
+    const char *fileName,
+    function<File *(const char *)> createFileWithDefaultFactory,
+    function<File *(const char *, ID3v2::FrameFactory *factory)> createFileWithFactory,
+    function<bool(const File &)> hasID3v2Tag,
+    function<ID3v2::Tag *(File &)> getID3v2Tag,
+    function<bool(File &)> stripAllTags)
+  {
+    CustomFrameFactory factory;
+
+    {
+      auto f = std::unique_ptr<File>(createFileWithDefaultFactory(fileName));
+      CPPUNIT_ASSERT(f->isValid());
+      ID3v2::Tag *tag = getID3v2Tag(*f);
+      const ID3v2::FrameList frames = tag->frameList();
+      for(const auto &frame : frames) {
+        tag->removeFrame(frame, false);
+      }
+      tag->setArtist("An artist");
+      tag->setTitle("A title");
+      f->save();
+    }
+    {
+      auto f = std::unique_ptr<File>(createFileWithDefaultFactory(fileName));
+      CPPUNIT_ASSERT(f->isValid());
+      CPPUNIT_ASSERT(hasID3v2Tag(*f));
+      ID3v2::Tag *tag = getID3v2Tag(*f);
+      tag->addFrame(new CustomFrame(1234567890));
+      f->save();
+    }
+    {
+      auto f = std::unique_ptr<File>(createFileWithDefaultFactory(fileName));
+      CPPUNIT_ASSERT(f->isValid());
+      CPPUNIT_ASSERT(hasID3v2Tag(*f));
+      ID3v2::Tag *tag = getID3v2Tag(*f);
+      const auto &frames = tag->frameList("CUST");
+      CPPUNIT_ASSERT(!frames.isEmpty());
+      // Without a specialized FrameFactory, you can add custom frames,
+      // but your cannot parse them.
+      CPPUNIT_ASSERT(!dynamic_cast<CustomFrame *>(frames.front()));
+    }
+    {
+      auto f = std::unique_ptr<File>(createFileWithFactory(fileName, &factory));
+      CPPUNIT_ASSERT(f->isValid());
+      CPPUNIT_ASSERT(hasID3v2Tag(*f));
+      ID3v2::Tag *tag = getID3v2Tag(*f);
+      const auto &frames = tag->frameList("CUST");
+      CPPUNIT_ASSERT(!frames.isEmpty());
+      auto frame = dynamic_cast<CustomFrame *>(frames.front());
+      CPPUNIT_ASSERT(frame);
+      CPPUNIT_ASSERT_EQUAL(1234567890U, frame->value());
+      PropertyMap properties = tag->properties();
+      CPPUNIT_ASSERT_EQUAL(StringList("1234567890"),
+        properties.value("CUSTOM"));
+      CPPUNIT_ASSERT_EQUAL(StringList("An artist"),
+        properties.value("ARTIST"));
+      CPPUNIT_ASSERT_EQUAL(StringList("A title"),
+        properties.value("TITLE"));
+      stripAllTags(*f);
+    }
+    {
+      auto f = std::unique_ptr<File>(createFileWithFactory(fileName, &factory));
+      CPPUNIT_ASSERT(f->isValid());
+      CPPUNIT_ASSERT(!hasID3v2Tag(*f));
+      ID3v2::Tag *tag = getID3v2Tag(*f);
+      PropertyMap properties = tag->properties();
+      CPPUNIT_ASSERT(properties.isEmpty());
+      properties.insert("CUSTOM", StringList("305419896"));
+      tag->setProperties(properties);
+      f->save();
+    }
+    {
+      auto f = std::unique_ptr<File>(createFileWithFactory(fileName, &factory));
+      CPPUNIT_ASSERT(f->isValid());
+      CPPUNIT_ASSERT(hasID3v2Tag(*f));
+      ID3v2::Tag *tag = getID3v2Tag(*f);
+      PropertyMap properties = tag->properties();
+      CPPUNIT_ASSERT_EQUAL(StringList("305419896"), properties.value("CUSTOM"));
+      const auto &frames = tag->frameList("CUST");
+      CPPUNIT_ASSERT(!frames.isEmpty());
+      auto frame = dynamic_cast<CustomFrame *>(frames.front());
+      CPPUNIT_ASSERT(frame);
+      CPPUNIT_ASSERT_EQUAL(0x12345678U, frame->value());
+    }
+  }
+
+  void testMPEG()
+  {
+    ScopedFileCopy copy("lame_cbr", ".mp3");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+        return new MPEG::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+        return new MPEG::File(fileName, factory);
+      },
+      [](const File &f) {
+        return static_cast<const MPEG::File &>(f).hasID3v2Tag();
+      },
+      [](File &f) {
+        return static_cast<MPEG::File &>(f).ID3v2Tag(true);
+      },
+      [](File &f) {
+        return static_cast<MPEG::File &>(f).strip();
+      }
+    );
+  }
+
+  void testFLAC()
+  {
+    ScopedFileCopy copy("no-tags", ".flac");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+        return new FLAC::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+        return new FLAC::File(fileName, factory);
+      },
+      [](const File &f) {
+        return static_cast<const FLAC::File &>(f).hasID3v2Tag();
+      },
+      [](File &f) {
+        return static_cast<FLAC::File &>(f).ID3v2Tag(true);
+      },
+      [](File &f) {
+        static_cast<FLAC::File &>(f).strip();
+        return f.save();
+      }
+    );
+  }
+
+  void testTrueAudio()
+  {
+    ScopedFileCopy copy("empty", ".tta");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+        return new TrueAudio::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+        return new TrueAudio::File(fileName, factory);
+      },
+      [](const File &f) {
+        return static_cast<const TrueAudio::File &>(f).hasID3v2Tag();
+      },
+      [](File &f) {
+        return static_cast<TrueAudio::File &>(f).ID3v2Tag(true);
+      },
+      [](File &f) {
+        static_cast<TrueAudio::File &>(f).strip();
+        return f.save();
+      }
+    );
+  }
+
+  void testWAV()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+          return new RIFF::WAV::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+          return new RIFF::WAV::File(
+              fileName, true, RIFF::WAV::Properties::Average, factory);
+      },
+      [](const File &f) {
+        return static_cast<const RIFF::WAV::File &>(f).hasID3v2Tag();
+      },
+      [](File &f) {
+          return static_cast<RIFF::WAV::File &>(f).tag();
+      },
+      [](File &f) {
+        static_cast<RIFF::WAV::File &>(f).strip();
+        return true;
+      }
+    );
+  }
+
+  void testAIFF()
+  {
+    ScopedFileCopy copy("empty", ".aiff");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+        return new RIFF::AIFF::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+        return new RIFF::AIFF::File(
+              fileName, true, RIFF::AIFF::Properties::Average, factory);
+      },
+      [](const File &f) {
+        return static_cast<const RIFF::AIFF::File &>(f).hasID3v2Tag();
+      },
+      [](File &f) {
+        return static_cast<RIFF::AIFF::File &>(f).tag();
+      },
+      [](File &f) {
+          f.setProperties({});
+          return f.save();
+      }
+    );
+  }
+
+  void testDSF()
+  {
+    ScopedFileCopy copy("empty10ms", ".dsf");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+        return new DSF::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+        return new DSF::File(
+              fileName, true, DSF::Properties::Average, factory);
+      },
+      [](const File &f) {
+        return !f.tag()->isEmpty();
+      },
+      [](File &f) {
+        return static_cast<DSF::File &>(f).tag();
+      },
+      [](File &f) {
+        f.setProperties({});
+        return f.save();
+      }
+    );
+  }
+
+  void testDSDIFF()
+  {
+    ScopedFileCopy copy("empty10ms", ".dff");
+    testGenericFrameFactory(
+      copy.fileName().c_str(),
+      [](const char *fileName) {
+        return new DSDIFF::File(fileName);
+      },
+      [](const char *fileName, ID3v2::FrameFactory *factory) {
+        return new DSDIFF::File(
+              fileName, true, DSDIFF::Properties::Average, factory);
+      },
+      [](const File &f) {
+        return static_cast<const DSDIFF::File &>(f).hasID3v2Tag();
+      },
+      [](File &f) {
+        return static_cast<DSDIFF::File &>(f).ID3v2Tag(true);
+      },
+      [](File &f) {
+        static_cast<DSDIFF::File &>(f).strip();
+        return true;
+      }
+    );
+  }
+
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(TestId3v2FrameFactory);


### PR DESCRIPTION
Because the main extension point of FrameFactory was using a protected Frame subclass, it was not really possible to implement a custom frame factory. Existing Frame subclasses also show that access to the frame header might be needed when implementing a Frame subclass.