### PR TITLE
Apply VISIBILITY_HIDDEN also to C++ files

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -362,6 +362,7 @@ set_target_properties(tag PROPERTIES
 )
 if(VISIBILITY_HIDDEN)
   set_target_properties(tag PROPERTIES C_VISIBILITY_PRESET hidden)
+  set_target_properties(tag PROPERTIES CXX_VISIBILITY_PRESET hidden)
 endif()
 
 if(BUILD_FRAMEWORK)


### PR DESCRIPTION
It was only used for C files, thereby making symbols of internal classes like TagUnion visible.