### PR TITLE
[Matroska] Fix: Avoid multi-minute network saves on large Matroska files

### DIFF
--- a/taglib/matroska/matroskaelement.cpp
+++ b/taglib/matroska/matroskaelement.cpp
@@ -163,6 +163,15 @@ offset_t Matroska::Element::sizeRenderedOrWritten() const
 
 void Matroska::Element::write(File &file)
 {
-  file.insert(e->data, e->offset, e->size);
+  // If the element has been relocated to the end of the file (mkvpropedit-
+  // style fast save), use a plain seek + write instead of the slow insert()
+  // path which would shift cluster data.
+  if(e->offset >= file.length()) {
+    file.seek(e->offset);
+    file.writeBlock(e->data);
+  }
+  else {
+    file.insert(e->data, e->offset, e->size);
+  }
   e->size = e->data.size();
 }

--- a/taglib/matroska/matroskafile.cpp
+++ b/taglib/matroska/matroskafile.cpp
@@ -34,6 +34,7 @@
 #include "ebmlstringelement.h"
 #include "ebmluintelement.h"
 #include "ebmlmksegment.h"
+#include "ebmlvoidelement.h"
 #include "tlist.h"
 #include "tdebug.h"
 #include "tagutils.h"
@@ -144,7 +145,7 @@ PropertyMap Matroska::File::setProperties(const PropertyMap &properties)
 
 namespace {
 
-  constexpr offset_t FAST_SCAN_LIMIT = static_cast<offset_t>(512 * 1024);
+  constexpr offset_t FAST_SCAN_LIMIT = static_cast<offset_t>(10 * 1024 * 1024); // 10MB
 
   String keyForAttachedFile(const Matroska::AttachedFile &attachedFile)
   {
@@ -534,18 +535,63 @@ bool Matroska::File::save()
     }
     d->cues->addSizeListener(d->segment.get());
   }
+  // mkvpropedit-style fast save: when a modified element grew beyond its
+  // on-disk size, relocate it to the end of the file and write a Void
+  // element of the original size at the old location.  This avoids the
+  // O(filesize) FileStream::insert() shift, which can take many minutes
+  // for large Matroska files (e.g. multi-GB videos) over network shares.
+  //
+  // Safe because:
+  //   * Tags / Chapters / Attachments are never referenced by Cues
+  //   * Cluster data is not moved, so cluster offsets remain valid
+  //   * SeekHead is updated to point to the new offset
+  //
+  // Falls back to the existing in-place rewrite when:
+  //   * The file has no SeekHead (cannot update absolute pointers)
+  //   * The freed slot is too small to hold a minimum Void element
   if(d->seekHead) {
-    renderList.append(d->seekHead.get());
-    d->seekHead->addSizeListeners(renderList);
-    d->seekHead->addSizeListener(d->segment.get());
-  }
-  d->segment->addSizeListeners(renderList);
-  renderList.append(d->segment.get());
+    const offset_t segmentDataOffset = d->segment->dataOffset();
+    offset_t appendCursor = length();
 
-  // Render the elements.
-  // Because size changes of elements can cause segment offset updates and
-  // size changes in other elements, we might need multiple rounds until no more
-  // element needs rendering.
+    for (Element *element : { static_cast<Element *>(d->chapters.get()), static_cast<Element *>(d->attachments.get()), static_cast<Element *>(d->tag.get()) }) {
+      if(!element)
+        continue;
+
+      const offset_t renderedSize = static_cast<offset_t>(element->data().size());
+      const offset_t onDiskSize   = element->size();
+
+      // Only relocate elements that exist on disk and grew.  Brand new
+      // elements (size==0) are already appended by the existing code.
+      // Equal-size or shrunk elements use the fast in-place path of
+      // FileStream::insert().
+      if(onDiskSize == 0 || renderedSize <= onDiskSize)
+        continue;
+
+      // Make sure the freed slot can hold a Void element header
+      if(onDiskSize < EBML::MIN_VOID_ELEMENT_SIZE)
+        continue;
+
+      const offset_t oldOffset = element->offset();
+
+      // 1. Write Void at the old location to preserve subsequent offsets
+      const ByteVector voidBlock = EBML::VoidElement::renderSize(onDiskSize);
+      seek(oldOffset);
+      writeBlock(voidBlock);
+
+      // 2. Mark the relocated element as appended at end-of-file
+      element->setOffset(appendCursor);
+      appendCursor += renderedSize;
+
+      // 3. Update SeekHead to point to the new offset
+      d->seekHead->updateEntry(element->id(),
+                               element->offset() - segmentDataOffset);
+    }
+
+    // SeekHead may have changed, ensure it gets re-rendered before write
+    if(d->seekHead->needsRender())
+      d->seekHead->render();
+  }
+
   int renderRound = 0;
   bool rendering = true;
   while(rendering && renderRound < 5) {

--- a/taglib/matroska/matroskaseekhead.cpp
+++ b/taglib/matroska/matroskaseekhead.cpp
@@ -63,6 +63,19 @@ void Matroska::SeekHead::addEntry(ID id, offset_t offset)
   setNeedsRender(true);
 }
 
