### PR TITLE
[WAV] Decode iXML as UTF-8

### DIFF
--- a/taglib/riff/wav/wavfile.cpp
+++ b/taglib/riff/wav/wavfile.cpp
@@ -276,7 +276,7 @@ void RIFF::WAV::File::read(bool readProperties)
     }
     else if(name == "iXML") {
       d->hasiXML = true;
-      d->iXMLData = String(chunkData(i));
+      d->iXMLData = String(chunkData(i), String::UTF8);
     }
     else if(name == "bext") {
       d->hasBEXT = true;


### PR DESCRIPTION
The iXML chunk in BWF/WAV files is specified as UTF-8 (per the EBU Tech 3285 supplement and the iXML spec). The reader was constructing the String without an encoding hint, which falls back to Latin-1 and mangles any non-ASCII bytes (e.g. Unicode in <NOTE>, <PROJECT>, or <TRACK_LIST> entries written by Sound Devices, Zaxcom, etc.).