### PR TITLE
wavpack: Fix infinite loop when reading broken files

### DIFF
--- a/taglib/wavpack/wavpackproperties.cpp
+++ b/taglib/wavpack/wavpackproperties.cpp
@@ -254,14 +254,14 @@ void WavPack::Properties::read(File *file, offset_t streamLength)
     const unsigned int flags = data.toUInt(24, false);
     unsigned int smplRate = sampleRates[(flags & SRATE_MASK) >> SRATE_LSB];
 
-    if(!blockSamples) {        // ignore blocks with no samples
-      offset += blockSize + 8;
-      continue;
-    }
-
     if(blockSize < 24 || blockSize > 1048576) {
       debug("WavPack::Properties::read() -- Invalid block header found.");
       break;
+    }
+
+    if(!blockSamples) {        // ignore blocks with no samples
+      offset += blockSize + 8;
+      continue;
     }
 
     // For non-standard sample rates or DSD audio files, we must read and parse the block


### PR DESCRIPTION
A crafted file can have blockSamples set to 0 and a blockSize so big that when adding 8 it overflows and offset is 0 so it goes back to the same position and loops forever