### PR TITLE
Tolerate trailing garbage in M4A files (#1186)

### DIFF
--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -602,10 +602,7 @@ public:
   void testFuzzedFile()
   {
     MP4::File f(TEST_FILE_PATH_C("infloop.m4a"));
-    // The file has an invalid atom length of 2775 in the last atom
-    // ("free", offset 0xc521, 00000ad7 66726565), whereas the remaining file
-    // length is 2727 bytes, therefore the file is now considered invalid.
-    CPPUNIT_ASSERT(!f.isValid());
+    CPPUNIT_ASSERT(f.isValid());
   }
 
   void testRepeatedSave()


### PR DESCRIPTION
If an M4A file contains trailing garbage (e.g. an APE tag at the end of the file), it was considered invalid since [e21640b]. It is important to make sure that atoms which affect modifications written by TagLib are valid, otherwise the file might be damaged. However, in cases where invalid atoms do not affect modifications (which are only done inside the root level "moov" and "moof" containers), they can be safely ignored.

This commit allows trailing garbage in M4A files as it is also accepted in MP3, WAV and DSF files.