### PR TITLE
Use fixed width types

### DIFF
--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -140,14 +140,13 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
   ::memcpy(&tmp, v.data() + offset, sizeof(T));
 
   if(swap) {
+    static_assert(sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8, "Byte swap requested for type with invalid size");
     if constexpr (sizeof(T) == 2)
       return Utils::byteSwap(static_cast<uint16_t>(tmp));
     else if constexpr (sizeof(T) == 4)
       return Utils::byteSwap(static_cast<uint32_t>(tmp));
     else if constexpr (sizeof(T) == 8)
       return Utils::byteSwap(static_cast<uint64_t>(tmp));
-    else
-      static_assert(false, "Byte swap requested for type with invalid size");
   }
   return tmp;
 }
@@ -158,14 +157,13 @@ ByteVector fromNumber(T value, bool mostSignificantByteFirst)
   const bool isBigEndian = Utils::systemByteOrder() == Utils::BigEndian;
 
   if(mostSignificantByteFirst != isBigEndian) {
+    static_assert(sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8, "Byte swap requested for type with invalid size");
     if constexpr (sizeof(T) == 2)
       value = Utils::byteSwap(static_cast<uint16_t>(value));
     else if constexpr (sizeof(T) == 4)
       value = Utils::byteSwap(static_cast<uint32_t>(value));
     else if constexpr (sizeof(T) == 8)
       value = Utils::byteSwap(static_cast<uint64_t>(value));
-    else
-      static_assert(false, "Byte swap requested for type with invalid size");
   }
 
   return ByteVector(reinterpret_cast<const char *>(&value), sizeof(T));
@@ -186,14 +184,13 @@ TFloat toFloat(const ByteVector &v, size_t offset)
   ::memcpy(&tmp, v.data() + offset, sizeof(TInt));
 
   if(ENDIAN != Utils::systemByteOrder()) {
+    static_assert(sizeof(TInt) == 2 || sizeof(TInt) == 4 || sizeof(TInt) == 8, "Byte swap requested for type with invalid size");
     if constexpr (sizeof(TInt) == 2)
       tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
     else if constexpr (sizeof(TInt) == 4)
       tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
     else if constexpr (sizeof(TInt) == 8)
       tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
-    else
-      static_assert(false, "Byte swap requested for type with invalid size");
   }
 
   return tmp.f;
@@ -209,14 +206,13 @@ ByteVector fromFloat(TFloat value)
   tmp.f = value;
 
   if(ENDIAN != Utils::systemByteOrder()) {
+    static_assert(sizeof(TInt) == 2 || sizeof(TInt) == 4 || sizeof(TInt) == 8, "Byte swap requested for type with invalid size");
     if constexpr (sizeof(TInt) == 2)
       tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
     else if constexpr (sizeof(TInt) == 4)
       tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
     else if constexpr (sizeof(TInt) == 8)
       tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
-    else
-      static_assert(false, "Byte swap requested for type with invalid size");
   }
 
   return ByteVector(reinterpret_cast<char *>(&tmp), sizeof(TInt));

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -139,15 +139,8 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
   T tmp;
   ::memcpy(&tmp, v.data() + offset, sizeof(T));
 
-  if(swap) {
-    static_assert(sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8, "Byte swap requested for type with invalid size");
-    if constexpr (sizeof(T) == 2)
-      return Utils::byteSwap(static_cast<uint16_t>(tmp));
-    else if constexpr (sizeof(T) == 4)
-      return Utils::byteSwap(static_cast<uint32_t>(tmp));
-    else if constexpr (sizeof(T) == 8)
-      return Utils::byteSwap(static_cast<uint64_t>(tmp));
-  }
+  if(swap)
+    return Utils::byteSwap(tmp);
   return tmp;
 }
 
