### PR TITLE
Fix/shorten rice golomb k bounds

### DIFF
--- a/taglib/shorten/shortenfile.cpp
+++ b/taglib/shorten/shortenfile.cpp
@@ -104,6 +104,11 @@ namespace {
 
   bool VariableLengthInput::getRiceGolombCode(int32_t &i32, int32_t k)
   {
+    // k must be in [0, 31]: values outside this range would cause shift-by-32
+    // (UB for int32_t) or negative shifts, and are invalid for this format.
+    if(k < 0 || k > 31)
+      return false;
+
     static constexpr uint32_t sMaskTable[] = {
       0x0,
       0x1,        0x3,        0x7,        0xf,


### PR DESCRIPTION
This was reported by the CSA (Clang Static Analyzer)

Shorten: Reject out-of-range k in getRiceGolombCode
k values outside [0, 31] cause undefined behavior: a left shift by 32
on int32_t (UB in C++) when bitsAvailable reaches 32 after a buffer
refill. Guard against this at the top of getRiceGolombCode and return
false (invalid file) for any k outside the valid range.