### PR TITLE
Fix writing too many offsets when updating MP4 stco/co64 atoms (#1332)

### DIFF
--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -200,7 +200,8 @@ MP4::Tag::updateOffsets(offset_t delta, offset_t offset)
       unsigned int count = data.toUInt();
       d->file->seek(atom->offset() + 16);
       unsigned int pos = 4;
-      while(count--) {
+      const unsigned int maxPos = data.size() - 4;
+      while(count-- && pos <= maxPos) {
         auto o = static_cast<offset_t>(data.toUInt(pos));
         if(o > offset) {
           o += delta;
@@ -220,7 +221,8 @@ MP4::Tag::updateOffsets(offset_t delta, offset_t offset)
       unsigned int count = data.toUInt();
       d->file->seek(atom->offset() + 16);
       unsigned int pos = 4;
-      while(count--) {
+      const unsigned int maxPos = data.size() - 8;
+      while(count-- && pos <= maxPos) {
         long long o = data.toLongLong(pos);
         if(o > offset) {
           o += delta;


### PR DESCRIPTION
This will fix a DoS with a crafted MP4 file causing too many offsets to be written when updating the stco or co64 tables in MP4 files.

Credits for the discovery of this bug go to Yuen Ying Ng (Ruth) (Cyber Security Researcher at PwC Hong Kong).

