### PR TITLE
Do not allow unknown frames embedded in CTOC and CHAP (#1306)

### DIFF
--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -30,6 +30,7 @@
 #include "tbytevectorlist.h"
 #include "tdebug.h"
 #include "tpropertymap.h"
+#include "unknownframe.h"
 
 using namespace TagLib;
 using namespace ID3v2;
@@ -259,7 +260,7 @@ void ChapterFrame::parseFields(const ByteVector &data)
       return;
 
     // Checks to make sure that frame parsed correctly.
-    if(frame->size() <= 0) {
+    if(frame->size() <= 0 || dynamic_cast<UnknownFrame *>(frame)) {
       delete frame;
       return;
     }

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -29,6 +29,7 @@
 
 #include "tpropertymap.h"
 #include "tdebug.h"
+#include "unknownframe.h"
 
 using namespace TagLib;
 using namespace ID3v2;
@@ -269,7 +270,7 @@ void TableOfContentsFrame::parseFields(const ByteVector &data)
       return;
 
     // Checks to make sure that frame parsed correctly.
-    if(frame->size() <= 0) {
+    if(frame->size() <= 0 || dynamic_cast<UnknownFrame *>(frame)) {
       delete frame;
       return;
     }


### PR DESCRIPTION
This prevents the parsing of frames with specially constructed recursive frame hierarchies from taking an extremely long time.