### PR TITLE
Fix Unicode property keys in C bindings

### DIFF
--- a/bindings/c/tag_c.cpp
+++ b/bindings/c/tag_c.cpp
@@ -469,12 +469,13 @@ void _taglib_property_set(TagLib_File *file, const char* prop, const char* value
     return;
 
   auto tfile = reinterpret_cast<FileRef *>(file);
+  auto propStr = charArrayToString(prop);
   PropertyMap map = tfile->tag()->properties();
 
   if(value) {
-    auto property = map.find(prop);
+    auto property = map.find(propStr);
     if(property == map.end()) {
-      map.insert(prop, StringList(charArrayToString(value)));
+      map.insert(propStr, StringList(charArrayToString(value)));
     }
     else {
       if(append) {
@@ -486,7 +487,7 @@ void _taglib_property_set(TagLib_File *file, const char* prop, const char* value
     }
   }
   else {
-    map.erase(prop);
+    map.erase(propStr);
   }
 
   tfile->setProperties(map);
@@ -531,7 +532,7 @@ char **taglib_property_get(const TagLib_File *file, const char *prop)
 
   const PropertyMap map = reinterpret_cast<const FileRef *>(file)->properties();
 
-  auto property = map.find(prop);
+  auto property = map.find(charArrayToString(prop));
   if(property == map.end())
     return NULL;
 
@@ -573,16 +574,17 @@ bool _taglib_complex_property_set(
     return false;
 
   auto tfile = reinterpret_cast<FileRef *>(file);
+  auto keyStr = charArrayToString(key);
 
   if(value == NULL) {
-    return tfile->setComplexProperties(key, {});
+    return tfile->setComplexProperties(keyStr, {});
   }
 
   VariantMap map;
   const TagLib_Complex_Property_Attribute** attrPtr = value;
   while(*attrPtr) {
     const TagLib_Complex_Property_Attribute *attr = *attrPtr;
-    String attrKey(attr->key);
+    auto attrKey = charArrayToString(attr->key);
     switch(attr->value.type) {
     case TagLib_Variant_Void:
       map.insert(attrKey, Variant());
@@ -627,8 +629,8 @@ bool _taglib_complex_property_set(
     ++attrPtr;
   }
 
-  return append ? tfile->setComplexProperties(key, tfile->complexProperties(key).append(map))
-                : tfile->setComplexProperties(key, {map});
+  return append ? tfile->setComplexProperties(keyStr, tfile->complexProperties(keyStr).append(map))
+                : tfile->setComplexProperties(keyStr, {map});
 }
 
 }  // namespace
@@ -676,7 +678,7 @@ TagLib_Complex_Property_Attribute*** taglib_complex_property_get(
     return NULL;
   }
 
-  const auto variantMaps = reinterpret_cast<const FileRef *>(file)->complexProperties(key);
+  const auto variantMaps = reinterpret_cast<const FileRef *>(file)->complexProperties(charArrayToString(key));
   if(variantMaps.isEmpty()) {
     return NULL;
   }

--- a/tests/test_tag_c.cpp
+++ b/tests/test_tag_c.cpp
@@ -110,6 +110,7 @@ public:
       taglib_property_set(file, "COMPOSER", "Composer 1");
       taglib_property_set_append(file, "COMPOSER", "Composer 2");
       taglib_property_set(file, "ALBUMARTIST", "Album Artist");
+      taglib_property_set(file, "COMMENT:\xE2\x80\xBB", "Comment (with description)");
 
       // cppcheck-suppress cstyleCast
       TAGLIB_COMPLEX_PROPERTY_PICTURE(props, "JPEG Data", 9, "Written by TagLib",
@@ -141,6 +142,7 @@ public:
         {"DATE"s, {"2023"s}},
         {"COMPOSER"s, {"Composer 1"s, "Composer 2"s}},
         {"COMMENT"s, {"Comment"s}},
+        {"COMMENT:\xE2\x80\xBB"s, {"Comment (with description)"s}},
         {"ARTIST"s, {"Artist"s}},
         {"ALBUMARTIST"s, {"Album Artist"s}},
         {"ALBUM"s, {"Album"s}}


### PR DESCRIPTION
The C bindings would convert a char* to String using the default constructor, which uses the Latin1 encoding, breaking when a key contains a Unicode character (e.g. an ID3v2 comment description).

This was observed failing when trying to _read_ a .mp3 file (crashing using [similar code](https://github.com/turtletowerz/audiotags/blob/d044f29536ef11ad17613f98589488da2618341d/audiotags.c#L65) to the C binding test) mostly containing UTF-16 but also with the following comment frame, noting the BOM in the otherwise empty description:

```
00000000  43 4f 4d 4d 00 00 00 13  00 00 00 65 6e 67 ff fe  |COMM.......eng..|
00000010  00 78 79 7a 78 79 7a 78  79 7a 78 79 7a           |.xyzxyzxyzxyz|
```

This fix makes these values round-trip correctly between `taglib_property_keys` and `taglib_property_get`, and also attempts to fix some other functions that relied on the default constructor.