### PR TITLE
Fix std::ostream not defined on Android NDK 29.0.14033849

### DIFF
--- a/taglib/toolkit/tvariant.h
+++ b/taglib/toolkit/tvariant.h
@@ -26,7 +26,7 @@
 #ifndef TAGLIB_VARIANT_H
 #define TAGLIB_VARIANT_H
 
-#include <iosfwd>
+#include <sstream>
 
 #include "tlist.h"
 #include "tmap.h"


### PR DESCRIPTION
taglib/toolkit/tvariant.h:43:29: note: candidate function
   43 | TAGLIB_EXPORT std::ostream &operator<<(std::ostream &s, const TagLib::Variant &v);