### PR TITLE
tag_c set properties use utf-8 encoding, 

### DIFF
--- a/bindings/c/tag_c.h
+++ b/bindings/c/tag_c.h
@@ -356,6 +356,19 @@ TAGLIB_C_EXPORT void taglib_property_set_append(TagLib_File *file, const char *p
  */
 TAGLIB_C_EXPORT char** taglib_property_keys(const TagLib_File *file);
 
+typedef struct {
+  unsigned int len;
+  char **value;
+} TagLib_Strings;
+
+/*!
+ * Get the keys of the property map.
+ * 
+ * It same as taglib_property_keys, but the return value with lenth, for Rust convert it to UTF8 String.
+ * It must be freed by the client using taglib_property_free().
+ */
+TAGLIB_C_EXPORT TagLib_Strings taglib_property_keys_strings(const TagLib_File *file);
+
 /*!
  * Get value(s) of property \a prop.
  *
@@ -363,6 +376,14 @@ TAGLIB_C_EXPORT char** taglib_property_keys(const TagLib_File *file);
  * It must be freed by the client using taglib_property_free().
  */
 TAGLIB_C_EXPORT char** taglib_property_get(const TagLib_File *file, const char *prop);
+
+/*!
+ * Get value(s) of property \a prop.
+ * 
+ * It same as taglib_property_get, but the return value with lenth, for Rust convert it to UTF8 String.
+ * It must be freed by the client using taglib_property_free().
+ */
+TAGLIB_C_EXPORT TagLib_Strings taglib_property_get_strings(const TagLib_File *file, const char *prop);
 
 /*!
  * Frees the NULL terminated array \a props and the C-strings it contains.


### PR DESCRIPTION
Hi,

Thanks for your great works! Now i can edit the tag in .dsf .mp3 .flac ... files via Rust call C lib. This lib use unique key for properties. It is ease for usage.

i just modified the tag_c.h and tag_c.cpp. 

1. fixed tag_c set properties use utf-8 encoding.

2. add 2 function taglib_property_keys_strings, taglib_property_get_strings which logic was same as the function without "_strings", but it return value with len (how many strings). It was facilitated decode from char** to multiple strings by Rust language.

also i just modified the Rust interface (taglib-rust) project and i would pull request to. (now just in my repo address: https://github.com/shenngw1127/taglib-rust/tree/dev)