@@ -156,15 +149,8 @@ ByteVector fromNumber(T value, bool mostSignificantByteFirst)
 {
   const bool isBigEndian = Utils::systemByteOrder() == Utils::BigEndian;
 
-  if(mostSignificantByteFirst != isBigEndian) {
-    static_assert(sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8, "Byte swap requested for type with invalid size");
-    if constexpr (sizeof(T) == 2)
-      value = Utils::byteSwap(static_cast<uint16_t>(value));
-    else if constexpr (sizeof(T) == 4)
-      value = Utils::byteSwap(static_cast<uint32_t>(value));
-    else if constexpr (sizeof(T) == 8)
-      value = Utils::byteSwap(static_cast<uint64_t>(value));
-  }
+  if(mostSignificantByteFirst != isBigEndian)
+    value = Utils::byteSwap(value);
 
   return ByteVector(reinterpret_cast<const char *>(&value), sizeof(T));
 }
@@ -183,15 +169,8 @@ TFloat toFloat(const ByteVector &v, size_t offset)
   } tmp;
   ::memcpy(&tmp, v.data() + offset, sizeof(TInt));
 
-  if(ENDIAN != Utils::systemByteOrder()) {
-    static_assert(sizeof(TInt) == 2 || sizeof(TInt) == 4 || sizeof(TInt) == 8, "Byte swap requested for type with invalid size");
-    if constexpr (sizeof(TInt) == 2)
-      tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
-    else if constexpr (sizeof(TInt) == 4)
-      tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
-    else if constexpr (sizeof(TInt) == 8)
-      tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
-  }
+  if(ENDIAN != Utils::systemByteOrder())
+    tmp.i = Utils::byteSwap(tmp.i);
 
   return tmp.f;
 }
@@ -205,15 +184,8 @@ ByteVector fromFloat(TFloat value)
   } tmp;
   tmp.f = value;
 
-  if(ENDIAN != Utils::systemByteOrder()) {
-    static_assert(sizeof(TInt) == 2 || sizeof(TInt) == 4 || sizeof(TInt) == 8, "Byte swap requested for type with invalid size");
-    if constexpr (sizeof(TInt) == 2)
-      tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
-    else if constexpr (sizeof(TInt) == 4)
-      tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
-    else if constexpr (sizeof(TInt) == 8)
-      tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
-  }
+  if(ENDIAN != Utils::systemByteOrder())
+    tmp.i = Utils::byteSwap(tmp.i);
 
   return ByteVector(reinterpret_cast<char *>(&tmp), sizeof(TInt));
 }
@@ -310,47 +282,47 @@ ByteVector ByteVector::fromCString(const char *s, unsigned int length)
 
 ByteVector ByteVector::fromUInt(unsigned int value, bool mostSignificantByteFirst)
 {
-  return fromNumber<unsigned int>(value, mostSignificantByteFirst);
+  return fromNumber<uint32_t>(value, mostSignificantByteFirst);
 }
 
 ByteVector ByteVector::fromShort(short value, bool mostSignificantByteFirst)
 {
-  return fromNumber<unsigned short>(value, mostSignificantByteFirst);
+  return fromNumber<uint16_t>(value, mostSignificantByteFirst);
 }
 
 ByteVector ByteVector::fromUShort(unsigned short value, bool mostSignificantByteFirst)
 {
-  return fromNumber<unsigned short>(value, mostSignificantByteFirst);
+  return fromNumber<uint16_t>(value, mostSignificantByteFirst);
 }
 
 ByteVector ByteVector::fromLongLong(long long value, bool mostSignificantByteFirst)
 {
-  return fromNumber<unsigned long long>(value, mostSignificantByteFirst);
+  return fromNumber<uint64_t>(value, mostSignificantByteFirst);
 }
 
 ByteVector ByteVector::fromULongLong(unsigned long long value, bool mostSignificantByteFirst)
 {
-  return fromNumber<unsigned long long>(value, mostSignificantByteFirst);
+  return fromNumber<uint64_t>(value, mostSignificantByteFirst);
 }
 
 ByteVector ByteVector::fromFloat32LE(float value)
 {
-  return fromFloat<float, unsigned int, Utils::LittleEndian>(value);
+  return fromFloat<float, uint32_t, Utils::LittleEndian>(value);
 }
 
 ByteVector ByteVector::fromFloat32BE(float value)
 {
-  return fromFloat<float, unsigned int, Utils::BigEndian>(value);
+  return fromFloat<float, uint32_t, Utils::BigEndian>(value);
 }
 
 ByteVector ByteVector::fromFloat64LE(double value)
 {
-  return fromFloat<double, unsigned long long, Utils::LittleEndian>(value);
+  return fromFloat<double, uint64_t, Utils::LittleEndian>(value);
 }
 
 ByteVector ByteVector::fromFloat64BE(double value)
 {
-  return fromFloat<double, unsigned long long, Utils::BigEndian>(value);
+  return fromFloat<double, uint64_t, Utils::BigEndian>(value);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -686,77 +658,77 @@ bool ByteVector::isEmpty() const
 
 unsigned int ByteVector::toUInt(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned int>(*this, 0, mostSignificantByteFirst);
+  return toNumber<uint32_t>(*this, 0, mostSignificantByteFirst);
 }
 
 unsigned int ByteVector::toUInt(unsigned int offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned int>(*this, offset, mostSignificantByteFirst);
+  return toNumber<uint32_t>(*this, offset, mostSignificantByteFirst);
 }
 
 unsigned int ByteVector::toUInt(unsigned int offset, unsigned int length, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned int>(*this, offset, length, mostSignificantByteFirst);
+  return toNumber<uint32_t>(*this, offset, length, mostSignificantByteFirst);
 }
 
 short ByteVector::toShort(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, 0, mostSignificantByteFirst);
+  return toNumber<uint16_t>(*this, 0, mostSignificantByteFirst);
 }
 
 short ByteVector::toShort(unsigned int offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, offset, mostSignificantByteFirst);
