### PR TITLE
Support older utfcpp versions with utf8cpp CMake target (#1243)

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -347,7 +347,7 @@ target_include_directories(tag INTERFACE
 )
 
 target_link_libraries(tag
-  PRIVATE $<$<TARGET_EXISTS:utf8::cpp>:utf8::cpp>
+  PRIVATE $<IF:$<TARGET_EXISTS:utf8::cpp>,utf8::cpp,$<$<TARGET_EXISTS:utf8cpp>:utf8cpp>>
           $<$<TARGET_EXISTS:ZLIB::ZLIB>:ZLIB::ZLIB>
 )
 


### PR DESCRIPTION
This affects for example openSUSE Leap 15.6, which installs utfcpp 3.2.1 in its own folder.
Now not only utf8::cpp, but also utf8cpp is supported as a CMake target.