### PR TITLE
Convert IPLS to TIPL and TMCL (#1274)

### DIFF
--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -315,7 +315,7 @@ PropertyMap TextIdentificationFrame::makeTIPLProperties() const
   const StringList l = fieldList();
   for(auto it = l.begin(); it != l.end(); ++it) {
     auto found = std::find_if(involvedPeople.begin(), involvedPeople.end(),
-      [=](const auto &person) { return *it == person.first; });
+      [=](const auto &person) { return it->upper() == person.first; });
     if(found != involvedPeople.end()) {
       map.insert(found->second, (++it)->split(","));
     }

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -1265,6 +1265,38 @@ public:
     CPPUNIT_ASSERT_EQUAL(static_cast<ID3v2::UserTextIdentificationFrame *>(nullptr), ID3v2::UserTextIdentificationFrame::find(&tag, "non existing"));
     CPPUNIT_ASSERT_EQUAL(frame10, ID3v2::CommentsFrame::findByDescription(&tag, "iTunNORM"));
     CPPUNIT_ASSERT_EQUAL(static_cast<ID3v2::CommentsFrame *>(nullptr), ID3v2::CommentsFrame::findByDescription(&tag, "non existing"));
+
+    // Check if the allowed TIPL keys are correctly mapped to properties.
+    // These are the keys used by MusicBrainz: arranger, engineer, producer, DJ-mix, mix.
+    // See https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html.
+    // MusicBrainz Picard uses lowercase keys whereas TagLib used uppercase keys.
+    auto frame11 = new ID3v2::TextIdentificationFrame("TIPL");
+    StringList tiplData;
+    tiplData.append("arranger");
+    tiplData.append("an arranger");
+    tiplData.append("ENGINEER");
+    tiplData.append("an engineer");
+    tiplData.append("producer");
+    tiplData.append("a producer");
+    tiplData.append("DJ-mix");
+    tiplData.append("a DJ mixer");
+    tiplData.append("mix");
+    tiplData.append("a mixer");
+    frame11->setText(tiplData);
+    tag.addFrame(frame11);
+
+    properties = tag.properties();
+    CPPUNIT_ASSERT_EQUAL(0u, properties.unsupportedData().size());
+    CPPUNIT_ASSERT(properties.contains("ARRANGER"));
+    CPPUNIT_ASSERT(properties.contains("ENGINEER"));
+    CPPUNIT_ASSERT(properties.contains("PRODUCER"));
+    CPPUNIT_ASSERT(properties.contains("DJMIXER"));
+    CPPUNIT_ASSERT(properties.contains("MIXER"));
+    CPPUNIT_ASSERT_EQUAL(String("an arranger"), properties["ARRANGER"].front());
+    CPPUNIT_ASSERT_EQUAL(String("an engineer"), properties["ENGINEER"].front());
+    CPPUNIT_ASSERT_EQUAL(String("a producer"), properties["PRODUCER"].front());
+    CPPUNIT_ASSERT_EQUAL(String("a DJ mixer"), properties["DJMIXER"].front());
+    CPPUNIT_ASSERT_EQUAL(String("a mixer"), properties["MIXER"].front());
   }
 
   void testPropertiesMovement()

--- a/tests/test_id3v2.cpp
+++ b/tests/test_id3v2.cpp
@@ -1035,7 +1035,7 @@ public:
       tf->setText(StringList().append("Guitar").append("Artist 1").append("Drums").append("Artist 2"));
       foo.ID3v2Tag()->addFrame(tf);
       tf = new ID3v2::TextIdentificationFrame("TIPL", String::Latin1);
-      tf->setText(StringList().append("Producer").append("Artist 3").append("Mastering").append("Artist 4"));
+      tf->setText(StringList().append("Producer").append("Artist 3").append("Engineer").append("Artist 4"));
       foo.ID3v2Tag()->addFrame(tf);
       tf = new ID3v2::TextIdentificationFrame("TCON", String::Latin1);
       tf->setText(StringList().append("51").append("Noise").append("Power Noise"));
@@ -1062,15 +1062,18 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("2012-04-17T12:01"), tf->fieldList().front());
       tf = dynamic_cast<ID3v2::TextIdentificationFrame *>(bar.ID3v2Tag()->frameList("TIPL").front());
       CPPUNIT_ASSERT(tf);