+  return toNumber<uint16_t>(*this, offset, mostSignificantByteFirst);
 }
 
 unsigned short ByteVector::toUShort(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, 0, mostSignificantByteFirst);
+  return toNumber<uint16_t>(*this, 0, mostSignificantByteFirst);
 }
 
 unsigned short ByteVector::toUShort(unsigned int offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned short>(*this, offset, mostSignificantByteFirst);
+  return toNumber<uint16_t>(*this, offset, mostSignificantByteFirst);
 }
 
 long long ByteVector::toLongLong(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned long long>(*this, 0, mostSignificantByteFirst);
+  return toNumber<uint64_t>(*this, 0, mostSignificantByteFirst);
 }
 
 long long ByteVector::toLongLong(unsigned int offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned long long>(*this, offset, mostSignificantByteFirst);
+  return toNumber<uint64_t>(*this, offset, mostSignificantByteFirst);
 }
 
 unsigned long long ByteVector::toULongLong(bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned long long>(*this, 0, mostSignificantByteFirst);
+  return toNumber<uint64_t>(*this, 0, mostSignificantByteFirst);
 }
 
 unsigned long long ByteVector::toULongLong(unsigned int offset, bool mostSignificantByteFirst) const
 {
-  return toNumber<unsigned long long>(*this, offset, mostSignificantByteFirst);
+  return toNumber<uint64_t>(*this, offset, mostSignificantByteFirst);
 }
 
 float ByteVector::toFloat32LE(size_t offset) const
 {
-  return toFloat<float, unsigned int, Utils::LittleEndian>(*this, offset);
+  return toFloat<float, uint32_t, Utils::LittleEndian>(*this, offset);
 }
 
 float ByteVector::toFloat32BE(size_t offset) const
 {
-  return toFloat<float, unsigned int, Utils::BigEndian>(*this, offset);
+  return toFloat<float, uint32_t, Utils::BigEndian>(*this, offset);
 }
 
 double ByteVector::toFloat64LE(size_t offset) const
 {
-  return toFloat<double, unsigned long long, Utils::LittleEndian>(*this, offset);
+  return toFloat<double, uint64_t, Utils::LittleEndian>(*this, offset);
 }
 
 double ByteVector::toFloat64BE(size_t offset) const
 {
-  return toFloat<double, unsigned long long, Utils::BigEndian>(*this, offset);
+  return toFloat<double, uint64_t, Utils::BigEndian>(*this, offset);
 }
 
 long double ByteVector::toFloat80LE(size_t offset) const

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -186,11 +186,11 @@ TFloat toFloat(const ByteVector &v, size_t offset)
   ::memcpy(&tmp, v.data() + offset, sizeof(TInt));
 
   if(ENDIAN != Utils::systemByteOrder()) {
-    if constexpr (sizeof(T) == 2)
+    if constexpr (sizeof(TInt) == 2)
       tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
-    else if constexpr (sizeof(T) == 4)
+    else if constexpr (sizeof(TInt) == 4)
       tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
-    else if constexpr (sizeof(T) == 8)
+    else if constexpr (sizeof(TInt) == 8)
       tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
     else
       static_assert(false, "Byte swap requested for type with invalid size");
@@ -209,11 +209,11 @@ ByteVector fromFloat(TFloat value)
   tmp.f = value;
 
   if(ENDIAN != Utils::systemByteOrder()) {
-    if constexpr (sizeof(T) == 2)
+    if constexpr (sizeof(TInt) == 2)
       tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
-    else if constexpr (sizeof(T) == 4)
+    else if constexpr (sizeof(TInt) == 4)
       tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
-    else if constexpr (sizeof(T) == 8)
+    else if constexpr (sizeof(TInt) == 8)
       tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
     else
       static_assert(false, "Byte swap requested for type with invalid size");

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -656,6 +656,13 @@ bool ByteVector::isEmpty() const
   return d->length == 0;
 }
 
+// Sanity checks
+static_assert(sizeof(unsigned short) == sizeof(uint16_t), "unsigned short and uint16_t are different sizes");
+static_assert(sizeof(unsigned int) == sizeof(uint32_t), "unsigned int and uint32_t are different sizes");
+static_assert(sizeof(unsigned long long) == sizeof(uint64_t), "unsigned long long and uint64_t are different sizes");
+static_assert(sizeof(float) == sizeof(uint32_t), "float and uint32_t are different sizes");
+static_assert(sizeof(double) == sizeof(uint64_t), "double and uint64_t are different sizes");
+
 unsigned int ByteVector::toUInt(bool mostSignificantByteFirst) const
 {
   return toNumber<uint32_t>(*this, 0, mostSignificantByteFirst);

--- a/taglib/toolkit/tbytevector.cpp
+++ b/taglib/toolkit/tbytevector.cpp
@@ -139,8 +139,16 @@ T toNumber(const ByteVector &v, size_t offset, bool mostSignificantByteFirst)
   T tmp;
   ::memcpy(&tmp, v.data() + offset, sizeof(T));
 
-  if(swap)
-    return Utils::byteSwap(tmp);
+  if(swap) {
+    if constexpr (sizeof(T) == 2)
+      return Utils::byteSwap(static_cast<uint16_t>(tmp));
+    else if constexpr (sizeof(T) == 4)
+      return Utils::byteSwap(static_cast<uint32_t>(tmp));
+    else if constexpr (sizeof(T) == 8)
+      return Utils::byteSwap(static_cast<uint64_t>(tmp));
+    else
+      static_assert(false, "Byte swap requested for type with invalid size");
+  }
   return tmp;
 }
 
@@ -149,8 +157,16 @@ ByteVector fromNumber(T value, bool mostSignificantByteFirst)
 {
   const bool isBigEndian = Utils::systemByteOrder() == Utils::BigEndian;
 
-  if(mostSignificantByteFirst != isBigEndian)
-    value = Utils::byteSwap(value);
+  if(mostSignificantByteFirst != isBigEndian) {
+    if constexpr (sizeof(T) == 2)
+      value = Utils::byteSwap(static_cast<uint16_t>(value));
+    else if constexpr (sizeof(T) == 4)
+      value = Utils::byteSwap(static_cast<uint32_t>(value));
+    else if constexpr (sizeof(T) == 8)
+      value = Utils::byteSwap(static_cast<uint64_t>(value));
+    else
+      static_assert(false, "Byte swap requested for type with invalid size");
+  }
 
   return ByteVector(reinterpret_cast<const char *>(&value), sizeof(T));
 }
@@ -169,8 +185,16 @@ TFloat toFloat(const ByteVector &v, size_t offset)
   } tmp;
   ::memcpy(&tmp, v.data() + offset, sizeof(TInt));
 
