### PR TITLE
Make classes with destructor as only virtual member non-virtual 

### DIFF
--- a/taglib/ape/apefooter.h
+++ b/taglib/ape/apefooter.h
@@ -59,7 +59,7 @@ namespace TagLib {
       /*!
        * Destroys the footer.
        */
-      virtual ~Footer();
+      ~Footer();
 
       Footer(const Footer &) = delete;
       Footer &operator=(const Footer &) = delete;

--- a/taglib/ape/apeitem.h
+++ b/taglib/ape/apeitem.h
@@ -75,7 +75,7 @@ namespace TagLib {
       /*!
        * Destroys the item.
        */
-      virtual ~Item();
+      ~Item();
 
       /*!
        * Copies the contents of \a item into this item.

--- a/taglib/asf/asfattribute.h
+++ b/taglib/asf/asfattribute.h
@@ -121,7 +121,7 @@ namespace TagLib
       /*!
        * Destroys the attribute.
        */
-      virtual ~Attribute();
+      ~Attribute();
 
       /*!
        * Returns type of the value.

--- a/taglib/asf/asfpicture.h
+++ b/taglib/asf/asfpicture.h
@@ -68,7 +68,7 @@ namespace TagLib
       /*!
        * Destroys the picture.
        */
-      virtual ~Picture();
+      ~Picture();
 
       /*!
        * Copies the contents of \a other into this picture.

--- a/taglib/mp4/mp4coverart.h
+++ b/taglib/mp4/mp4coverart.h
@@ -48,7 +48,7 @@ namespace TagLib {
       };
 
       CoverArt(Format format, const ByteVector &data);
-      virtual ~CoverArt();
+      ~CoverArt();
 
       CoverArt(const CoverArt &item);
 

--- a/taglib/mp4/mp4item.h
+++ b/taglib/mp4/mp4item.h
@@ -52,7 +52,7 @@ namespace TagLib {
        */
       void swap(Item &item) noexcept;
 
-      virtual ~Item();
+      ~Item();
 
       Item(int value);
       Item(unsigned char value);

--- a/taglib/mpeg/id3v2/id3v2extendedheader.h
+++ b/taglib/mpeg/id3v2/id3v2extendedheader.h
@@ -56,7 +56,7 @@ namespace TagLib {
       /*!
        * Destroys the extended header.
        */
-      virtual ~ExtendedHeader();
+      ~ExtendedHeader();
 
       ExtendedHeader(const ExtendedHeader &) = delete;
       ExtendedHeader &operator=(const ExtendedHeader &) = delete;

--- a/taglib/mpeg/id3v2/id3v2footer.h
+++ b/taglib/mpeg/id3v2/id3v2footer.h
@@ -57,7 +57,7 @@ namespace TagLib {
       /*!
        * Destroys the footer.
        */
-      virtual ~Footer();
+      ~Footer();
 
       Footer(const Footer &) = delete;
       Footer &operator=(const Footer &) = delete;

--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -92,7 +92,7 @@ const String Frame::urlPrefix("URL:");
 // public members
 ////////////////////////////////////////////////////////////////////////////////
 
-unsigned int Frame::headerSize()
+unsigned int Frame::headerSize() const
 {
   return d->header->size();
 }
@@ -421,7 +421,7 @@ public:
 // public members (Frame::Header)
 ////////////////////////////////////////////////////////////////////////////////
 
-unsigned int Frame::Header::size()
+unsigned int Frame::Header::size() const
 {
   switch(d->version) {
   case 0:

--- a/taglib/mpeg/id3v2/id3v2frame.h
+++ b/taglib/mpeg/id3v2/id3v2frame.h
@@ -80,7 +80,7 @@ namespace TagLib {
       /*!
        * Returns the size of the frame header
        */
-      unsigned int headerSize();
+      unsigned int headerSize() const;
 
       /*!
        * Sets the data that will be used as the frame.  Since the length is not
@@ -350,7 +350,7 @@ namespace TagLib {
       /*!
        * Returns the size of the frame header in bytes.
        */
-      unsigned int size();
+      unsigned int size() const;
 
       /*!
        * Returns true if the flag for tag alter preservation is set.

--- a/taglib/mpeg/id3v2/id3v2header.h
+++ b/taglib/mpeg/id3v2/id3v2header.h
@@ -62,7 +62,7 @@ namespace TagLib {
       /*!
        * Destroys the header.
        */
-      virtual ~Header();
+      ~Header();
 
       Header(const Header &) = delete;
       Header &operator=(const Header &) = delete;

--- a/taglib/mpeg/mpegheader.h
+++ b/taglib/mpeg/mpegheader.h
@@ -67,7 +67,7 @@ namespace TagLib {
       /*!
        * Destroys this Header instance.
        */
-      virtual ~Header();
+      ~Header();
 
       /*!
        * Returns true if the frame is at least an appropriate size and has

--- a/taglib/mpeg/xingheader.h
+++ b/taglib/mpeg/xingheader.h
@@ -82,7 +82,7 @@ namespace TagLib {
       /*!
        * Destroy this XingHeader instance.
        */
-      virtual ~XingHeader();
+      ~XingHeader();
 
       XingHeader(const XingHeader &) = delete;
       XingHeader &operator=(const XingHeader &) = delete;

--- a/taglib/ogg/oggpage.h
+++ b/taglib/ogg/oggpage.h
@@ -57,7 +57,7 @@ namespace TagLib {
        */
       Page(File *file, offset_t pageOffset);
 
-      virtual ~Page();
+      ~Page();
 
       Page(const Page &) = delete;
       Page &operator=(const Page &) = delete;

--- a/taglib/ogg/oggpageheader.h
+++ b/taglib/ogg/oggpageheader.h
@@ -57,7 +57,7 @@ namespace TagLib {
       /*!
        * Deletes this instance of the PageHeader.
        */
-      virtual ~PageHeader();
+      ~PageHeader();
 
       PageHeader(const PageHeader &) = delete;
       PageHeader &operator=(const PageHeader &) = delete;

--- a/tests/test_sizes.cpp
+++ b/tests/test_sizes.cpp
@@ -149,13 +149,13 @@ public:
         // $ grep kind=\"class\" index.xml | sed -E -e 's/(.*<name>|<\/name>.*)//g'
 
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::APE::File));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::APE::Footer));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::APE::Item));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::APE::Footer));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::APE::Item));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::APE::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::APE::Tag));
-        CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ASF::Attribute));
+        CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::ASF::Attribute));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ASF::File));
-        CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ASF::Picture));
+        CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::ASF::Picture));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ASF::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ASF::Tag));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::AudioProperties));
@@ -185,12 +185,12 @@ public:
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ID3v2::ChapterFrame));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ID3v2::CommentsFrame));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ID3v2::EventTimingCodesFrame));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::ID3v2::ExtendedHeader));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::ID3v2::Footer));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::ID3v2::ExtendedHeader));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::ID3v2::Footer));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::ID3v2::Frame));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::ID3v2::FrameFactory));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ID3v2::GeneralEncapsulatedObjectFrame));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::ID3v2::Header));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::ID3v2::Header));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::ID3v2::Latin1StringHandler));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ID3v2::OwnershipFrame));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::ID3v2::PodcastFrame));
@@ -211,18 +211,18 @@ public:
         CPPUNIT_ASSERT_EQUAL(classSize(2, true), sizeof(TagLib::IT::File));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::IT::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::List<int>));
