### PR TITLE
matroska: speed up ReadStyle::Fast with SeekHead lookups

### DIFF
--- a/taglib/matroska/matroskafile.cpp
+++ b/taglib/matroska/matroskafile.cpp
@@ -31,9 +31,14 @@
 #include "matroskasegment.h"
 #include "ebmlutils.h"
 #include "ebmlelement.h"
+#include "ebmlmasterelement.h"
 #include "ebmlstringelement.h"
 #include "ebmluintelement.h"
+#include "ebmlmkinfo.h"
+#include "ebmlmkseekhead.h"
 #include "ebmlmksegment.h"
+#include "ebmlmktags.h"
+#include "ebmlmktracks.h"
 #include "tlist.h"
 #include "tdebug.h"
 #include "tagutils.h"
@@ -57,6 +62,8 @@ public:
   std::unique_ptr<Cues> cues;
   std::unique_ptr<Segment> segment;
   std::unique_ptr<Properties> properties;
+  bool partialRead = false;
+  bool tagStateResolved = true;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -113,6 +120,10 @@ Tag *Matroska::File::tag() const
 
 Matroska::Tag *Matroska::File::tag(bool create) const
 {
+  if(!ensureTagResolved()) {
+    return nullptr;
+  }
+
   if(!d->tag && create) {
     d->tag = std::make_unique<Tag>();
     if(d->properties) {
@@ -124,11 +135,17 @@ Matroska::Tag *Matroska::File::tag(bool create) const
 
 PropertyMap Matroska::File::properties() const
 {
+  if(!ensureTagResolved()) {
+    return PropertyMap();
+  }
   return d->tag ? d->tag->properties() : PropertyMap();
 }
 
 void Matroska::File::removeUnsupportedProperties(const StringList &properties)
 {
+  if(!ensureTagResolved()) {
+    return;
+  }
   if(d->tag) {
     d->tag->removeUnsupportedProperties(properties);
   }
@@ -136,6 +153,9 @@ void Matroska::File::removeUnsupportedProperties(const StringList &properties)
 
 PropertyMap Matroska::File::setProperties(const PropertyMap &properties)
 {
+  if(!ensureTagResolved()) {
+    return properties;
+  }
   if(!d->tag) {
     d->tag = std::make_unique<Tag>();
   }
@@ -143,6 +163,14 @@ PropertyMap Matroska::File::setProperties(const PropertyMap &properties)
 }
 
 namespace {
+
+  constexpr offset_t FastScanLimit = static_cast<offset_t>(512 * 1024);
+
+  struct FastSegmentReadResult
+  {
+    bool success = false;
+    bool tagStateResolved = false;
+  };
 
   String keyForAttachedFile(const Matroska::AttachedFile &attachedFile)
   {
@@ -168,10 +196,179 @@ namespace {
     );
   }
 
+  template <EBML::Element::Id Id, typename ElementType>
+  std::unique_ptr<ElementType> readElementAt(Matroska::File &file,
+                                             offset_t offset,
+                                             offset_t maxOffset)
+  {
+    if(offset < 0 || offset >= maxOffset) {
+      return nullptr;
+    }
+
+    file.seek(offset);
+    auto element = EBML::Element::factory(file);
+    if(!element || element->getId() != Id) {
+      return nullptr;
+    }
+
+    auto typed = EBML::element_cast<Id>(std::move(element));
+    if(!typed || !typed->read(file)) {
+      return nullptr;
+    }
+    return typed;
+  }
+
+  FastSegmentReadResult readFastSegmentData(Matroska::File &file,
+                                            const EBML::MkSegment &segment,
+                                            bool readProperties,
+                                            std::unique_ptr<Matroska::SeekHead> &seekHead,
+                                            std::unique_ptr<Matroska::Tag> &tag,
+                                            std::unique_ptr<Matroska::Properties> &properties)
+  {
+    const offset_t fileLength = file.length();
+    const offset_t segmentDataOffset = segment.segmentDataOffset();
+    if(segmentDataOffset < 0 || segmentDataOffset >= fileLength) {
+      return {};
+    }
+
+    bool haveInfo = !readProperties;
+    bool haveTracks = !readProperties;
+    bool tagStateResolved = tag != nullptr;
+    offset_t scanLimit = segmentDataOffset + FastScanLimit;
+    if(scanLimit > fileLength) {
+      scanLimit = fileLength;
+    }
+
+    file.seek(segmentDataOffset);
+    while(file.tell() < scanLimit) {
+      auto element = EBML::Element::factory(file);
+      if(!element) {
+        break;
+      }
+
+      switch(element->getId()) {
+      case EBML::Element::Id::MkSeekHead: {
+        auto mkSeekHead = EBML::element_cast<EBML::Element::Id::MkSeekHead>(std::move(element));
+        if(!mkSeekHead || !mkSeekHead->read(file)) {
+          return {};
+        }
+        seekHead = mkSeekHead->parse(segmentDataOffset);
+        break;
+      }
+      case EBML::Element::Id::MkInfo:
+        if(readProperties && properties && !haveInfo) {
+          auto mkInfo = EBML::element_cast<EBML::Element::Id::MkInfo>(std::move(element));
+          if(!mkInfo || !mkInfo->read(file)) {
+            return {};
+          }
+          mkInfo->parse(properties.get());
+          haveInfo = true;
+        }
+        else {
+          element->skipData(file);
+        }
+        break;
+      case EBML::Element::Id::MkTracks:
+        if(readProperties && properties && !haveTracks) {
+          auto mkTracks = EBML::element_cast<EBML::Element::Id::MkTracks>(std::move(element));
+          if(!mkTracks || !mkTracks->read(file)) {
+            return {};
+          }
+          mkTracks->parse(properties.get());
+          haveTracks = true;
+        }
+        else {
+          element->skipData(file);
+        }
+        break;
+      case EBML::Element::Id::MkTags:
+        if(!tag) {
+          auto mkTags = EBML::element_cast<EBML::Element::Id::MkTags>(std::move(element));
+          if(!mkTags || !mkTags->read(file)) {
+            return {};
+          }
+          tag = mkTags->parse();
+          tagStateResolved = true;
+        }
+        else {
+          element->skipData(file);
+        }
+        break;
+      default:
+        element->skipData(file);
+        break;
+      }
+
+      if(haveInfo && haveTracks && tagStateResolved) {
+        return {true, true};
+      }
+    }
+
+    bool hasTagsEntry = false;
+    if(seekHead) {
+      for(const auto &[idValue, relativeOffset] : seekHead->entryList()) {
+        const auto id = static_cast<EBML::Element::Id>(idValue);
+        const offset_t absoluteOffset = segmentDataOffset + relativeOffset;
+        switch(id) {
+        case EBML::Element::Id::MkInfo:
+          if(readProperties && properties && !haveInfo) {
+            auto mkInfo = readElementAt<EBML::Element::Id::MkInfo, EBML::MkInfo>(
+              file, absoluteOffset, fileLength);
+            if(!mkInfo) {
+              return {};
+            }
+            mkInfo->parse(properties.get());
+            haveInfo = true;
+          }
+          break;
+        case EBML::Element::Id::MkTracks:
+          if(readProperties && properties && !haveTracks) {
+            auto mkTracks = readElementAt<EBML::Element::Id::MkTracks, EBML::MkTracks>(
+              file, absoluteOffset, fileLength);
+            if(!mkTracks) {
+              return {};
+            }
+            mkTracks->parse(properties.get());
+            haveTracks = true;
+          }
+          break;
+        case EBML::Element::Id::MkTags:
+          hasTagsEntry = true;
+          if(!tag) {
+            auto mkTags = readElementAt<EBML::Element::Id::MkTags, EBML::MkTags>(
+              file, absoluteOffset, fileLength);
+            if(!mkTags) {
+              return {};
+            }
+            tag = mkTags->parse();
+          }
+          tagStateResolved = true;
+          break;
+        default:
+          break;
+        }
+
+        if(haveInfo && haveTracks && tagStateResolved) {
+          return {true, true};
+        }
+      }
+    }
+
+    if(seekHead && !hasTagsEntry && !tag) {
+      tagStateResolved = true;
+    }
+
+    return {haveInfo && haveTracks, tagStateResolved};
+  }
+
 }
 
 StringList Matroska::File::complexPropertyKeys() const
 {
+  if(d->partialRead && !ensureFullyParsed()) {
+    return TagLib::File::complexPropertyKeys();
+  }
+
   StringList keys = TagLib::File::complexPropertyKeys();
   if(d->attachments) {
     const auto &attachedFiles = d->attachments->attachedFileList();
@@ -191,6 +388,10 @@ StringList Matroska::File::complexPropertyKeys() const
 List<VariantMap> Matroska::File::complexProperties(const String &key) const
 {
   List<VariantMap> props = TagLib::File::complexProperties(key);
+  if(d->partialRead && !ensureFullyParsed()) {
+    return props;
+  }
+
   if(key.upper() == "CHAPTERS") {
     if(d->chapters) {
       for(const auto &edition : d->chapters->chapterEditionList()) {
@@ -259,6 +460,10 @@ List<VariantMap> Matroska::File::complexProperties(const String &key) const
 
 bool Matroska::File::setComplexProperties(const String &key, const List<VariantMap> &value)
 {
+  if(d->partialRead && !ensureFullyParsed()) {
+    return false;
+  }
+
   if(TagLib::File::setComplexProperties(key, value)) {
     return true;
   }
@@ -345,6 +550,9 @@ bool Matroska::File::setComplexProperties(const String &key, const List<VariantM
 
 Matroska::Attachments *Matroska::File::attachments(bool create) const
 {
+  if(d->partialRead && !ensureFullyParsed()) {
+    return nullptr;
+  }
   if(!d->attachments && create)
     d->attachments = std::make_unique<Attachments>();
   return d->attachments.get();
@@ -352,9 +560,82 @@ Matroska::Attachments *Matroska::File::attachments(bool create) const
 
 Matroska::Chapters *Matroska::File::chapters(bool create) const
 {
+  if(d->partialRead && !ensureFullyParsed()) {
+    return nullptr;
+  }
   if(!d->chapters && create)
     d->chapters = std::make_unique<Chapters>();
   return d->chapters.get();
+}
+
+bool Matroska::File::ensureFullyParsed() const
+{
+  if(!d->partialRead) {
+    return true;
+  }
+
+  auto &file = *const_cast<Matroska::File *>(this);
+  const offset_t fileLength = file.length();
+  file.seek(0);
+
+  const auto head = EBML::element_cast<EBML::Element::Id::EBMLHeader>(
+    EBML::Element::factory(file));
+  if(!head || head->getId() != EBML::Element::Id::EBMLHeader) {
+    debug("Failed to find EBML head");
+    file.setValid(false);
+    return false;
+  }
+  head->skipData(file);
+
+  const std::unique_ptr<EBML::MkSegment> segment(
+    EBML::element_cast<EBML::Element::Id::MkSegment>(
+      EBML::findElement(file, EBML::Element::Id::MkSegment, fileLength - file.tell())
+    )
+  );
+  if(!segment) {
+    debug("Failed to find Matroska segment");
+    file.setValid(false);
+    return false;
+  }
+
+  if(!segment->read(file)) {
+    debug("Failed to read segment");
+    file.setValid(false);
+    return false;
+  }
+
+  auto existingTag = std::move(d->tag);
+
+  d->segment = segment->parseSegment();
+  d->seekHead = segment->parseSeekHead();
+  d->cues = segment->parseCues();
+  d->attachments = segment->parseAttachments();
+  d->chapters = segment->parseChapters();
+
+  if(existingTag) {
+    if(d->properties) {
+      existingTag->setSegmentTitle(d->properties->title());
+    }
+    d->tag = std::move(existingTag);
+  }
+  else {
+    d->tag = segment->parseTag();
+    if(d->tag && d->properties) {
+      d->tag->setSegmentTitle(d->properties->title());
+    }
+  }
+
+  d->partialRead = false;
+  d->tagStateResolved = true;
+  return true;
+}
+
+bool Matroska::File::ensureTagResolved() const
+{
+  if(d->tagStateResolved) {
+    return true;
+  }
+  return ensureFullyParsed();
 }
 
 void Matroska::File::read(bool readProperties, Properties::ReadStyle readStyle)
@@ -388,20 +669,7 @@ void Matroska::File::read(bool readProperties, Properties::ReadStyle readStyle)
     return;
   }
 
-  // Read the segment into memory from file
-  if(!segment->read(*this)) {
-    debug("Failed to read segment");
-    setValid(false);
-    return;
-  }
-
-  // Parse the elements
   d->segment = segment->parseSegment();
-  d->seekHead = segment->parseSeekHead();
-  d->cues = segment->parseCues();
-  d->tag = segment->parseTag();
-  d->attachments = segment->parseAttachments();
-  d->chapters = segment->parseChapters();
 
   if(readProperties) {
     d->properties = std::make_unique<Properties>(this);
@@ -416,7 +684,66 @@ void Matroska::File::read(bool readProperties, Properties::ReadStyle readStyle)
           EBML::element_cast<EBML::Element::Id::DocTypeVersion>(element)->getValue()));
       }
     }
+  }
 
+  if(readStyle == AudioProperties::ReadStyle::Fast) {
+    const auto fastRead = readFastSegmentData(*this, *segment, readProperties,
+                                              d->seekHead, d->tag, d->properties);
+    if(fastRead.success) {
+      if(d->tag && d->properties) {
+        d->tag->setSegmentTitle(d->properties->title());
+      }
+      d->partialRead = true;
+      d->tagStateResolved = fastRead.tagStateResolved;
+      setValid(true);
+      return;
+    }
+
+    d->seekHead.reset();
+    d->cues.reset();
+    d->tag.reset();
+    d->attachments.reset();
+    d->chapters.reset();
+    d->partialRead = false;
+    d->tagStateResolved = true;
+    if(readProperties) {
+      d->properties = std::make_unique<Properties>(this);
+      for(const auto &element : *head) {
+        if(const auto id = element->getId(); id == EBML::Element::Id::DocType) {
+          d->properties->setDocType(
+            EBML::element_cast<EBML::Element::Id::DocType>(element)->getValue());
+        }
+        else if(id == EBML::Element::Id::DocTypeVersion) {
+          d->properties->setDocTypeVersion(static_cast<int>(
+            EBML::element_cast<EBML::Element::Id::DocTypeVersion>(element)->getValue()));
+        }
+      }
+    }
+    else {
+      d->properties.reset();
+    }
+
+    seek(segment->segmentDataOffset());
+  }
+
+  // Read the segment into memory from file
+  if(!segment->read(*this)) {
+    debug("Failed to read segment");
+    setValid(false);
+    return;
+  }
+
+  // Parse the elements
+  d->segment = segment->parseSegment();
+  d->seekHead = segment->parseSeekHead();
+  d->cues = segment->parseCues();
+  d->tag = segment->parseTag();
+  d->attachments = segment->parseAttachments();
+  d->chapters = segment->parseChapters();
+  d->partialRead = false;
+  d->tagStateResolved = true;
+
+  if(readProperties) {
     segment->parseInfo(d->properties.get());
     segment->parseTracks(d->properties.get());
     if(d->tag) {
@@ -435,6 +762,9 @@ void Matroska::File::read(bool readProperties, Properties::ReadStyle readStyle)
 
 bool Matroska::File::save()
 {
+  if(d->partialRead && !ensureFullyParsed()) {
+    return false;
+  }
   if(readOnly()) {
     debug("Matroska::File::save() -- File is read only.");
     return false;

--- a/taglib/matroska/matroskafile.h
+++ b/taglib/matroska/matroskafile.h
@@ -176,6 +176,8 @@ namespace TagLib::Matroska {
 
   private:
     void read(bool readProperties, Properties::ReadStyle readStyle);
+    bool ensureFullyParsed() const;
+    bool ensureTagResolved() const;
     class FilePrivate;
     friend class Properties;
     TAGLIB_MSVC_SUPPRESS_WARNING_NEEDS_TO_HAVE_DLL_INTERFACE

--- a/taglib/matroska/matroskaseekhead.cpp
+++ b/taglib/matroska/matroskaseekhead.cpp
@@ -64,6 +64,11 @@ void Matroska::SeekHead::addEntry(ID id, offset_t offset)
   setNeedsRender(true);
 }
 
+const List<std::pair<unsigned int, offset_t>> &Matroska::SeekHead::entryList() const
+{
+  return entries;
+}
+
 ByteVector Matroska::SeekHead::renderInternal()
 {
   const auto beforeSize = sizeRenderedOrWritten();

--- a/taglib/matroska/matroskaseekhead.h
+++ b/taglib/matroska/matroskaseekhead.h
@@ -39,6 +39,7 @@ namespace TagLib {
       bool isValid(TagLib::File &file) const;
       void addEntry(const Element &element);
       void addEntry(ID id, offset_t offset);
+      const List<std::pair<unsigned int, offset_t>> &entryList() const;
       void write(TagLib::File &file) override;
       void sort();
       bool sizeChanged(Element &caller, offset_t delta) override;

--- a/tests/test_matroska.cpp
+++ b/tests/test_matroska.cpp
@@ -120,11 +120,13 @@
  * - some error cases because they never occur with the unit tests.
  */
 
-#include <string>
 #include <cstdio>
+#include <string>
+#include <vector>
 
 #include "tbytevectorlist.h"
 #include "tbytevectorstream.h"
+#include "tfilestream.h"
 #include "tpropertymap.h"
 #include "matroskafile.h"
 #include "matroskatag.h"
@@ -141,12 +143,114 @@
 using namespace std;
 using namespace TagLib;
 
+class RangeRestrictedFileStream : public IOStream
+{
+public:
+  explicit RangeRestrictedFileStream(const char *fileName) :
+    m_stream(fileName, true)
+  {
+  }
+
+  void allowRead(offset_t begin, offset_t end)
+  {
+    m_allowedReads.push_back({begin, end});
+  }
+
+  FileName name() const override
+  {
+    return m_stream.name();
+  }
+
+  ByteVector readBlock(size_t length) override
+  {
+    const offset_t begin = m_stream.tell();
+    const offset_t end = begin + static_cast<offset_t>(length);
+    if(length != 0 && !isReadAllowed(begin, end)) {
+      return ByteVector();
+    }
+    return m_stream.readBlock(length);
+  }
+
+  void writeBlock(const ByteVector &data) override
+  {
+    m_stream.writeBlock(data);
+  }
+
+  void insert(const ByteVector &data, offset_t start, size_t replace) override
+  {
+    m_stream.insert(data, start, replace);
+  }
+
+  void removeBlock(offset_t start, size_t length) override
+  {
+    m_stream.removeBlock(start, length);
+  }
+
+  bool readOnly() const override
+  {
+    return m_stream.readOnly();
+  }
+
+  bool isOpen() const override
+  {
+    return m_stream.isOpen();
+  }
+
+  void seek(offset_t offset, Position p = Beginning) override
+  {
+    m_stream.seek(offset, p);
+  }
+
+  void clear() override
+  {
+    m_stream.clear();
+  }
+
+  offset_t tell() const override
+  {
+    return m_stream.tell();
+  }
+
+  offset_t length() override
+  {
+    return m_stream.length();
+  }
+
+  void truncate(offset_t length) override
+  {
+    m_stream.truncate(length);
+  }
+
+private:
+  struct ReadRange
+  {
+    offset_t begin;
+    offset_t end;
+  };
+
+  bool isReadAllowed(offset_t begin, offset_t end) const
+  {
+    for(const auto &range : m_allowedReads) {
+      if(range.begin <= begin && end <= range.end) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  FileStream m_stream;
+  vector<ReadRange> m_allowedReads;
+};
+
 class TestMatroska : public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestMatroska);
   CPPUNIT_TEST(testPropertiesMka);
   CPPUNIT_TEST(testPropertiesMkv);
   CPPUNIT_TEST(testPropertiesWebm);
+  CPPUNIT_TEST(testFastReadWithoutTags);
+  CPPUNIT_TEST(testFastReadWithLateTags);
+  CPPUNIT_TEST(testFastReadPreservesAttachmentsChaptersOnSave);
   CPPUNIT_TEST(testSimpleTagsAndAttachments);
   CPPUNIT_TEST(testAddRemoveTagsAttachments);
   CPPUNIT_TEST(testTagsWebm);
@@ -205,6 +309,83 @@ public:
 
     Matroska::File noProps(TEST_FILE_PATH_C("no-tags.webm"), false);
     CPPUNIT_ASSERT(!noProps.audioProperties());
+  }
+
+  void testFastReadWithoutTags()
+  {
+    RangeRestrictedFileStream stream(TEST_FILE_PATH_C("no-tags.mka"));
+    CPPUNIT_ASSERT(stream.isOpen());
+    stream.allowRead(0, 512);
+
+    Matroska::File f(&stream, true, AudioProperties::Fast);
+    CPPUNIT_ASSERT(f.isValid());
+    CPPUNIT_ASSERT(f.audioProperties());
+    CPPUNIT_ASSERT_EQUAL(444, f.audioProperties()->lengthInMilliseconds());
+    CPPUNIT_ASSERT_EQUAL(223, f.audioProperties()->bitrate());
+    CPPUNIT_ASSERT_EQUAL(String("A_MPEG/L3"), f.audioProperties()->codecName());
+    CPPUNIT_ASSERT(!f.tag(false));
+  }
+
+  void testFastReadWithLateTags()
+  {
+    RangeRestrictedFileStream stream(TEST_FILE_PATH_C("tags-before-cues.mkv"));
+    CPPUNIT_ASSERT(stream.isOpen());
+    stream.allowRead(0, 512);
+    stream.allowRead(2800, 3300);
+
+    Matroska::File f(&stream, true, AudioProperties::Fast);
+    CPPUNIT_ASSERT(f.isValid());
+    CPPUNIT_ASSERT(f.audioProperties());
+    CPPUNIT_ASSERT_EQUAL(120, f.audioProperties()->lengthInMilliseconds());
+    auto tag = f.tag(false);
+    CPPUNIT_ASSERT(tag);
+    CPPUNIT_ASSERT_EQUAL(String("handbrake"), tag->title());
+  }
+
+  void testFastReadPreservesAttachmentsChaptersOnSave()
+  {
+    ScopedFileCopy copy("tags-before-cues", ".mkv");
+    const string newname = copy.fileName();
+    const List<Matroska::Chapter> chapterList{
+      Matroska::Chapter(
+        0ULL, 40000ULL,
+        List<Matroska::Chapter::Display>{Matroska::Chapter::Display("Fast Chapter", "eng")},
+        77ULL, false)
+    };
+    const Matroska::ChapterEdition edition(chapterList, true, false, 88ULL);
+
+    {
+      Matroska::File f(newname.c_str());
+      CPPUNIT_ASSERT(f.isValid());
+      f.attachments(true)->addAttachedFile(Matroska::AttachedFile(
+        ByteVector("PNG data"), "folder.png", "image/png", 1763187649ULL,
+        "Cover"));
+      f.chapters(true)->addChapterEdition(edition);
+      CPPUNIT_ASSERT(f.save());
+    }
+    {
+      Matroska::File f(newname.c_str(), true, AudioProperties::Fast);
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.tag(false));
+      CPPUNIT_ASSERT_EQUAL(StringList({"DURATION", "PICTURE", "CHAPTERS"}),
+                           f.complexPropertyKeys());
+      CPPUNIT_ASSERT(f.attachments(false));
+      CPPUNIT_ASSERT(f.chapters(false));
+      f.tag()->setComment("Fast path comment");
+      CPPUNIT_ASSERT(f.save());
+    }
+    {
+      Matroska::File f(newname.c_str(), true, AudioProperties::Accurate);
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.tag(false));
+      CPPUNIT_ASSERT_EQUAL(String("Fast path comment"), f.tag()->comment());
+      auto attachments = f.attachments(false);
+      CPPUNIT_ASSERT(attachments);
+      CPPUNIT_ASSERT_EQUAL(1U, attachments->attachedFileList().size());
+      auto chapters = f.chapters(false);
+      CPPUNIT_ASSERT(chapters);
+      CPPUNIT_ASSERT_EQUAL(1U, chapters->chapterEditionList().size());
+    }
   }
 
   void testSimpleTagsAndAttachments()


### PR DESCRIPTION
Use a bounded early segment scan in Matroska::File when opening with ReadStyle::Fast, then use SeekHead entries to jump directly to Info, Tracks, and Tags instead of reading the whole segment into memory.

Keep the optimization semantics-safe by tracking partial parses and falling back to a full segment parse on demand before operations that need unresolved state such as tag creation, attachments, chapters, complex properties, and save. This preserves existing behavior for attachments, chapters, and writes while still allowing no-tag files and late-tag files to complete the fast read path.

Add regression coverage for no-tag fast reads, late-tag fast reads, and a save round-trip that verifies attachments and chapters survive a fast open followed by a tag update. Also expose SeekHead entries through a const accessor so the fast path can resolve target element offsets without reparsing the segment.