-  if(ENDIAN != Utils::systemByteOrder())
-    tmp.i = Utils::byteSwap(tmp.i);
+  if(ENDIAN != Utils::systemByteOrder()) {
+    if constexpr (sizeof(T) == 2)
+      tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
+    else if constexpr (sizeof(T) == 4)
+      tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
+    else if constexpr (sizeof(T) == 8)
+      tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
+    else
+      static_assert(false, "Byte swap requested for type with invalid size");
+  }
 
   return tmp.f;
 }
@@ -184,8 +208,16 @@ ByteVector fromFloat(TFloat value)
   } tmp;
   tmp.f = value;
 
-  if(ENDIAN != Utils::systemByteOrder())
-    tmp.i = Utils::byteSwap(tmp.i);
+  if(ENDIAN != Utils::systemByteOrder()) {
+    if constexpr (sizeof(T) == 2)
+      tmp.i = Utils::byteSwap(static_cast<uint16_t>(tmp.i));
+    else if constexpr (sizeof(T) == 4)
+      tmp.i = Utils::byteSwap(static_cast<uint32_t>(tmp.i));
+    else if constexpr (sizeof(T) == 8)
+      tmp.i = Utils::byteSwap(static_cast<uint64_t>(tmp.i));
+    else
+      static_assert(false, "Byte swap requested for type with invalid size");
+  }
 
   return ByteVector(reinterpret_cast<char *>(&tmp), sizeof(TInt));
 }

