### PR TITLE
Remove 'using namespace std' to avoid potential conflicts in tagreader.cpp example

### DIFF
--- a/examples/framelist.cpp
+++ b/examples/framelist.cpp
@@ -34,7 +34,6 @@
 #include "id3v1tag.h"
 #include "apetag.h"
 
-using namespace std;
 using namespace TagLib;
 
 int main(int argc, char *argv[])
@@ -44,7 +43,7 @@ int main(int argc, char *argv[])
 
   for(int i = 1; i < argc; i++) {
 
-    cout << "******************** \"" << argv[i] << "\"********************" << endl;
+    std::cout << "******************** \"" << argv[i] << "\"********************" << std::endl;
 
     MPEG::File f(argv[i]);
 
@@ -52,62 +51,62 @@ int main(int argc, char *argv[])
 
     if(id3v2tag) {
 
-      cout << "ID3v2."
+      std::cout << "ID3v2."
            << id3v2tag->header()->majorVersion()
            << "."
            << id3v2tag->header()->revisionNumber()
            << ", "
            << id3v2tag->header()->tagSize()
            << " bytes in tag"
-           << endl;
+           << std::endl;
 
       const auto &frames = id3v2tag->frameList();
       for(auto it = frames.begin(); it != frames.end(); it++) {
-        cout << (*it)->frameID();
+        std::cout << (*it)->frameID();
 
         if(auto comment = dynamic_cast<ID3v2::CommentsFrame *>(*it))
           if(!comment->description().isEmpty())
-            cout << " [" << comment->description() << "]";
+            std::cout << " [" << comment->description() << "]";
 
-        cout << " - \"" << (*it)->toString() << "\"" << endl;
+        std::cout << " - \"" << (*it)->toString() << "\"" << std::endl;
       }
     }
     else
-      cout << "file does not have a valid id3v2 tag" << endl;
+      std::cout << "file does not have a valid id3v2 tag" << std::endl;
 
-    cout << endl << "ID3v1" << endl;
+    std::cout << std::endl << "ID3v1" << std::endl;
 
     ID3v1::Tag *id3v1tag = f.ID3v1Tag();
 
     if(id3v1tag) {
-      cout << "title   - \"" << id3v1tag->title()   << "\"" << endl;
-      cout << "artist  - \"" << id3v1tag->artist()  << "\"" << endl;
-      cout << "album   - \"" << id3v1tag->album()   << "\"" << endl;
-      cout << "year    - \"" << id3v1tag->year()    << "\"" << endl;
-      cout << "comment - \"" << id3v1tag->comment() << "\"" << endl;
-      cout << "track   - \"" << id3v1tag->track()   << "\"" << endl;
-      cout << "genre   - \"" << id3v1tag->genre()   << "\"" << endl;
+      std::cout << "title   - \"" << id3v1tag->title()   << "\"" << std::endl;
+      std::cout << "artist  - \"" << id3v1tag->artist()  << "\"" << std::endl;
+      std::cout << "album   - \"" << id3v1tag->album()   << "\"" << std::endl;
+      std::cout << "year    - \"" << id3v1tag->year()    << "\"" << std::endl;
+      std::cout << "comment - \"" << id3v1tag->comment() << "\"" << std::endl;
+      std::cout << "track   - \"" << id3v1tag->track()   << "\"" << std::endl;
+      std::cout << "genre   - \"" << id3v1tag->genre()   << "\"" << std::endl;
     }
     else
-      cout << "file does not have a valid id3v1 tag" << endl;
+      std::cout << "file does not have a valid id3v1 tag" << std::endl;
 
     APE::Tag *ape = f.APETag();
 
-    cout << endl << "APE" << endl;
+    std::cout << std::endl << "APE" << std::endl;
 
     if(ape) {
       const auto &items = ape->itemListMap();
       for(auto it = items.begin(); it != items.end(); ++it)
       {
         if((*it).second.type() != APE::Item::Binary)
-          cout << (*it).first << " - \"" << (*it).second.toString() << "\"" << endl;
+          std::cout << (*it).first << " - \"" << (*it).second.toString() << "\"" << std::endl;
         else
-          cout << (*it).first << " - Binary data (" << (*it).second.binaryData().size() << " bytes)" << endl;
+          std::cout << (*it).first << " - Binary data (" << (*it).second.binaryData().size() << " bytes)" << std::endl;
       }
     }
     else
-      cout << "file does not have a valid APE tag" << endl;
+      std::cout << "file does not have a valid APE tag" << std::endl;
 
-    cout << endl;
+    std::cout << std::endl;
   }
 }