-      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(8), tf->fieldList().size());
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), tf->fieldList().size());
+      CPPUNIT_ASSERT_EQUAL(String("Producer"), tf->fieldList()[0]);
+      CPPUNIT_ASSERT_EQUAL(String("Artist 3"), tf->fieldList()[1]);
+      CPPUNIT_ASSERT_EQUAL(String("Engineer"), tf->fieldList()[2]);
+      CPPUNIT_ASSERT_EQUAL(String("Artist 4"), tf->fieldList()[3]);
+      tf = dynamic_cast<ID3v2::TextIdentificationFrame *>(bar.ID3v2Tag()->frameList("TMCL").front());
+      CPPUNIT_ASSERT(tf);
+      CPPUNIT_ASSERT_EQUAL(static_cast<unsigned int>(4), tf->fieldList().size());
       CPPUNIT_ASSERT_EQUAL(String("Guitar"), tf->fieldList()[0]);
       CPPUNIT_ASSERT_EQUAL(String("Artist 1"), tf->fieldList()[1]);
       CPPUNIT_ASSERT_EQUAL(String("Drums"), tf->fieldList()[2]);
       CPPUNIT_ASSERT_EQUAL(String("Artist 2"), tf->fieldList()[3]);
-      CPPUNIT_ASSERT_EQUAL(String("Producer"), tf->fieldList()[4]);
-      CPPUNIT_ASSERT_EQUAL(String("Artist 3"), tf->fieldList()[5]);
-      CPPUNIT_ASSERT_EQUAL(String("Mastering"), tf->fieldList()[6]);
-      CPPUNIT_ASSERT_EQUAL(String("Artist 4"), tf->fieldList()[7]);
       tf = dynamic_cast<ID3v2::TextIdentificationFrame *>(bar.ID3v2Tag()->frameList("TCON").front());
       CPPUNIT_ASSERT(tf);
       CPPUNIT_ASSERT_EQUAL(3U, tf->fieldList().size());
@@ -1090,7 +1093,7 @@ public:
     }
     {
       const ByteVector expectedId3v23Data(
-            "ID3" "\x03\x00\x00\x00\x00\x09\x49"
+            "ID3" "\x03\x00\x00\x00\x00\x09\x48"
             "TSOA" "\x00\x00\x00\x01\x00\x00\x00"
             "TSOT" "\x00\x00\x00\x01\x00\x00\x00"
             "TSOP" "\x00\x00\x00\x01\x00\x00\x00"
@@ -1098,10 +1101,10 @@ public:
             "TYER" "\x00\x00\x00\x05\x00\x00\x00" "2012"
             "TDAT" "\x00\x00\x00\x05\x00\x00\x00" "1704"
             "TIME" "\x00\x00\x00\x05\x00\x00\x00" "1201"
-            "IPLS" "\x00\x00\x00\x44\x00\x00\x00" "Guitar" "\x00"
+            "IPLS" "\x00\x00\x00\x43\x00\x00\x00" "Guitar" "\x00"
             "Artist 1" "\x00" "Drums" "\x00" "Artist 2" "\x00" "Producer" "\x00"
-            "Artist 3" "\x00" "Mastering" "\x00" "Artist 4"
-            "TCON" "\x00\x00\x00\x14\x00\x00\x00" "(51)(39)Power Noise", 211);
+            "Artist 3" "\x00" "Engineer" "\x00" "Artist 4"
+            "TCON" "\x00\x00\x00\x14\x00\x00\x00" "(51)(39)Power Noise", 210);
       const ByteVector actualId3v23Data =
           PlainFile(newname.c_str()).readBlock(expectedId3v23Data.size());
       CPPUNIT_ASSERT_EQUAL(expectedId3v23Data, actualId3v23Data);


### PR DESCRIPTION
The involvement/involvee pairs which are supported for TIPL properties (ARRANGER, ENGINEER, PRODUCER, DJ-MIX, MIX) are left in the TIPL frame, other pairs are moved to a TMCL frame. This will result in a consistent behavior for both ID3v2.3 and ID3v2.4 tags produced by MusicBrainz Picard.

This will improve compatibility of the property map interface with files tagged by MusicBrainz Picard. Two problems are addressed:

- The involvements supported by the property interface for TIPL frames (ARRANGER, ENGINEER, PRODUCER, DJ-MIX, MIX) are the keys which are used by MusicBrainz (arranger, engineer, producer, DJ-mix, mix), but different in case. Now the check is case insensitive, so that TIPL frames created by MusicBrainz will be accessible via the property interface.
- The IPLS frames from ID3v2.3 tags were internally converted to a TIPL frame, which then contained also the musicians, which should go into a TMCL frame. Therefore, for files with ID3v2.3 tags, the musicians were missing (PERFORMER:instrument properties) and also the other involvements because TIPL frames are only used for the properties if they do not contain other involvements than those listed above.

