### PR TITLE
Add .clang-format configuration for contributor use

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,112 @@
+# TagLib coding style for clang-format
+#
+# This configuration approximates the formatting conventions used throughout
+# the TagLib codebase.  It is intended as a contributor aid, not a strict
+# enforcer -- manual review is still expected for complex constructs
+# (particularly constructor initializer alignment and multi-line expressions).
+
+Language: Cpp
+Standard: c++20
+
+# -- Indentation --
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+IndentAccessModifiers: false
+AccessModifierOffset: -2
+NamespaceIndentation: All
+IndentWrappedFunctionNames: false
+
+# -- Braces --
+# Functions/classes/structs: opening brace on own line.
+# Control flow (if, for, while): brace attached to statement.
+# else/catch: on own line after closing brace.
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# -- Spaces --
+SpaceBeforeParens: Never
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesInParentheses: false
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeCpp11BracedList: true
+SpacesBeforeTrailingComments: 2
+
+# -- Alignment --
+PointerAlignment: Right
+ReferenceAlignment: Right
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: true
+
+# -- Line breaks --
+ColumnLimit: 100
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+
+# -- Constructor initializers --
+# Upstream style:  Foo(...) :
+#                    base(...),
+#                    d(...)
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerIndentWidth: 2
+PackConstructorInitializers: Never
+
+# -- Includes --
+SortIncludes: false
+
+# -- Penalties --
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+
+# -- Misc --
+Cpp11BracedListStyle: false
+FixNamespaceComments: true
+MaxEmptyLinesToKeep: 1
+ReflowComments: false
+InsertTrailingCommas: None
+SeparateDefinitionBlocks: Leave

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ CMakeLists.txt.user*
 taglib.h.stamp
 taglib.xcodeproj
 CMakeScripts
-/.clang-format
 /compile_commands.json
 /build/
 .clangd


### PR DESCRIPTION
Hi,
This is a followup from the issue I opened a bit ago about codifying a convention for formatting. Could be worth considering the existing formatting files in place if you want this. I had Claude make this...

This was interesting to watch it analyze the codebase and come up with the most accurate formatting file it could.

Ryan

***

Reverse-engineered from the existing codebase conventions:
- 2-space indentation, no tabs
- Allman braces for functions/classes/structs
- Attached braces for control flow (if, for, while)
- Detached else/catch (on own line after closing brace)
- No space before parentheses: if(...), for(...)
- Right-aligned pointers/references: Type *name, Type &name
- Namespace contents indented
- Constructor initializers on separate lines after colon

This is intended as a contributor aid -- the codebase has some historical inconsistencies (e.g. mixed else placement, return type on own line in some files) that cannot all be captured in a single configuration.  Manual review is still expected for complex constructs.

Also removes /.clang-format from .gitignore so the file can be tracked.