--- a/examples/tagreader.cpp
+++ b/examples/tagreader.cpp
@@ -32,13 +32,11 @@
 #include "fileref.h"
 #include "tag.h"
 
-using namespace std;
-
 int main(int argc, char *argv[])
 {
   for(int i = 1; i < argc; i++) {
 
-    cout << "******************** \"" << argv[i] << "\" ********************" << endl;
+    std::cout << "******************** \"" << argv[i] << "\" ********************" << std::endl;
 
     TagLib::FileRef f(argv[i]);
 
@@ -46,14 +44,14 @@ int main(int argc, char *argv[])
 
       TagLib::Tag *tag = f.tag();
 
-      cout << "-- TAG (basic) --" << endl;
-      cout << "title   - \"" << tag->title()   << "\"" << endl;
-      cout << "artist  - \"" << tag->artist()  << "\"" << endl;
-      cout << "album   - \"" << tag->album()   << "\"" << endl;
-      cout << "year    - \"" << tag->year()    << "\"" << endl;
-      cout << "comment - \"" << tag->comment() << "\"" << endl;
-      cout << "track   - \"" << tag->track()   << "\"" << endl;
-      cout << "genre   - \"" << tag->genre()   << "\"" << endl;
+      std::cout << "-- TAG (basic) --" << std::endl;
+      std::cout << "title   - \"" << tag->title()   << "\"" << std::endl;
+      std::cout << "artist  - \"" << tag->artist()  << "\"" << std::endl;
+      std::cout << "album   - \"" << tag->album()   << "\"" << std::endl;
+      std::cout << "year    - \"" << tag->year()    << "\"" << std::endl;
+      std::cout << "comment - \"" << tag->comment() << "\"" << std::endl;
+      std::cout << "track   - \"" << tag->track()   << "\"" << std::endl;
+      std::cout << "genre   - \"" << tag->genre()   << "\"" << std::endl;
 
       TagLib::PropertyMap tags = f.properties();
       if(!tags.isEmpty()) {
@@ -64,10 +62,10 @@ int main(int argc, char *argv[])
           }
         }
 
-        cout << "-- TAG (properties) --" << endl;
+        std::cout << "-- TAG (properties) --" << std::endl;
         for(auto j = tags.cbegin(); j != tags.cend(); ++j) {
           for(auto k = j->second.begin(); k != j->second.end(); ++k) {
-            cout << left << std::setfill(' ') << std::setw(longest) << j->first << " - " << '"' << *k << '"' << endl;
+            std::cout << std::left << std::setfill(' ') << std::setw(longest) << j->first << " - " << '"' << *k << '"' << std::endl;
           }
         }
       }
@@ -76,13 +74,13 @@ int main(int argc, char *argv[])
       for(const auto &name : names) {
         const auto& properties = f.complexProperties(name);
         for(const auto &property : properties) {
-          cout << name << ":" << endl;
+          std::cout << name << ":" << std::endl;
           for(const auto &[key, value] : property) {
-            cout << "  " << left << std::setfill(' ') << std::setw(11) << key << " - ";
+            std::cout << "  " << std::left << std::setfill(' ') << std::setw(11) << key << " - ";
             if(value.type() == TagLib::Variant::ByteVector) {
-              cout << "(" << value.value<TagLib::ByteVector>().size() << " bytes)" << endl;
+              std::cout << "(" << value.value<TagLib::ByteVector>().size() << " bytes)" << std::endl;
               /* The picture could be extracted using:
-              ofstream picture;
+              std::ofstream picture;
               TagLib::String fn(argv[i]);
               int slashPos = fn.rfind('/');
               int dotPos = fn.rfind('.');
@@ -96,7 +94,7 @@ int main(int argc, char *argv[])
               */
             }
             else {
-              cout << value << endl;
+              std::cout << value << std::endl;
             }
           }
         }
@@ -110,12 +108,13 @@ int main(int argc, char *argv[])
       int seconds = properties->lengthInSeconds() % 60;
       int minutes = (properties->lengthInSeconds() - seconds) / 60;
 
-      cout << "-- AUDIO --" << endl;
-      cout << "bitrate     - " << properties->bitrate() << endl;
-      cout << "sample rate - " << properties->sampleRate() << endl;
-      cout << "channels    - " << properties->channels() << endl;
-      cout << "length      - " << minutes << ":" << setfill('0') << setw(2) << right << seconds << endl;
+      std::cout << "-- AUDIO --" << std::endl;
+      std::cout << "bitrate     - " << properties->bitrate() << std::endl;
+      std::cout << "sample rate - " << properties->sampleRate() << std::endl;
+      std::cout << "channels    - " << properties->channels() << std::endl;
+      std::cout << "length      - " << minutes << ":" << std::setfill('0') << std::setw(2) << std::right << seconds << std::endl;
     }
   }
   return 0;
 }
