### PR TITLE
[Matroska] Follow chained SeekHead entries when parsing segment metadata

### DIFF
--- a/taglib/matroska/ebml/ebmlmksegment.cpp
+++ b/taglib/matroska/ebml/ebmlmksegment.cpp
@@ -108,9 +108,36 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
         if(accPadding > 0)
           target->setPadding(accPadding);
       };
-      for(const auto &[idValue, relativeOffset] : matroskaSeekHead->entryList()) {
+
+      // Build a work list of seek entries.  Some muxers (e.g. MakeMKV,
+      // mkvmerge) write a small primary SeekHead at the start of the segment
+      // that only references a secondary SeekHead at the end of the file,
+      // which in turn lists Info / Tracks / Tags / Chapters / Attachments.
+      // Follow such MkSeekHead -> MkSeekHead chains so the real entries are
+      // not silently dropped.
+      List<std::pair<unsigned int, offset_t>> entries =
+        matroskaSeekHead->entryList();
+      // Guard against pathological / circular chains.
+      int chainedSeekHeadsFollowed = 0;
+      constexpr int MAX_CHAINED_SEEKHEADS = 8;
+
+      for(size_t i = 0; i < entries.size(); ++i) {
+        const auto &[idValue, relativeOffset] = entries[i];
         const offset_t absoluteOffset = segDataOffset + relativeOffset;
         switch(static_cast<Id>(idValue)) {
+        case Id::MkSeekHead: {
+          if(chainedSeekHeadsFollowed++ >= MAX_CHAINED_SEEKHEADS)
+            break;
+          auto chained = readElementAt<Id::MkSeekHead, MkSeekHead>(
+            file, absoluteOffset, maxOffset);
+          if(!chained)
+            break;
+          if(const auto parsed = chained->parse(segDataOffset)) {
+            for(const auto &entry : parsed->entryList())
+              entries.append(entry);
+          }
+          break;
+        }
         case Id::MkCues:
           if(!((cues = readElementAt<Id::MkCues, MkCues>(
             file, absoluteOffset, maxOffset))))


### PR DESCRIPTION
Some muxers — notably MakeMKV, and mkvmerge in certain configurations — write a small primary seekHead at the start of the segment that contains a single entry referencing a secondary seekHead near the end of the file. The secondary seekHead carries the actual entries for info, tracks, tags, chapters, and attachments.

MkSegment::readLimited() previously had no case Id::MkSeekHead: in its seek-driven dispatch, so chained SeekHead entries were silently dropped. The result was a file that opened as valid (isValid() == true) but with empty properties, no chapters, no tags, and no attachments — even though mkvinfo, ffprobe, and MediaInfo all read the file correctly.

This change follows MkSeekHead-typed seek entries (with a guard against pathological/circular chains, capped at 8 chained SeekHeads) and merges the referenced SeekHead's entries into the work list, so all metadata is loaded.

Verified against a 3.5 GB MakeMKV-produced MKV containing 11 chapters, 28 simple tags, full Info and Tracks — all of which previously parsed as empty and now parse correctly. Files with a flat (non-chained) SeekHead are unaffected.

This is a critical fix for all Kodi use. Please include in upcoming 2.3 release.