-        CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MP4::CoverArt));
+        CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::MP4::CoverArt));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MP4::File));
-        CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MP4::Item));
+        CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::MP4::Item));
         CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::MP4::ItemFactory));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MP4::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MP4::Tag));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MPC::File));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MPC::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MPEG::File));
-        CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MPEG::Header));
+        CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::MPEG::Header));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::MPEG::Properties));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::MPEG::XingHeader));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::MPEG::XingHeader));
         CPPUNIT_ASSERT_EQUAL(classSize(1, false), sizeof(TagLib::Map<int, int>));
         CPPUNIT_ASSERT_EQUAL(classSize(2, true), sizeof(TagLib::Mod::File));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::Mod::FileBase));
@@ -232,8 +232,8 @@ public:
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::Ogg::File));
         CPPUNIT_ASSERT_EQUAL(classSize(2, true), sizeof(TagLib::Ogg::Opus::File));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::Ogg::Opus::Properties));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::Ogg::Page));
-        CPPUNIT_ASSERT_EQUAL(classSize(0, true), sizeof(TagLib::Ogg::PageHeader));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::Ogg::Page));
+        CPPUNIT_ASSERT_EQUAL(classSize(0, false), sizeof(TagLib::Ogg::PageHeader));
         CPPUNIT_ASSERT_EQUAL(classSize(2, true), sizeof(TagLib::Ogg::Speex::File));
         CPPUNIT_ASSERT_EQUAL(classSize(1, true), sizeof(TagLib::Ogg::Speex::Properties));
         CPPUNIT_ASSERT_EQUAL(classSize(2, true), sizeof(TagLib::Ogg::Vorbis::File));


### PR DESCRIPTION
Please have a look at these changes affecting the ABI of TagLib 2.0. Do you agree that these classes do not have to be virtual?