+

--- a/examples/tagreader.cpp
+++ b/examples/tagreader.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
                 fn = fn.substr(slashPos + 1, dotPos - slashPos - 1);
               }
               fn += ".jpg";
-              picture.open(fn.toCString(), ios_base::out | ios_base::binary);
+              picture.open(fn.toCString(), std::ios_base::out | std::ios_base::binary);
               picture << value.value<TagLib::ByteVector>();
               picture.close();
               */

--- a/examples/tagwriter.cpp
+++ b/examples/tagwriter.cpp
@@ -39,8 +39,6 @@
 #include "fileref.h"
 #include "tag.h"
 
-using namespace std;
-
 bool isArgument(const char *s)
 {
   return strlen(s) == 2 && s[0] == '-';
@@ -59,22 +57,22 @@ bool isFile(const char *s)
 
 void usage()
 {
-  cout << endl;
-  cout << "Usage: tagwriter <fields> <files>" << endl;
-  cout << endl;
-  cout << "Where the valid fields are:" << endl;
-  cout << "  -t <title>"   << endl;
-  cout << "  -a <artist>"  << endl;
-  cout << "  -A <album>"   << endl;
-  cout << "  -c <comment>" << endl;
-  cout << "  -g <genre>"   << endl;
-  cout << "  -y <year>"    << endl;
-  cout << "  -T <track>"   << endl;
-  cout << "  -R <tagname> <tagvalue>"   << endl;
-  cout << "  -I <tagname> <tagvalue>"   << endl;
-  cout << "  -D <tagname>"   << endl;
-  cout << "  -p <picturefile> <description> (\"\" \"\" to remove)" << endl;
-  cout << endl;
+  std::cout << std::endl;
+  std::cout << "Usage: tagwriter <fields> <files>" << std::endl;
+  std::cout << std::endl;
+  std::cout << "Where the valid fields are:" << std::endl;
+  std::cout << "  -t <title>"   << std::endl;
+  std::cout << "  -a <artist>"  << std::endl;
+  std::cout << "  -A <album>"   << std::endl;
+  std::cout << "  -c <comment>" << std::endl;
+  std::cout << "  -g <genre>"   << std::endl;
+  std::cout << "  -y <year>"    << std::endl;
+  std::cout << "  -T <track>"   << std::endl;
+  std::cout << "  -R <tagname> <tagvalue>"   << std::endl;
+  std::cout << "  -I <tagname> <tagvalue>"   << std::endl;
+  std::cout << "  -D <tagname>"   << std::endl;
+  std::cout << "  -p <picturefile> <description> (\"\" \"\" to remove)" << std::endl;
+  std::cout << std::endl;
 
   exit(1);
 }
@@ -88,10 +86,10 @@ void checkForRejectedProperties(const TagLib::PropertyMap &tags)
         longest = i->first.size();
       }
     }
-    cout << "-- rejected TAGs (properties) --" << endl;
+    std::cout << "-- rejected TAGs (properties) --" << std::endl;
     for(auto i = tags.begin(); i != tags.end(); ++i) {
       for(auto j = i->second.begin(); j != i->second.end(); ++j) {
-        cout << left << std::setw(longest) << i->first << " - " << '"' << *j << '"' << endl;
+        std::cout << std::left << std::setw(longest) << i->first << " - " << '"' << *j << '"' << std::endl;
       }
     }
   }
@@ -177,12 +175,12 @@ int main(int argc, char *argv[])
             numArgsConsumed = 3;
             if(!value.isEmpty()) {
               if(!isFile(value.toCString())) {
-                cout << value.toCString() << " not found." << endl;
+                std::cout << value.toCString() << " not found." << std::endl;
                 return 1;
               }
-              ifstream picture;
-              picture.open(value.toCString(), ios::in | ios::binary);
-              stringstream buffer;
+              std::ifstream picture;
+              picture.open(value.toCString(), std::ios::in | std::ios::binary);
+              std::stringstream buffer;
               buffer << picture.rdbuf();
               picture.close();
               TagLib::String buf(buffer.str());


### PR DESCRIPTION
Although there are no particular problems with global scope in this example, it might cause issues in the future or when users try to copy-paste code from it directly.