### PR TITLE
Support custom temp and tests directories (#1268)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,10 @@ set(TAGLIB_INSTALL_SUFFIX "" CACHE STRING
   "Suffix added to installed files (include directory, libraries, .pc)")
 
 add_definitions(-DHAVE_CONFIG_H)
-set(TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests/")
+set(TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tests/" CACHE STRING
+  "Tests directory, is path to unit test data when 'data' is appended")
+set(TESTS_TMPDIR "" CACHE STRING
+  "Directory for temporary files created during unit tests, system tmpdir is used if undefined")
 
 if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -20,5 +20,6 @@
 #cmakedefine   TRACE_IN_RELEASE 1
 
 #cmakedefine TESTS_DIR "@TESTS_DIR@"
+#cmakedefine TESTS_TMPDIR "@TESTS_TMPDIR@"
 
 #endif

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -54,12 +54,14 @@ inline string copyFile(const string &filename, const string &ext)
 {
   char testFileName[1024];
 
-#ifdef _WIN32
+#ifdef TESTS_TMPDIR
+  snprintf(testFileName, sizeof(testFileName), "%s/taglib-test%s", TESTS_TMPDIR, ext.c_str());
+#elif defined _WIN32
   char tempDir[MAX_PATH + 1];
   GetTempPathA(sizeof(tempDir), tempDir);
   wsprintfA(testFileName, "%s\\taglib-test%s", tempDir, ext.c_str());
 #else
-  snprintf(testFileName, sizeof(testFileName), "/%s/taglib-test%s", P_tmpdir, ext.c_str());
+  snprintf(testFileName, sizeof(testFileName), "%s/taglib-test%s", P_tmpdir, ext.c_str());
 #endif
 
   string sourceFileName = testFilePath(filename) + ext;


### PR DESCRIPTION
The following user-settable values for CMake are supported:

- TESTS_DIR: Tests directory, is path to unit test data when 'data' is appended. Can be used to run the unit tests on a target.
- TESTS_TMPDIR: Directory for temporary files created during unit tests, system tmpdir is used if undefined. Has to be defined on systems without global temporary directory.