--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -30,6 +30,7 @@
 
 #ifndef DO_NOT_DOCUMENT  // tell Doxygen not to document this header
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdarg>
 #include <cstring>
@@ -60,7 +61,7 @@ namespace TagLib
       /*!
        * Reverses the order of bytes in a 16-bit integer.
        */
-      inline unsigned short byteSwap(unsigned short x)
+      inline uint16_t byteSwap(uint16_t x)
       {
 #if defined(HAVE_GCC_BYTESWAP)
 
@@ -92,7 +93,7 @@ namespace TagLib
       /*!
        * Reverses the order of bytes in a 32-bit integer.
        */
-      inline unsigned int byteSwap(unsigned int x)
+      inline uint32_t byteSwap(uint32_t x)
       {
 #if defined(HAVE_GCC_BYTESWAP)
 
@@ -127,7 +128,7 @@ namespace TagLib
       /*!
        * Reverses the order of bytes in a 64-bit integer.
        */
-      inline unsigned long long byteSwap(unsigned long long x)
+      inline uint64_t byteSwap(uint64_t x)
       {
 #if defined(HAVE_GCC_BYTESWAP)
 


### PR DESCRIPTION
Most 64-bit Linux systems and macOS use LP64 with 64-bit `long` and pointers. Windows is slightly different and uses LLP64. 

This means that on LP64 systems `long` and `long long` are the same size.

As usual cppreference.com has a good page on [Fundamental Types](https://en.cppreference.com/w/cpp/language/types).

The current definition of the `byteSwap` functions use `unsigned short`, `unsigned int` and `unsigned long long` for 16-, 32-, and 64-bit uints.

The definitions I've seen for the various builtin `bswap` functions are defined using fixed with types.  For example [gcc](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html) has the folllwing:

> Built-in Function: uint16_t __builtin_bswap16 (uint16_t x)
> Returns x with the order of the bytes reversed; for example, 0xaabb becomes 0xbbaa. Byte here always means exactly 8 bits.
> 
> Built-in Function: uint32_t __builtin_bswap32 (uint32_t x)
> Similar to __builtin_bswap16, except the argument and return types are 32-bit.
> 
> Built-in Function: uint64_t __builtin_bswap64 (uint64_t x)
> Similar to __builtin_bswap32, except the argument and return types are 64-bit.

And macOS uses something similar for the `OSSwap` functions.


I think it would be great if TagLib followed suit.