### PR TITLE
Fix bitrate calculation unit errors in ADTS and MP4 ESDS parsers (Breakout from other MP4 commits)

### DIFF
--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -224,7 +224,7 @@ MP4::Properties::read(File *file, const Atoms *atoms)
         pos += 10;
         if(const unsigned int bitrateValue = data.toUInt(pos);
            bitrateValue != 0 || d->length <= 0) {
-          d->bitrate = static_cast<int>((bitrateValue + 500) / 1000.0 + 0.5);
+          d->bitrate = static_cast<int>(bitrateValue / 1000.0 + 0.5);
         }
         else {
           d->bitrate = static_cast<int>(

--- a/taglib/mpeg/mpegheader.cpp
+++ b/taglib/mpeg/mpegheader.cpp
@@ -239,7 +239,7 @@ void MPEG::Header::parse(File *file, offset_t offset, bool checkLength)
                        (static_cast<unsigned char>(frameLengthData[0]) << 3) |
                        (static_cast<unsigned char>(frameLengthData[1]) >> 5);
 
-      d->bitrate = static_cast<int>(d->frameLength * d->sampleRate / 1024.0 + 0.5) * 8 / 1024;
+      d->bitrate = static_cast<int>(d->frameLength * d->sampleRate / 1024.0 + 0.5) * 8 / 1000;
     }
   }
   else {


### PR DESCRIPTION
mpegheader.cpp: ADTS bitrate divided by 1024 (binary kilo) instead of 1000 (decimal kilo), causing ~2.4% underreporting for all AAC streams.

mp4properties.cpp: ESDS averageBitrate double-rounded via both +500 and +0.5 before int cast, causing standard bitrates (128000, 192000, etc.) to read 1 kbps too high.

urs: this is the fix for the bitrate problem that we were discussing on the Issue a while ago:
https://github.com/taglib/taglib/issues/1292