### PR TITLE
Feature/wav bext ixml

### DIFF
--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -57,6 +57,9 @@ public:
   bool hasInfo { false };
   bool hasiXML { false };
   bool hasBEXT { false };
+
+  String iXMLData;
+  ByteVector bextData;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -108,6 +111,26 @@ ID3v2::Tag *RIFF::WAV::File::ID3v2Tag() const
 RIFF::Info::Tag *RIFF::WAV::File::InfoTag() const
 {
   return d->tag.access<RIFF::Info::Tag>(InfoIndex, false);
+}
+
+String RIFF::WAV::File::iXMLData() const
+{
+  return d->iXMLData;
+}
+
+void RIFF::WAV::File::setiXMLData(const String &data)
+{
+  d->iXMLData = data;
+}
+
+ByteVector RIFF::WAV::File::BEXTData() const
+{
+  return d->bextData;
+}
+
+void RIFF::WAV::File::setBEXTData(const ByteVector &data)
+{
+  d->bextData = data;
 }
 
 void RIFF::WAV::File::strip(TagTypes tags)
@@ -162,9 +185,9 @@ bool RIFF::WAV::File::save(TagTypes tags, StripTags strip, ID3v2::Version versio
   if(strip == StripOthers)
     File::strip(static_cast<TagTypes>(AllTags & ~tags));
 
-  if(!bextTag.isEmpty()) {
+  if(!d->bextData.isEmpty()) {
     removeChunk("bext");
-    setChunkData("bext", bextTag);
+    setChunkData("bext", d->bextData);
     d->hasBEXT = true;
   }
   else if(d->hasBEXT) {
@@ -172,9 +195,9 @@ bool RIFF::WAV::File::save(TagTypes tags, StripTags strip, ID3v2::Version versio
     d->hasBEXT = false;
   }
 
-  if(!iXMLTag.isEmpty()) {
+  if(!d->iXMLData.isEmpty()) {
     removeChunk("iXML");
-    setChunkData("iXML", iXMLTag.data(String::UTF8));
+    setChunkData("iXML", d->iXMLData.data(String::UTF8));
     d->hasiXML = true;
   }
   else if(d->hasiXML) {
@@ -253,11 +276,11 @@ void RIFF::WAV::File::read(bool readProperties)
     }
     else if(name == "iXML") {
       d->hasiXML = true;
-      iXMLTag = String(chunkData(i));
+      d->iXMLData = String(chunkData(i));
     }
     else if(name == "bext") {
       d->hasBEXT = true;
-      bextTag = chunkData(i);
+      d->bextData = chunkData(i);
     }
   }
 

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -236,12 +236,12 @@ bool RIFF::WAV::File::hasInfoTag() const
   return d->hasInfo;
 }
 
-bool RIFF::WAV::File::hasiXMLTag() const
+bool RIFF::WAV::File::hasiXMLData() const
 {
   return d->hasiXML;
 }
 
-bool RIFF::WAV::File::hasBEXTTag() const
+bool RIFF::WAV::File::hasBEXTData() const
 {
   return d->hasBEXT;
 }

--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -55,6 +55,8 @@ public:
 
   bool hasID3v2 { false };
   bool hasInfo { false };
+  bool hasiXML { false };
+  bool hasBEXT { false };
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -160,6 +162,26 @@ bool RIFF::WAV::File::save(TagTypes tags, StripTags strip, ID3v2::Version versio
   if(strip == StripOthers)
     File::strip(static_cast<TagTypes>(AllTags & ~tags));
 
+  if(!bextTag.isEmpty()) {
+    removeChunk("bext");
+    setChunkData("bext", bextTag);
+    d->hasBEXT = true;
+  }
+  else if(d->hasBEXT) {
+    removeChunk("bext");
+    d->hasBEXT = false;
+  }
+
+  if(!iXMLTag.isEmpty()) {
+    removeChunk("iXML");
+    setChunkData("iXML", iXMLTag.data(String::UTF8));
+    d->hasiXML = true;
+  }
+  else if(d->hasiXML) {
+    removeChunk("iXML");
+    d->hasiXML = false;
+  }
+
   if(tags & ID3v2) {
     removeTagChunks(ID3v2);
 
@@ -191,6 +213,16 @@ bool RIFF::WAV::File::hasInfoTag() const
   return d->hasInfo;
 }
 
+bool RIFF::WAV::File::hasiXMLTag() const
+{
+  return d->hasiXML;
+}
+
+bool RIFF::WAV::File::hasBEXTTag() const
+{
+  return d->hasBEXT;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // private members
 ////////////////////////////////////////////////////////////////////////////////
@@ -218,6 +250,14 @@ void RIFF::WAV::File::read(bool readProperties)
           debug("RIFF::WAV::File::read() - Duplicate INFO tag found.");
         }
       }
+    }
+    else if(name == "iXML") {
+      d->hasiXML = true;
+      iXMLTag = String(chunkData(i));
+    }
+    else if(name == "bext") {
+      d->hasBEXT = true;
+      bextTag = chunkData(i);
     }
   }
 

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -135,22 +135,40 @@ namespace TagLib {
         Info::Tag *InfoTag() const;
 
         /*!
-         * Raw iXML chunk data as a String.
+         * Returns the raw iXML chunk data as a String.
          * Empty if no iXML chunk is present.
-         * Set this to write/update an iXML chunk on save; clear to remove it.
          *
+         * \see setiXMLData()
          * \see hasiXMLTag()
          */
-        String iXMLTag;
+        String iXMLData() const;
 
         /*!
-         * Raw BEXT (Broadcast Audio Extension) chunk data as a ByteVector.
-         * Empty if no BEXT chunk is present.
-         * Set this to write/update a BEXT chunk on save; clear to remove it.
+         * Sets the iXML chunk data.  Pass an empty string to remove the
+         * iXML chunk on save.
          *
+         * \see iXMLData()
+         * \see hasiXMLTag()
+         */
+        void setiXMLData(const String &data);
+
+        /*!
+         * Returns the raw BEXT (Broadcast Audio Extension) chunk data
+         * as a ByteVector.  Empty if no BEXT chunk is present.
+         *
+         * \see setBEXTData()
          * \see hasBEXTTag()
          */
-        ByteVector bextTag;
+        ByteVector BEXTData() const;
+
+        /*!
+         * Sets the BEXT chunk data.  Pass an empty ByteVector to remove
+         * the BEXT chunk on save.
+         *
+         * \see BEXTData()
+         * \see hasBEXTTag()
+         */
+        void setBEXTData(const ByteVector &data);
 
         /*!
          * This will strip the tags that match the OR-ed together TagTypes from the

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -139,7 +139,7 @@ namespace TagLib {
          * Empty if no iXML chunk is present.
          *
          * \see setiXMLData()
-         * \see hasiXMLTag()
+         * \see hasiXMLData()
          */
         String iXMLData() const;
 
@@ -148,7 +148,7 @@ namespace TagLib {
          * iXML chunk on save.
          *
          * \see iXMLData()
-         * \see hasiXMLTag()
+         * \see hasiXMLData()
          */
         void setiXMLData(const String &data);
 
@@ -157,7 +157,7 @@ namespace TagLib {
          * as a ByteVector.  Empty if no BEXT chunk is present.
          *
          * \see setBEXTData()
-         * \see hasBEXTTag()
+         * \see hasBEXTData()
          */
         ByteVector BEXTData() const;
 
@@ -166,7 +166,7 @@ namespace TagLib {
          * the BEXT chunk on save.
          *
          * \see BEXTData()
-         * \see hasBEXTTag()
+         * \see hasBEXTData()
          */
         void setBEXTData(const ByteVector &data);
 
@@ -232,14 +232,14 @@ namespace TagLib {
          *
          * \see iXMLTag
          */
-        bool hasiXMLTag() const;
+        bool hasiXMLData() const;
 
         /*!
          * Returns whether or not the file on disk actually has a BEXT chunk.
          *
          * \see bextTag
          */
-        bool hasBEXTTag() const;
+        bool hasBEXTData() const;
 
         /*!
          * Returns whether or not the given \a stream can be opened as a WAV

--- a/taglib/riff/wav/wavfile.h
+++ b/taglib/riff/wav/wavfile.h
@@ -135,6 +135,24 @@ namespace TagLib {
         Info::Tag *InfoTag() const;
 
         /*!
+         * Raw iXML chunk data as a String.
+         * Empty if no iXML chunk is present.
+         * Set this to write/update an iXML chunk on save; clear to remove it.
+         *
+         * \see hasiXMLTag()
+         */
+        String iXMLTag;
+
+        /*!
+         * Raw BEXT (Broadcast Audio Extension) chunk data as a ByteVector.
+         * Empty if no BEXT chunk is present.
+         * Set this to write/update a BEXT chunk on save; clear to remove it.
+         *
+         * \see hasBEXTTag()
+         */
+        ByteVector bextTag;
+
+        /*!
          * This will strip the tags that match the OR-ed together TagTypes from the
          * file.  By default it strips all tags.  It returns \c true if the tags are
          * successfully stripped.
@@ -190,6 +208,20 @@ namespace TagLib {
          * \see InfoTag()
          */
         bool hasInfoTag() const;
+
+        /*!
+         * Returns whether or not the file on disk actually has an iXML chunk.
+         *
+         * \see iXMLTag
+         */
+        bool hasiXMLTag() const;
+
+        /*!
+         * Returns whether or not the file on disk actually has a BEXT chunk.
+         *
+         * \see bextTag
+         */
+        bool hasBEXTTag() const;
 
         /*!
          * Returns whether or not the given \a stream can be opened as a WAV

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -61,6 +61,10 @@ class TestWAV : public CppUnit::TestFixture
   CPPUNIT_TEST(testWaveFormatExtensible);
   CPPUNIT_TEST(testInvalidChunk);
   CPPUNIT_TEST(testRIFFInfoProperties);
+  CPPUNIT_TEST(testBEXTTag);
+  CPPUNIT_TEST(testBEXTTagWithOtherTags);
+  CPPUNIT_TEST(testiXMLTag);
+  CPPUNIT_TEST(testiXMLTagWithOtherTags);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -479,6 +483,122 @@ public:
         {"IPRT", "2/4"}
       };
       CPPUNIT_ASSERT(expectedFields == infoTag->fieldListMap());
+    }
+  }
+
+  void testBEXTTag()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+    string filename = copy.fileName();
+
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasBEXTTag());
+      CPPUNIT_ASSERT(f.bextTag.isEmpty());
+
+      f.bextTag = ByteVector("test bext data");
+      f.save();
+      CPPUNIT_ASSERT(f.hasBEXTTag());
+    }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT_EQUAL(ByteVector("test bext data"), f.bextTag);
+
+      f.bextTag.clear();
+      f.save();
+      CPPUNIT_ASSERT(!f.hasBEXTTag());
+    }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasBEXTTag());
+      CPPUNIT_ASSERT(f.bextTag.isEmpty());
+    }
+  }
+
+  void testBEXTTagWithOtherTags()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+    string filename = copy.fileName();
+
+    {
+      RIFF::WAV::File f(filename.c_str());
+      f.ID3v2Tag()->setTitle("ID3v2 Title");
+      f.InfoTag()->setTitle("INFO Title");
+      f.bextTag = ByteVector("bext payload");
+      f.save();
+    }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasInfoTag());
+      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT_EQUAL(String("ID3v2 Title"), f.ID3v2Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(String("INFO Title"), f.InfoTag()->title());
+      CPPUNIT_ASSERT_EQUAL(ByteVector("bext payload"), f.bextTag);
+    }
+  }
+
+  void testiXMLTag()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+    string filename = copy.fileName();
+
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasiXMLTag());
+      CPPUNIT_ASSERT(f.iXMLTag.isEmpty());
+
+      f.iXMLTag = "<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>";
+      f.save();
+      CPPUNIT_ASSERT(f.hasiXMLTag());
+    }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.hasiXMLTag());
+      CPPUNIT_ASSERT_EQUAL(
+        String("<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>"),
+        f.iXMLTag);
+
+      f.iXMLTag = String();
+      f.save();
+      CPPUNIT_ASSERT(!f.hasiXMLTag());
+    }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasiXMLTag());
+      CPPUNIT_ASSERT(f.iXMLTag.isEmpty());
+    }
+  }
+
+  void testiXMLTagWithOtherTags()
+  {
+    ScopedFileCopy copy("empty", ".wav");
+    string filename = copy.fileName();
+
+    {
+      RIFF::WAV::File f(filename.c_str());
+      f.ID3v2Tag()->setTitle("ID3v2 Title");
+      f.iXMLTag = "<BWFXML><SCENE>1</SCENE></BWFXML>";
+      f.bextTag = ByteVector("bext data");
+      f.save();
+    }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.hasID3v2Tag());
+      CPPUNIT_ASSERT(f.hasiXMLTag());
+      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT_EQUAL(String("ID3v2 Title"), f.ID3v2Tag()->title());
+      CPPUNIT_ASSERT_EQUAL(
+        String("<BWFXML><SCENE>1</SCENE></BWFXML>"),
+        f.iXMLTag);
+      CPPUNIT_ASSERT_EQUAL(ByteVector("bext data"), f.bextTag);
     }
   }
 

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -494,29 +494,34 @@ public:
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
-      CPPUNIT_ASSERT(!f.hasBEXTTag());
+      CPPUNIT_ASSERT(!f.hasBEXTData());
       CPPUNIT_ASSERT(f.BEXTData().isEmpty());
 
       f.setBEXTData(ByteVector("test bext data"));
       f.save();
-      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT(f.hasBEXTData());
     }
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
-      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT(f.hasBEXTData());
       CPPUNIT_ASSERT_EQUAL(ByteVector("test bext data"), f.BEXTData());
 
       f.setBEXTData(ByteVector());
       f.save();
-      CPPUNIT_ASSERT(!f.hasBEXTTag());
+      CPPUNIT_ASSERT(!f.hasBEXTData());
     }
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
-      CPPUNIT_ASSERT(!f.hasBEXTTag());
+      CPPUNIT_ASSERT(!f.hasBEXTData());
       CPPUNIT_ASSERT(f.BEXTData().isEmpty());
     }
+
+    // Check if file without BEXT is same as original empty file
+    const ByteVector origData = PlainFile(TEST_FILE_PATH_C("empty.wav")).readAll();
+    const ByteVector fileData = PlainFile(filename.c_str()).readAll();
+    CPPUNIT_ASSERT(origData == fileData);
   }
 
   void testBEXTTagWithOtherTags()
@@ -535,7 +540,7 @@ public:
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
       CPPUNIT_ASSERT(f.hasInfoTag());
-      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT(f.hasBEXTData());
       CPPUNIT_ASSERT_EQUAL(String("ID3v2 Title"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("INFO Title"), f.InfoTag()->title());
       CPPUNIT_ASSERT_EQUAL(ByteVector("bext payload"), f.BEXTData());
@@ -550,31 +555,36 @@ public:
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
-      CPPUNIT_ASSERT(!f.hasiXMLTag());
+      CPPUNIT_ASSERT(!f.hasiXMLData());
       CPPUNIT_ASSERT(f.iXMLData().isEmpty());
 
       f.setiXMLData("<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>");
       f.save();
-      CPPUNIT_ASSERT(f.hasiXMLTag());
+      CPPUNIT_ASSERT(f.hasiXMLData());
     }
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
-      CPPUNIT_ASSERT(f.hasiXMLTag());
+      CPPUNIT_ASSERT(f.hasiXMLData());
       CPPUNIT_ASSERT_EQUAL(
         String("<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>"),
         f.iXMLData());
 
       f.setiXMLData(String());
       f.save();
-      CPPUNIT_ASSERT(!f.hasiXMLTag());
+      CPPUNIT_ASSERT(!f.hasiXMLData());
     }
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
-      CPPUNIT_ASSERT(!f.hasiXMLTag());
+      CPPUNIT_ASSERT(!f.hasiXMLData());
       CPPUNIT_ASSERT(f.iXMLData().isEmpty());
     }
+
+    // Check if file without iXML is same as original empty file
+    const ByteVector origData = PlainFile(TEST_FILE_PATH_C("empty.wav")).readAll();
+    const ByteVector fileData = PlainFile(filename.c_str()).readAll();
+    CPPUNIT_ASSERT(origData == fileData);
   }
 
   void testiXMLTagWithOtherTags()
@@ -592,14 +602,33 @@ public:
     {
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.hasID3v2Tag());
-      CPPUNIT_ASSERT(f.hasiXMLTag());
-      CPPUNIT_ASSERT(f.hasBEXTTag());
+      CPPUNIT_ASSERT(f.hasiXMLData());
+      CPPUNIT_ASSERT(f.hasBEXTData());
       CPPUNIT_ASSERT_EQUAL(String("ID3v2 Title"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(
         String("<BWFXML><SCENE>1</SCENE></BWFXML>"),
         f.iXMLData());
       CPPUNIT_ASSERT_EQUAL(ByteVector("bext data"), f.BEXTData());
+
+      f.setiXMLData(String());
+      f.setBEXTData(ByteVector());
+      f.strip();
+      CPPUNIT_ASSERT(f.save());
     }
+    {
+      RIFF::WAV::File f(filename.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(!f.hasID3v2Tag());
+      CPPUNIT_ASSERT(!f.hasiXMLData());
+      CPPUNIT_ASSERT(f.iXMLData().isEmpty());
+      CPPUNIT_ASSERT(!f.hasBEXTData());
+      CPPUNIT_ASSERT(f.BEXTData().isEmpty());
+    }
+
+    // Check if file without tags is same as original empty file
+    const ByteVector origData = PlainFile(TEST_FILE_PATH_C("empty.wav")).readAll();
+    const ByteVector fileData = PlainFile(filename.c_str()).readAll();
+    CPPUNIT_ASSERT(origData == fileData);
   }
 
 };

--- a/tests/test_wav.cpp
+++ b/tests/test_wav.cpp
@@ -495,9 +495,9 @@ public:
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT(!f.hasBEXTTag());
-      CPPUNIT_ASSERT(f.bextTag.isEmpty());
+      CPPUNIT_ASSERT(f.BEXTData().isEmpty());
 
-      f.bextTag = ByteVector("test bext data");
+      f.setBEXTData(ByteVector("test bext data"));
       f.save();
       CPPUNIT_ASSERT(f.hasBEXTTag());
     }
@@ -505,9 +505,9 @@ public:
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT(f.hasBEXTTag());
-      CPPUNIT_ASSERT_EQUAL(ByteVector("test bext data"), f.bextTag);
+      CPPUNIT_ASSERT_EQUAL(ByteVector("test bext data"), f.BEXTData());
 
-      f.bextTag.clear();
+      f.setBEXTData(ByteVector());
       f.save();
       CPPUNIT_ASSERT(!f.hasBEXTTag());
     }
@@ -515,7 +515,7 @@ public:
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT(!f.hasBEXTTag());
-      CPPUNIT_ASSERT(f.bextTag.isEmpty());
+      CPPUNIT_ASSERT(f.BEXTData().isEmpty());
     }
   }
 
@@ -528,7 +528,7 @@ public:
       RIFF::WAV::File f(filename.c_str());
       f.ID3v2Tag()->setTitle("ID3v2 Title");
       f.InfoTag()->setTitle("INFO Title");
-      f.bextTag = ByteVector("bext payload");
+      f.setBEXTData(ByteVector("bext payload"));
       f.save();
     }
     {
@@ -538,7 +538,7 @@ public:
       CPPUNIT_ASSERT(f.hasBEXTTag());
       CPPUNIT_ASSERT_EQUAL(String("ID3v2 Title"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(String("INFO Title"), f.InfoTag()->title());
-      CPPUNIT_ASSERT_EQUAL(ByteVector("bext payload"), f.bextTag);
+      CPPUNIT_ASSERT_EQUAL(ByteVector("bext payload"), f.BEXTData());
     }
   }
 
@@ -551,9 +551,9 @@ public:
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT(!f.hasiXMLTag());
-      CPPUNIT_ASSERT(f.iXMLTag.isEmpty());
+      CPPUNIT_ASSERT(f.iXMLData().isEmpty());
 
-      f.iXMLTag = "<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>";
+      f.setiXMLData("<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>");
       f.save();
       CPPUNIT_ASSERT(f.hasiXMLTag());
     }
@@ -563,9 +563,9 @@ public:
       CPPUNIT_ASSERT(f.hasiXMLTag());
       CPPUNIT_ASSERT_EQUAL(
         String("<BWFXML><IXML_VERSION>1.0</IXML_VERSION></BWFXML>"),
-        f.iXMLTag);
+        f.iXMLData());
 
-      f.iXMLTag = String();
+      f.setiXMLData(String());
       f.save();
       CPPUNIT_ASSERT(!f.hasiXMLTag());
     }
@@ -573,7 +573,7 @@ public:
       RIFF::WAV::File f(filename.c_str());
       CPPUNIT_ASSERT(f.isValid());
       CPPUNIT_ASSERT(!f.hasiXMLTag());
-      CPPUNIT_ASSERT(f.iXMLTag.isEmpty());
+      CPPUNIT_ASSERT(f.iXMLData().isEmpty());
     }
   }
 
@@ -585,8 +585,8 @@ public:
     {
       RIFF::WAV::File f(filename.c_str());
       f.ID3v2Tag()->setTitle("ID3v2 Title");
-      f.iXMLTag = "<BWFXML><SCENE>1</SCENE></BWFXML>";
-      f.bextTag = ByteVector("bext data");
+      f.setiXMLData("<BWFXML><SCENE>1</SCENE></BWFXML>");
+      f.setBEXTData(ByteVector("bext data"));
       f.save();
     }
     {
@@ -597,8 +597,8 @@ public:
       CPPUNIT_ASSERT_EQUAL(String("ID3v2 Title"), f.ID3v2Tag()->title());
       CPPUNIT_ASSERT_EQUAL(
         String("<BWFXML><SCENE>1</SCENE></BWFXML>"),
-        f.iXMLTag);
-      CPPUNIT_ASSERT_EQUAL(ByteVector("bext data"), f.bextTag);
+        f.iXMLData());
+      CPPUNIT_ASSERT_EQUAL(ByteVector("bext data"), f.BEXTData());
     }
   }
 


### PR DESCRIPTION
Hi,

This is arguably out of scope for taglib (feel free to pass on it), but again, this is something I needed and in the context of what I'm doing, taglib is the most logical place to keep the raw chunk access. iXML is straightforward, but I didn't put the BEXT chunk parsing into taglib, just access. I am handling the bext parse in my own framework a bit higher up. I'm working exclusively in SPM myself, so these changes are carefully remerged into taglib. The implementation/swift bridges can be seen here: https://github.com/ryanfrancesconi/spfk-metadata

Cheers,
Ryan