### PR TITLE
Use offset_t in XM::File::save()

### DIFF
--- a/taglib/xm/xmfile.cpp
+++ b/taglib/xm/xmfile.cpp
@@ -417,7 +417,7 @@ bool XM::File::save()
   if(!readU16L(patternCount) || !readU16L(instrumentCount))
     return false;
 
-  long pos = 60 + headerSize; // should be long long in taglib2.
+  offset_t pos = 60 + headerSize;
 
   // need to read patterns again in order to seek to the instruments:
   for(unsigned short i = 0; i < patternCount; ++ i) {


### PR DESCRIPTION
@ufleisch this may or may not be beneficial. I'm not sure how many XM files with sizes this large are floating around, but I don't think this fix alone will get TagLib working for them.