### PR TITLE
Fix cmake_minimum_required version range typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10..3.31)
+cmake_minimum_required(VERSION 3.10...3.31)
 
 project(taglib)
 


### PR DESCRIPTION
While CMake appears to accept the ".." notation, it does not correctly apply the policy_max version in that case.

Amends ab31d11c8d1e04eb710aab7902d9564b4947de8c

(@ufleisch sorry about that)