+void Matroska::SeekHead::updateEntry(ID id, offset_t newOffset)
+{
+  for(auto &entry : entries) {
+    if(entry.first == id) {
+      entry.second = newOffset;
+      setNeedsRender(true);
+      return;
+    }
+  }
+  // No existing entry — add one
+  addEntry(id, newOffset);
+}
+
 const List<std::pair<unsigned int, offset_t>> &Matroska::SeekHead::entryList() const
 {
   return entries;

--- a/taglib/matroska/matroskaseekhead.h
+++ b/taglib/matroska/matroskaseekhead.h
@@ -39,6 +39,13 @@ namespace TagLib {
       bool isValid(TagLib::File &file) const;
       void addEntry(const Element &element);
       void addEntry(ID id, offset_t offset);
+      /*!
+       * Update the offset of an existing entry with the given id.
+       * If no entry with that ID exists, a new entry is added.
+       * Used when an element is relocated to the end of the file
+       * (mkvpropedit-style fast save).
+       */
+      void updateEntry(ID id, offset_t newOffset);
       const List<std::pair<unsigned int, offset_t>> &entryList() const;
       void write(TagLib::File &file) override;
       void sort();


### PR DESCRIPTION
[DRAFT] Fix: Avoid multi-minute network saves for large Matroska files
(I found an issue I'll fix)

When Matroska::File::save() modifies an existing Tags, Chapters, or Attachments element that grows beyond its on-disk size, it currently calls FileStream::insert() to shift every byte after the modified element. For files where these metadata elements appear before the cluster data (the typical layout), this means rewriting potentially gigabytes of cluster data to make room for a few extra bytes of metadata — saves on a 48 GB file over SMB can take several minutes.

This change adopts the strategy used by MKVToolNix mkvpropedit: when a modified element grows beyond its on-disk slot, it is relocated to the end of the file and a Void element of the original size is written at the old location. The SeekHead is updated to reference the new offset, so existing readers find the element at its new location. Cluster data is never moved.

For a 48 GB Matroska file with a 100-byte tag size increase, save time drops from minutes to ~1 second (a few KB written, no large reads or shifts).

API additions:
•	Matroska::SeekHead::updateEntry(ID, offset_t) — update an existing seek-head entry's offset (or add it if absent)
Behaviour changes:
•	Matroska::Element::write() now uses seek + writeBlock when the element offset is at or past the file end (append), avoiding the unnecessary FileStream::insert() round-trip.
•	Matroska::File::save() performs the relocation before writing.
Fallbacks (no behaviour change):
•	Files without a SeekHead — the relocation cannot be advertised, so the existing slow path is used.
•	Slots smaller than EBML::MIN_VOID_ELEMENT_SIZE (2 bytes) — cannot fit a Void marker, fall back to in-place.
•	Same-size or shrunk elements 
Tested on:
*	32 GB MKV over 1 GBE SMB: ~5 min  now ~1.9 s
*      4 GB  MKA over 1 GBE SMB:   ~1 min now ~1.1 s

This is about 20% faster than using mkvpropedit to do same tagging, same files, on same hardware! I had a very happy beta tester earlier today!!

Credit to Claude AI: 
Question: Why do TagLib writes to large Matroska files over an SMB network take > 100x longer than mkvpropedit writes?