### PR TITLE
MP4: Support 64-bit atoms on Windows

### DIFF
--- a/taglib/mp4/mp4atom.cpp
+++ b/taglib/mp4/mp4atom.cpp
@@ -74,17 +74,7 @@ MP4::Atom::Atom(File *file)
   }
   else if(d->length == 1) {
     // The atom has a 64-bit length.
-    if(const long long longLength = file->readBlock(8).toLongLong();
-       longLength <= LONG_MAX) {
-      // The actual length fits in long. That's always the case if long is 64-bit.
-      d->length = static_cast<long>(longLength);
-    }
-    else {
-      debug("MP4: 64-bit atoms are not supported");
-      d->length = 0;
-      file->seek(0, File::End);
-      return;
-    }
+    d->length = file->readBlock(8).toLongLong();
   }
 
   if(d->length < 8 || d->length > file->length() - d->offset) {


### PR DESCRIPTION
The check for the size of long is no longer needed because since TagLib 2.0 the related fields are 64-bit on Windows too.

Related to https://bugs.kde.org/show_bug.cgi?id=513531