### PR TITLE
Clean up code marked as deprecated or TODO

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -103,31 +103,31 @@ ByteVector APE::Tag::fileIdentifier()
 String APE::Tag::title() const
 {
   Item value = d->itemListMap.value("TITLE");
-  return value.isEmpty() ? String() : value.values().toString();
+  return value.isEmpty() ? String() : joinTagValues(value.values());
 }
 
 String APE::Tag::artist() const
 {
   Item value = d->itemListMap.value("ARTIST");
-  return value.isEmpty() ? String() : value.values().toString();
+  return value.isEmpty() ? String() : joinTagValues(value.values());
 }
 
 String APE::Tag::album() const
 {
   Item value = d->itemListMap.value("ALBUM");
-  return value.isEmpty() ? String() : value.values().toString();
+  return value.isEmpty() ? String() : joinTagValues(value.values());
 }
 
 String APE::Tag::comment() const
 {
   Item value = d->itemListMap.value("COMMENT");
-  return value.isEmpty() ? String() : value.values().toString();
+  return value.isEmpty() ? String() : joinTagValues(value.values());
 }
 
 String APE::Tag::genre() const
 {
   Item value = d->itemListMap.value("GENRE");
-  return value.isEmpty() ? String() : value.values().toString();
+  return value.isEmpty() ? String() : joinTagValues(value.values());
 }
 
 unsigned int APE::Tag::year() const

--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -207,7 +207,7 @@ PropertyMap APE::Tag::properties() const
     // if the item is Binary or Locator, or if the key is an invalid string,
     // add to unsupportedData
     if(item.type() != Item::Text || tagName.isEmpty()) {
-      properties.unsupportedData().append(tag);
+      properties.addUnsupportedData(tag);
     }
     else {
       // Some tags need to be handled specially

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -305,7 +305,7 @@ PropertyMap ASF::Tag::properties() const
       }
     }
     else {
-      props.unsupportedData().append(k);
+      props.addUnsupportedData(k);
     }
   }
   return props;

--- a/taglib/asf/asftag.cpp
+++ b/taglib/asf/asftag.cpp
@@ -34,6 +34,18 @@
 
 using namespace TagLib;
 
+namespace
+{
+  StringList attributeListToStringList(const ASF::AttributeList &attributes)
+  {
+    StringList strs;
+    for(const auto &attribute : attributes) {
+      strs.append(attribute.toString());
+    }
+    return strs;
+  }
+}  // namespace
+
 class ASF::Tag::TagPrivate
 {
 public:
@@ -65,7 +77,8 @@ String ASF::Tag::artist() const
 String ASF::Tag::album() const
 {
   if(d->attributeListMap.contains("WM/AlbumTitle"))
-    return d->attributeListMap["WM/AlbumTitle"][0].toString();
+    return joinTagValues(
+      attributeListToStringList(d->attributeListMap.value("WM/AlbumTitle")));
   return String();
 }
 
@@ -107,7 +120,8 @@ unsigned int ASF::Tag::track() const
 String ASF::Tag::genre() const
 {
   if(d->attributeListMap.contains("WM/Genre"))
-    return d->attributeListMap["WM/Genre"][0].toString();
+    return joinTagValues(
+      attributeListToStringList(d->attributeListMap.value("WM/Genre")));
   return String();
 }
 

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -478,7 +478,7 @@ PropertyMap MP4::Tag::properties() const
       props[key] = value;
     }
     else {
-      props.unsupportedData().append(k);
+      props.addUnsupportedData(k);
     }
   }
   return props;

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
@@ -66,6 +66,11 @@ String AttachedPictureFrame::toString() const
   return d->description.isEmpty() ? s : d->description + " " + s;
 }
 
