### PR TITLE
gcc: fix various Wnrvo warnings

### DIFF
--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -449,10 +449,12 @@ UserTextIdentificationFrame *UserTextIdentificationFrame::find(
 
 String UserTextIdentificationFrame::txxxToKey(const String &description)
 {
-  const String d = description.upper();
+  String d = description.upper();
   for(const auto &[o, t] : txxxFrameTranslation) {
-    if(d == o)
-      return t;
+    if(d == o) {
+      d = t;
+      break;
+    }
   }
   return d;
 }

--- a/taglib/mpeg/id3v2/id3v2synchdata.cpp
+++ b/taglib/mpeg/id3v2/id3v2synchdata.cpp
@@ -72,14 +72,15 @@ ByteVector SynchData::fromUInt(unsigned int value)
 
 ByteVector SynchData::decode(const ByteVector &data)
 {
+  ByteVector result;
   if(data.isEmpty()) {
-    return ByteVector();
+    return result;
   }
 
   // We have this optimized method instead of using ByteVector::replace(),
   // since it makes a great difference when decoding huge unsynchronized frames.
 
-  ByteVector result(data.size());
+  result = ByteVector(data.size());
 
   auto src = data.begin();
   auto dst = result.begin();

--- a/taglib/ogg/oggfile.cpp
+++ b/taglib/ogg/oggfile.cpp
@@ -67,18 +67,21 @@ Ogg::File::~File() = default;
 
 ByteVector Ogg::File::packet(unsigned int i)
 {
+  ByteVector packet;
   // Check to see if we're called setPacket() for this packet since the last
   // save:
 
-  if(d->dirtyPackets.contains(i))
-    return d->dirtyPackets[i];
+  if(d->dirtyPackets.contains(i)) {
+    packet = d->dirtyPackets[i];
+    return packet;
+  }
 
   // If we haven't indexed the page where the packet we're interested in starts,
   // begin reading pages until we have.
 
   if(!readPages(i)) {
     debug("Ogg::File::packet() -- Could not find the requested packet.");
-    return ByteVector();
+    return packet;
   }
 
   // Look for the first page in which the requested packet starts.
@@ -94,7 +97,7 @@ ByteVector Ogg::File::packet(unsigned int i)
   // the pages' packet data until we hit a page that either does not end with the
   // packet that we're fetching or where the last packet is complete.
 
-  ByteVector packet = (*it)->packets()[i - (*it)->firstPacketIndex()];
+  packet = (*it)->packets()[i - (*it)->firstPacketIndex()];
 
   while(nextPacketIndex(*it) <= i) {
     ++it;

--- a/taglib/ogg/oggpage.cpp
+++ b/taglib/ogg/oggpage.cpp
@@ -203,10 +203,12 @@ unsigned int Ogg::Page::packetCount() const
 
 ByteVectorList Ogg::Page::packets() const
 {
-  if(!d->packets.isEmpty())
-    return d->packets;
-
   ByteVectorList l;
+
+  if(!d->packets.isEmpty()) {
+    l = d->packets;
+    return l;
+  }
 
   if(d->file && d->header.isValid()) {
 

--- a/taglib/tagutils.cpp
+++ b/taglib/tagutils.cpp
@@ -92,8 +92,9 @@ offset_t Utils::findAPE(File *file, offset_t id3v1Location)
 ByteVector TagLib::Utils::readHeader(IOStream *stream, unsigned int length,
                                      bool skipID3v2, offset_t *headerOffset)
 {
+  ByteVector header;
   if(!stream || !stream->isOpen())
-    return ByteVector();
+    return header;
 
   const offset_t originalPosition = stream->tell();
   offset_t bufferOffset = 0;
@@ -106,7 +107,7 @@ ByteVector TagLib::Utils::readHeader(IOStream *stream, unsigned int length,
   }
 
   stream->seek(bufferOffset);
-  const ByteVector header = stream->readBlock(length);
+  header = stream->readBlock(length);
   stream->seek(originalPosition);
 
   if(headerOffset)

--- a/taglib/toolkit/tbytevectorstream.cpp
+++ b/taglib/toolkit/tbytevectorstream.cpp
@@ -61,10 +61,11 @@ FileName ByteVectorStream::name() const
 
 ByteVector ByteVectorStream::readBlock(size_t length)
 {
+  ByteVector v;
   if(length == 0)
-    return ByteVector();
+    return v;
 
-  ByteVector v = d->data.mid(static_cast<unsigned int>(d->position),
+  v = d->data.mid(static_cast<unsigned int>(d->position),
                              static_cast<unsigned int>(length));
   d->position += v.size();
   return v;

--- a/taglib/toolkit/tfilestream.cpp
+++ b/taglib/toolkit/tfilestream.cpp
@@ -208,13 +208,14 @@ FileName FileStream::name() const
 
 ByteVector FileStream::readBlock(size_t length)
 {
+  ByteVector buffer;
   if(!isOpen()) {
     debug("FileStream::readBlock() -- invalid file.");
-    return ByteVector();
+    return buffer;
   }
 
   if(length == 0)
-    return ByteVector();
+    return buffer;
 
   if(length > bufferSize()) {
     if(const auto streamLength = static_cast<size_t>(FileStream::length());
@@ -223,7 +224,7 @@ ByteVector FileStream::readBlock(size_t length)
     }
   }
 
-  ByteVector buffer(static_cast<unsigned int>(length));
+  buffer = ByteVector(static_cast<unsigned int>(length));
 
   const size_t count = readFile(d->file, buffer);
   buffer.resize(static_cast<unsigned int>(count));


### PR DESCRIPTION
GCC cannot elide copies with multiple returns.