With these changes, running examples/tagreader on the example file from #1274 will contain the missing properties:

```
-- TAG (basic) --
title   - "Sgt. Pepper's Lonely Hearts Club Band (2018 Mix)"
artist  - "The Beatles"
album   - "Sgt. Pepper's Lonely Hearts Club Band (Super Deluxe Edition)"
year    - "2018"
comment - ""
track   - "1"
genre   - "Art Rock; Baroque Pop; Music Hall; Psychedelic Rock; Rock; Rock Music; Symphonic Rock"
-- TAG (properties) --
ALBUM                       - "Sgt. Pepper's Lonely Hearts Club Band (Super Deluxe Edition)"
ALBUMARTIST                 - "The Beatles"
ALBUMARTISTSORT             - "Beatles, The"
ARTIST                      - "The Beatles"
ARTISTS                     - "The Beatles"
ARTISTSORT                  - "Beatles, The"
BARCODE                     - "602567971542"
BPM                         - "93"
DATE                        - "2018-09-21"
DISCNUMBER                  - "1/4"
GENRE                       - "Art Rock; Baroque Pop; Music Hall; Psychedelic Rock; Rock; Rock Music; Symphonic Rock"
ISRC                        - "GBUM71700956"
LABEL                       - "Universal Music Catalogue"
LANGUAGE                    - "eng"
MEDIA                       - "Digital Media"
MIXER                       - "Giles Martin"
MUSICBRAINZ_ALBUMARTISTID   - "b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d"
MUSICBRAINZ_ALBUMID         - "e8862e8c-68c6-4265-b689-6c808280c3c0"
MUSICBRAINZ_ARTISTID        - "b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d"
MUSICBRAINZ_RELEASEGROUPID  - "9f7a4c28-8fa2-3113-929c-c47a9f7982c3"
MUSICBRAINZ_RELEASETRACKID  - "d01e77fb-b351-4db4-9c3f-218d7c17f65b"
MUSICBRAINZ_TRACKID         - "effc6a79-fc7c-4ac5-b8b9-8670ed59920e"
MUSICBRAINZ_WORKID          - "c6402058-011c-30d1-8189-6d8eedebfed2"
ORIGINALDATE                - "1967"
ORIGINALYEAR                - "1967"
PERFORMER:BACKGROUND VOCALS - "George Harrison"
PERFORMER:BACKGROUND VOCALS - "John Lennon"
PERFORMER:BACKGROUND VOCALS - "Paul McCartney"
PERFORMER:BASS              - "Paul McCartney"
PERFORMER:DRUMS (DRUM SET)  - "Ringo Starr"
PERFORMER:FRENCH HORN       - "James W. Buck"
PERFORMER:FRENCH HORN       - "John Burden"
PERFORMER:FRENCH HORN       - "Neill Sanders"
PERFORMER:FRENCH HORN       - "Tony Randall"
PERFORMER:GUITAR            - "George Harrison"
PERFORMER:GUITAR            - "John Lennon"
PERFORMER:GUITAR            - "Paul McCartney"
PERFORMER:LEAD VOCALS       - "Paul McCartney"
RELEASECOUNTRY              - "AF"
RELEASESTATUS               - "official"
RELEASETYPE                 - "album"
REPLAYGAIN_ALBUM_GAIN       - "-5.32 dB"
REPLAYGAIN_ALBUM_PEAK       - "1.000000"
REPLAYGAIN_TRACK_GAIN       - "-9.26 dB"
REPLAYGAIN_TRACK_PEAK       - "1.000000"
SCRIPT                      - "Latn"
TITLE                       - "Sgt. Pepper's Lonely Hearts Club Band (2018 Mix)"
TRACKNUMBER                 - "1/13"
WORK                        - "Sgt. Pepper's Lonely Hearts Club Band"
WRITER                      - "John Lennon/Paul McCartney"
PICTURE:
  data        - (112693 bytes)
  description - ""
  mimeType    - "image/jpeg"
  pictureType - "Front Cover"
-- AUDIO --
bitrate     - 320
sample rate - 44100
channels    - 2
length      - 2:02
```

The file has an IPLS frame containing "guitar|George Harrison|guitar|John Lennon|guitar|Paul McCartney|bass|Paul McCartney|drums (drum set)|Ringo Starr|French horn|James W. Buck|French horn|John Burden|French horn|Neill Sanders|French horn|Tony Randall|mix|Giles Martin|background vocals|George Harrison|background vocals|John Lennon|background vocals|Paul McCartney|lead vocals|Paul McCartney", the "mix" involvement is the "MIXER" property, all other involvements are "PERFORMER:" properties.