+StringList AttachedPictureFrame::toStringList() const
+{
+  return {d->description, d->mimeType};
+}
+
 String::Type AttachedPictureFrame::textEncoding() const
 {
   return d->textEncoding;

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.h
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.h
@@ -80,6 +80,11 @@ namespace TagLib {
       String toString() const override;
 
       /*!
+       * Returns a string list containing the description and mime-type.
+       */
+      StringList toStringList() const override;
+
+      /*!
        * Returns the text encoding used for the description.
        *
        * \see setTextEncoding()

--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -209,7 +209,7 @@ PropertyMap ChapterFrame::asProperties() const
 {
   PropertyMap map;
 
-  map.unsupportedData().append(frameID() + String("/") + d->elementID);
+  map.addUnsupportedData(frameID() + String("/") + d->elementID);
 
   return map;
 }

--- a/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
+++ b/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
@@ -76,6 +76,11 @@ String GeneralEncapsulatedObjectFrame::toString() const
   return text;
 }
 
+StringList GeneralEncapsulatedObjectFrame::toStringList() const
+{
+  return {d->description, d->fileName, d->mimeType};
+}
+
 String::Type GeneralEncapsulatedObjectFrame::textEncoding() const
 {
   return d->textEncoding;

--- a/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.h
+++ b/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.h
@@ -83,6 +83,11 @@ namespace TagLib {
       String toString() const override;
 
       /*!
+       * Returns a string list containing the description, file name and mime-type.
+       */
+      StringList toStringList() const override;
+
+      /*!
        * Returns the text encoding used for the description and file name.
        *
        * \see setTextEncoding()

--- a/taglib/mpeg/id3v2/frames/ownershipframe.cpp
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.cpp
@@ -65,6 +65,11 @@ String OwnershipFrame::toString() const
   return "pricePaid=" + d->pricePaid + " datePurchased=" + d->datePurchased + " seller=" + d->seller;
 }
 
+StringList OwnershipFrame::toStringList() const
+{
+  return {d->pricePaid, d->datePurchased, d->seller};
+}
+
 String OwnershipFrame::pricePaid() const
 {
   return d->pricePaid;

--- a/taglib/mpeg/id3v2/frames/ownershipframe.h
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.h
@@ -64,11 +64,16 @@ namespace TagLib {
       OwnershipFrame &operator=(const OwnershipFrame &) = delete;
 
       /*!
-       * Returns the text of this popularimeter.
+       * Returns price paid, date purchased and seller.
        *
        * \see text()
        */
       String toString() const override;
+
+      /*!
+       * Returns price paid, date purchased and seller.
+       */
+      StringList toStringList() const override;
 
       /*!
        * Returns the date purchased.

--- a/taglib/mpeg/id3v2/frames/popularimeterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/popularimeterframe.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "popularimeterframe.h"
+#include "tstringlist.h"
 
 using namespace TagLib;
 using namespace ID3v2;
@@ -58,6 +59,11 @@ PopularimeterFrame::~PopularimeterFrame() = default;
 String PopularimeterFrame::toString() const
 {
   return d->email + " rating=" + String::number(d->rating) + " counter=" + String::number(d->counter);
+}
+
+StringList PopularimeterFrame::toStringList() const
+{
+  return {d->email, String::number(d->rating), String::number(d->counter)};
 }
 
 String PopularimeterFrame::email() const

--- a/taglib/mpeg/id3v2/frames/popularimeterframe.h
+++ b/taglib/mpeg/id3v2/frames/popularimeterframe.h
@@ -72,6 +72,11 @@ namespace TagLib {
       String toString() const override;
 
       /*!
+       * Returns email, rating and counter.
+       */
+      StringList toStringList() const override;
+
+      /*!
        * Returns the email.
        *
        * \see setEmail()

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -236,7 +236,7 @@ PropertyMap TableOfContentsFrame::asProperties() const
 {
   PropertyMap map;
 
-  map.unsupportedData().append(frameID() + String("/") + d->elementID);
+  map.addUnsupportedData(frameID() + String("/") + d->elementID);
 
   return map;
 }

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -50,30 +50,6 @@ public:
   FrameList embeddedFrameList;
 };
 
-namespace {
-
-  // These functions are needed to try to aim for backward compatibility with
-  // an API that previously (unreasonably) required null bytes to be appended
-  // at the end of identifiers explicitly by the API user.
-
-  // BIC: remove these
-
-  ByteVector &strip(ByteVector &b)
-  {
-    if(b.endsWith('\0'))
-      b.resize(b.size() - 1);
-    return b;
-  }
-
-  ByteVectorList &strip(ByteVectorList &l)
-  {
-    for(auto &v : l) {
-      strip(v);
-    }
-    return l;
-  }
-}  // namespace
-
 ////////////////////////////////////////////////////////////////////////////////
 // public methods
 ////////////////////////////////////////////////////////////////////////////////
@@ -93,7 +69,6 @@ TableOfContentsFrame::TableOfContentsFrame(const ByteVector &elementID,
   d(std::make_unique<TableOfContentsFramePrivate>())
 {
   d->elementID = elementID;
-  strip(d->elementID);
   d->childElements = children;
 
   for(const auto &frame : embeddedFrames)
@@ -130,7 +105,6 @@ ByteVectorList TableOfContentsFrame::childElements() const
 void TableOfContentsFrame::setElementID(const ByteVector &eID)
 {
   d->elementID = eID;
-  strip(d->elementID);
 }
 
 void TableOfContentsFrame::setIsTopLevel(const bool &t)
@@ -146,13 +120,11 @@ void TableOfContentsFrame::setIsOrdered(const bool &o)
 void TableOfContentsFrame::setChildElements(const ByteVectorList &l)
 {
   d->childElements = l;
-  strip(d->childElements);
 }
 
 void TableOfContentsFrame::addChildElement(const ByteVector &cE)
 {
   d->childElements.append(cE);
-  strip(d->childElements);
 }
 
 void TableOfContentsFrame::removeChildElement(const ByteVector &cE)

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.h
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.h
@@ -70,8 +70,8 @@ namespace TagLib {
       TableOfContentsFrame &operator=(const TableOfContentsFrame &) = delete;
 
       /*!
-       * Returns the elementID of the frame. Element ID
-       * is a null terminated string, however it's not human-readable.
+       * Returns the elementID of the frame.
+       * Element ID is not intended to be human readable.
        *
        * \see setElementID()
        */
@@ -109,8 +109,7 @@ namespace TagLib {
       ByteVectorList childElements() const;
 
       /*!
-       * Sets the elementID of the frame to \a eID. If \a eID isn't
-       * null terminated, a null char is appended automatically.
+       * Sets the elementID of the frame to \a eID.
        *
        * \see elementID()
        */

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -391,13 +391,6 @@ String UserTextIdentificationFrame::description() const
     : String();
 }
 
-StringList UserTextIdentificationFrame::fieldList() const
-{
-  // TODO: remove this function
-
-  return TextIdentificationFrame::fieldList();
-}
-
 void UserTextIdentificationFrame::setText(const String &text)
 {
   if(description().isEmpty())

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -110,6 +110,11 @@ String TextIdentificationFrame::toString() const
   return d->fieldList.toString();
 }
 
+StringList TextIdentificationFrame::toStringList() const
+{
+  return d->fieldList;
+}
+
 StringList TextIdentificationFrame::fieldList() const
 {
   return d->fieldList;

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -171,7 +171,7 @@ PropertyMap TextIdentificationFrame::asProperties() const
   PropertyMap map;
   String tagName = frameIDToKey(frameID());
   if(tagName.isEmpty()) {
-    map.unsupportedData().append(frameID());
+    map.addUnsupportedData(frameID());
     return map;
   }
   StringList values = fieldList();
@@ -304,7 +304,7 @@ PropertyMap TextIdentificationFrame::makeTIPLProperties() const
   PropertyMap map;
   if(fieldList().size() % 2 != 0){
     // according to the ID3 spec, TIPL must contain an even number of entries
-    map.unsupportedData().append(frameID());
+    map.addUnsupportedData(frameID());
     return map;
   }
   const StringList l = fieldList();
@@ -317,7 +317,7 @@ PropertyMap TextIdentificationFrame::makeTIPLProperties() const
     else {
       // invalid involved role -> mark whole frame as unsupported in order to be consistent with writing
       map.clear();
-      map.unsupportedData().append(frameID());
+      map.addUnsupportedData(frameID());
       return map;
     }
   }
@@ -329,7 +329,7 @@ PropertyMap TextIdentificationFrame::makeTMCLProperties() const
   PropertyMap map;
   if(fieldList().size() % 2 != 0){
     // according to the ID3 spec, TMCL must contain an even number of entries
-    map.unsupportedData().append(frameID());
+    map.addUnsupportedData(frameID());
     return map;
   }
   const StringList l = fieldList();
@@ -338,7 +338,7 @@ PropertyMap TextIdentificationFrame::makeTMCLProperties() const
     if(instrument.isEmpty()) {
       // instrument is not a valid key -> frame unsupported
       map.clear();
-      map.unsupportedData().append(frameID());
+      map.addUnsupportedData(frameID());
       return map;
     }
     map.insert(L"PERFORMER:" + instrument, (++it)->split(","));

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.h
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.h
@@ -276,7 +276,6 @@ namespace TagLib {
        */
       void setDescription(const String &s);
 
-      StringList fieldList() const;
       void setText(const String &text) override;
       void setText(const StringList &fields);
 

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.h
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.h
@@ -162,6 +162,7 @@ namespace TagLib {
 
       void setText(const String &s) override;
       String toString() const override;
+      StringList toStringList() const override;
 
       /*!
        * Returns the text encoding that will be used in rendering this frame.

--- a/taglib/mpeg/id3v2/frames/uniquefileidentifierframe.cpp
+++ b/taglib/mpeg/id3v2/frames/uniquefileidentifierframe.cpp
@@ -95,7 +95,7 @@ PropertyMap UniqueFileIdentifierFrame::asProperties() const
     map.insert("MUSICBRAINZ_TRACKID", String(d->identifier));
   }
   else {
-    map.unsupportedData().append(frameID() + String("/") + d->owner);
+    map.addUnsupportedData(frameID() + String("/") + d->owner);
   }
   return map;
 }

--- a/taglib/mpeg/id3v2/frames/urllinkframe.cpp
+++ b/taglib/mpeg/id3v2/frames/urllinkframe.cpp
@@ -90,7 +90,7 @@ PropertyMap UrlLinkFrame::asProperties() const
   PropertyMap map;
   if(key.isEmpty())
     // unknown W*** frame - this normally shouldn't happen
-    map.unsupportedData().append(frameID());
+    map.addUnsupportedData(frameID());
   else
     map.insert(key, url());
   return map;

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -122,6 +122,11 @@ void Frame::setText(const String &)
 {
 }
 
+StringList Frame::toStringList() const
+{
+  return toString();
+}
+
 ByteVector Frame::render() const
 {
   ByteVector fieldData = renderFields();

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -364,12 +364,12 @@ PropertyMap Frame::asProperties() const
 {
   if(dynamic_cast< const UnknownFrame *>(this)) {
     PropertyMap m;
-    m.unsupportedData().append("UNKNOWN/" + frameID());
+    m.addUnsupportedData("UNKNOWN/" + frameID());
     return m;
   }
   const ByteVector &id = frameID();
   PropertyMap m;
-  m.unsupportedData().append(id);
+  m.addUnsupportedData(id);
   return m;
 }
 

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -109,6 +109,14 @@ namespace TagLib {
       virtual String toString() const = 0;
 
       /*!
+       * This returns the textual representation of the data in the frame.
+       * Subclasses can reimplement this method to provide a string list
+       * representation of the frame's data.  The default implementation
+       * returns the single string representation from toString().
+       */
+      virtual StringList toStringList() const;
+
+      /*!
        * Render the frame back to its binary format in a ByteVector.
        */
       ByteVector render() const;

--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -121,21 +121,21 @@ ID3v2::Tag::~Tag() = default;
 String ID3v2::Tag::title() const
 {
   if(!d->frameListMap["TIT2"].isEmpty())
-    return d->frameListMap["TIT2"].front()->toString();
+    return joinTagValues(d->frameListMap["TIT2"].front()->toStringList());
   return String();
 }
 
 String ID3v2::Tag::artist() const
 {
   if(!d->frameListMap["TPE1"].isEmpty())
-    return d->frameListMap["TPE1"].front()->toString();
+    return joinTagValues(d->frameListMap["TPE1"].front()->toStringList());
   return String();
 }
 
 String ID3v2::Tag::album() const
 {
   if(!d->frameListMap["TALB"].isEmpty())
-    return d->frameListMap["TALB"].front()->toString();
+    return joinTagValues(d->frameListMap["TALB"].front()->toStringList());
   return String();
 }
 
@@ -157,10 +157,6 @@ String ID3v2::Tag::comment() const
 
 String ID3v2::Tag::genre() const
 {
-  // TODO: In the next major version (TagLib 2.0) a list of multiple genres
-  // should be separated by " / " instead of " ".  For the moment to keep
-  // the behavior the same as released versions it is being left with " ".
-
   const FrameList &tconFrames = d->frameListMap["TCON"];
   if(tconFrames.isEmpty())
   {
@@ -196,7 +192,7 @@ String ID3v2::Tag::genre() const
       genres.append(field);
   }
 
-  return genres.toString();
+  return joinTagValues(genres);
 }
 
 unsigned int ID3v2::Tag::year() const

--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -66,19 +66,19 @@ Ogg::XiphComment::~XiphComment() = default;
 String Ogg::XiphComment::title() const
 {
   StringList value = d->fieldListMap.value("TITLE");
-  return value.isEmpty() ? String() : value.toString();
+  return value.isEmpty() ? String() : joinTagValues(value);
 }
 
 String Ogg::XiphComment::artist() const
 {
   StringList value = d->fieldListMap.value("ARTIST");
-  return value.isEmpty() ? String() : value.toString();
+  return value.isEmpty() ? String() : joinTagValues(value);
 }
 
 String Ogg::XiphComment::album() const
 {
   StringList value = d->fieldListMap.value("ALBUM");
-  return value.isEmpty() ? String() : value.toString();
+  return value.isEmpty() ? String() : joinTagValues(value);
 }
 
 String Ogg::XiphComment::comment() const
@@ -86,13 +86,13 @@ String Ogg::XiphComment::comment() const
   StringList value = d->fieldListMap.value("DESCRIPTION");
   if(!value.isEmpty()) {
     d->commentField = "DESCRIPTION";
-    return value.toString();
+    return joinTagValues(value);
   }
 
   value = d->fieldListMap.value("COMMENT");
   if(!value.isEmpty()) {
     d->commentField = "COMMENT";
-    return value.toString();
+    return joinTagValues(value);
   }
 
   return String();
@@ -101,7 +101,7 @@ String Ogg::XiphComment::comment() const
 String Ogg::XiphComment::genre() const
 {
   StringList value = d->fieldListMap.value("GENRE");
-  return value.isEmpty() ? String() : value.toString();
+  return value.isEmpty() ? String() : joinTagValues(value);
 }
 
 unsigned int Ogg::XiphComment::year() const

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -93,9 +93,9 @@ RIFF::WAV::File::File(IOStream *stream, bool readProperties, Properties::ReadSty
 
 RIFF::WAV::File::~File() = default;
 
-ID3v2::Tag *RIFF::WAV::File::tag() const
+TagLib::Tag *RIFF::WAV::File::tag() const
 {
-  return ID3v2Tag();
+  return &d->tag;
 }
 
 ID3v2::Tag *RIFF::WAV::File::ID3v2Tag() const

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -107,12 +107,10 @@ namespace TagLib {
         File &operator=(const File &) = delete;
 
         /*!
-         * Returns the ID3v2 Tag for this file.
-         *
-         * \note This method does not return all the tags for this file for
-         * backward compatibility.  Will be fixed in TagLib 2.0.
+         * Returns the tag for this file.  This will be an RIFF INFO tag, an
+         * ID3v2 tag or a combination of the two.
          */
-        ID3v2::Tag *tag() const override;
+        TagLib::Tag *tag() const override;
 
         /*!
          * Returns the ID3v2 Tag for this file.

--- a/taglib/tag.cpp
+++ b/taglib/tag.cpp
@@ -189,3 +189,8 @@ void Tag::duplicate(const Tag *source, Tag *target, bool overwrite) // static
       target->setTrack(source->track());
   }
 }
+
+String Tag::joinTagValues(const StringList &l)
+{
+  return l.toString(" / ");
+}

--- a/taglib/tag.h
+++ b/taglib/tag.h
@@ -227,6 +227,14 @@ namespace TagLib {
      */
     static void duplicate(const Tag *source, Tag *target, bool overwrite = true);
 
+    /*!
+     * Join the \a values of a tag to a single string separated by " / ".
+     * If the tag implementation can have multiple values for a basic tag
+     * (e.g. artist), they can be combined to a single string for the basic
+     * tag getters (e.g. artist()).
+     */
+    static String joinTagValues(const StringList &values);
+
   protected:
     /*!
      * Construct a Tag.  This is protected since tags should only be instantiated

--- a/taglib/toolkit/tpropertymap.cpp
+++ b/taglib/toolkit/tpropertymap.cpp
@@ -179,9 +179,14 @@ void PropertyMap::removeEmpty()
   *this = m;
 }
 
-StringList &PropertyMap::unsupportedData()
+const StringList &PropertyMap::unsupportedData() const
 {
   return d->unsupported;
+}
+
+void PropertyMap::addUnsupportedData(const String &key)
+{
+  d->unsupported.append(key);
 }
 
 PropertyMap &PropertyMap::operator=(const PropertyMap &other)

--- a/taglib/toolkit/tpropertymap.h
+++ b/taglib/toolkit/tpropertymap.h
@@ -236,11 +236,15 @@ namespace TagLib {
      * You can remove items from the returned list, which tells TagLib to remove
      * those unsupported elements if you call File::setProperties() with the
      * same PropertyMap as argument.
-     *
-     * \deprecated
      */
-    // TODO: Returning mutable references to internal data structures is a bad idea.
-    StringList &unsupportedData();
+    const StringList &unsupportedData() const;
+
+    /*!
+     * Add property \a key to list of unsupported data.
+     *
+     * \see unsupportedData()
+     */
+    void addUnsupportedData(const String &key);
 
     /*!
      * Removes all entries which have an empty value list.

--- a/tests/test_apetag.cpp
+++ b/tests/test_apetag.cpp
@@ -80,7 +80,7 @@ public:
     tag.setProperties(dict);
     CPPUNIT_ASSERT_EQUAL(String("17"), tag.itemListMap()["TRACK"].values()[0]);
     CPPUNIT_ASSERT_EQUAL(2u, tag.itemListMap()["ARTIST"].values().size());
-    CPPUNIT_ASSERT_EQUAL(String("artist 1 artist 2"), tag.artist());
+    CPPUNIT_ASSERT_EQUAL(String("artist 1 / artist 2"), tag.artist());
     CPPUNIT_ASSERT_EQUAL(17u, tag.track());
     const APE::Item &textItem = tag.itemListMap()["TRACK"];
     CPPUNIT_ASSERT_EQUAL(APE::Item::Text, textItem.type());

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -957,7 +957,7 @@ public:
 
     ID3v2::Tag tag;
     tag.addFrame(frame);
-    CPPUNIT_ASSERT_EQUAL(String("Disco Eurodisco"), tag.genre());
+    CPPUNIT_ASSERT_EQUAL(String("Disco / Eurodisco"), tag.genre());
   }
 
   void testUpdateGenre23_3()
@@ -980,7 +980,7 @@ public:
 
     ID3v2::Tag tag;
     tag.addFrame(frame);
-    CPPUNIT_ASSERT_EQUAL(String("Metal Black Metal Viking Metal"), tag.genre());
+    CPPUNIT_ASSERT_EQUAL(String("Metal / Black Metal / Viking Metal"), tag.genre());
   }
 
   void testUpdateGenre24()
@@ -1000,7 +1000,7 @@ public:
 
     ID3v2::Tag tag;
     tag.addFrame(frame);
-    CPPUNIT_ASSERT_EQUAL(String("R&B Eurodisco"), tag.genre());
+    CPPUNIT_ASSERT_EQUAL(String("R&B / Eurodisco"), tag.genre());
   }
 
   void testUpdateDate22()

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -1533,11 +1533,11 @@ public:
   {
     ID3v2::Header header;
     ID3v2::TableOfContentsFrame f(&header, "CTOC");
-    f.setElementID(ByteVector("\x54\x00", 2));
+    f.setElementID("T");
     f.setIsTopLevel(false);
     f.setIsOrdered(true);
-    f.addChildElement(ByteVector("\x43\x00", 2));
-    f.addChildElement(ByteVector("\x44\x00", 2));
+    f.addChildElement("C");
+    f.addChildElement("D");
     auto eF = new ID3v2::TextIdentificationFrame("TIT2");
     eF->setText("TC1");
     f.addEmbeddedFrame(eF);

--- a/tests/test_id3v2framefactory.cpp
+++ b/tests/test_id3v2framefactory.cpp
@@ -290,7 +290,7 @@ public:
         return static_cast<const RIFF::WAV::File &>(f).hasID3v2Tag();
       },
       [](File &f) {
-          return static_cast<RIFF::WAV::File &>(f).tag();
+          return static_cast<RIFF::WAV::File &>(f).ID3v2Tag();
       },
       [](File &f) {
         static_cast<RIFF::WAV::File &>(f).strip();

--- a/tests/test_tag_c.cpp
+++ b/tests/test_tag_c.cpp
@@ -181,7 +181,7 @@ public:
 
       TagLib_Tag *tag = taglib_file_tag(file);
       CPPUNIT_ASSERT_EQUAL("Quod Libet Test Data"s, std::string(taglib_tag_album(tag)));
-      CPPUNIT_ASSERT_EQUAL("piman jzig"s, std::string(taglib_tag_artist(tag)));
+      CPPUNIT_ASSERT_EQUAL("piman / jzig"s, std::string(taglib_tag_artist(tag)));
       CPPUNIT_ASSERT_EQUAL("Silence"s, std::string(taglib_tag_genre(tag)));
       CPPUNIT_ASSERT_EQUAL(""s, std::string(taglib_tag_comment(tag)));
       CPPUNIT_ASSERT_EQUAL("Silence"s, std::string(taglib_tag_title(tag)));

--- a/tests/test_xiphcomment.cpp
+++ b/tests/test_xiphcomment.cpp
@@ -144,15 +144,15 @@ public:
     f.tag()->addField("TITLE", "Title3", false);
     f.tag()->addField("artist", "Artist1");
     f.tag()->addField("ARTIST", "Artist2", false);
-    CPPUNIT_ASSERT_EQUAL(String("Title1 Title1 Title2 Title3"), f.tag()->title());
-    CPPUNIT_ASSERT_EQUAL(String("Artist1 Artist2"), f.tag()->artist());
+    CPPUNIT_ASSERT_EQUAL(String("Title1 / Title1 / Title2 / Title3"), f.tag()->title());
+    CPPUNIT_ASSERT_EQUAL(String("Artist1 / Artist2"), f.tag()->artist());
 
     f.tag()->removeFields("title", "Title1");
-    CPPUNIT_ASSERT_EQUAL(String("Title2 Title3"), f.tag()->title());
-    CPPUNIT_ASSERT_EQUAL(String("Artist1 Artist2"), f.tag()->artist());
+    CPPUNIT_ASSERT_EQUAL(String("Title2 / Title3"), f.tag()->title());
+    CPPUNIT_ASSERT_EQUAL(String("Artist1 / Artist2"), f.tag()->artist());
 
     f.tag()->removeFields("Artist");
-    CPPUNIT_ASSERT_EQUAL(String("Title2 Title3"), f.tag()->title());
+    CPPUNIT_ASSERT_EQUAL(String("Title2 / Title3"), f.tag()->title());
     CPPUNIT_ASSERT(f.tag()->artist().isEmpty());
 
     f.tag()->removeAllFields();


### PR DESCRIPTION
This includes some behavioral changes:
- Basic tag getters now use " / " instead of " " as the separator if multiple values are present (e.g. multiple genres).
- The IDs for the table of contents frame must not be terminated with a null characters.

There are also some changes in the API, which should not break typical client code:
- The list reference returned by `PropertyMap::unsupportedData()` is now `const`.
- `RIFF::WAV::File::tag()` returns now the `TagUnion` and no longer the `ID3v2::Tag`.