### PR TITLE
Fixed warning about shadowing variable

### DIFF
--- a/taglib/mp4/mp4atom.h
+++ b/taglib/mp4/mp4atom.h
@@ -60,8 +60,8 @@ namespace TagLib {
 
 #ifndef DO_NOT_DOCUMENT
     struct AtomData {
-      AtomData(AtomDataType type, const ByteVector &data) :
-        type(type), data(data) { }
+      AtomData(AtomDataType ptype, const ByteVector &pdata) :
+        type(ptype), data(pdata) { }
       AtomDataType type;
       int locale { 0 };
       ByteVector data;


### PR DESCRIPTION
You can't name parameter and structure field the same as complier frequently complain about this.