### PR TITLE
[Matrsoka] Read Performance over SMB/NFS

### DIFF
--- a/taglib/matroska/ebml/ebmlmkattachments.cpp
+++ b/taglib/matroska/ebml/ebmlmkattachments.cpp
@@ -22,6 +22,8 @@
 #include "ebmlstringelement.h"
 #include "ebmluintelement.h"
 #include "ebmlbinaryelement.h"
+#include "ebmlutils.h"
+#include "tfile.h"
 #include "matroskaattachments.h"
 #include "matroskaattachedfile.h"
 
@@ -40,6 +42,32 @@ EBML::MkAttachments::MkAttachments(Id, int sizeLength, offset_t dataSize, offset
 EBML::MkAttachments::MkAttachments():
   MasterElement(Id::MkAttachments, 0, 0, 0)
 {
+}
+
+bool EBML::MkAttachments::readMetadataOnly(File &file)
+{
+  const offset_t maxOffset = file.tell() + dataSize;
+  std::unique_ptr<Element> element;
+  while((element = findNextElement(file, maxOffset))) {
+    if(element->getId() != Id::MkAttachedFile) {
+      element->skipData(file);
+      continue;
+    }
+    // Manually iterate MkAttachedFile children so we can skip the binary
+    // MkAttachedFileData payload, which can be very large (cover art, fonts).
+    auto attachedFile = std::make_unique<MasterElement>(Id::MkAttachedFile);
+    const offset_t childMaxOffset = file.tell() + element->getDataSize();
+    std::unique_ptr<Element> child;
+    while((child = findNextElement(file, childMaxOffset))) {
+      if(child->getId() == Id::MkAttachedFileData)
+        child->skipData(file);
+      else if(!child->read(file))
+        return false;
+      attachedFile->appendElement(std::move(child));
+    }
+    elements.push_back(std::move(attachedFile));
+  }
+  return file.tell() == maxOffset;
 }
 
 std::unique_ptr<Matroska::Attachments> EBML::MkAttachments::parse() const
@@ -70,11 +98,14 @@ std::unique_ptr<Matroska::Attachments> EBML::MkAttachments::parse() const
       else if(id == Id::MkAttachedFileUID)
         uid = element_cast<Id::MkAttachedFileUID>(attachedFileChild)->getValue();
     }
-    if(!(filename && data))
+    // In Fast mode, MkAttachedFileData has been skipped; emit the
+    // attachment with an empty data ByteVector so callers still see its
+    // metadata (filename, media type, UID, description).
+    if(!filename)
       continue;
 
     attachments->addAttachedFile(Matroska::AttachedFile(
-      *data, *filename, mediaType ? *mediaType : String(),
+      data ? *data : ByteVector(), *filename, mediaType ? *mediaType : String(),
       uid, description ? *description : String()));
   }
   return attachments;

--- a/taglib/matroska/ebml/ebmlmkattachments.h
+++ b/taglib/matroska/ebml/ebmlmkattachments.h
@@ -39,6 +39,17 @@ namespace TagLib {
       MkAttachments();
 
       std::unique_ptr<Matroska::Attachments> parse() const;
+
+      /*!
+       * Read the children of this element but skip the binary data of every
+       * MkAttachedFileData child.  The resulting Matroska::AttachedFile
+       * objects expose all metadata (file name, media type, UID, description,
+       * size) but their data() will be empty.
+       *
+       * Used for AudioProperties::Fast to avoid reading potentially large
+       * attachments (cover art, fonts) when the caller only wants metadata.
+       */
+      bool readMetadataOnly(File &file);
     };
   }
 }

--- a/taglib/matroska/ebml/ebmlmksegment.cpp
+++ b/taglib/matroska/ebml/ebmlmksegment.cpp
@@ -83,6 +83,12 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
   const offset_t filePos = file.tell();
   const offset_t maxOffset = filePos + dataSize;
   const offset_t maxScanOffset = filePos + std::min(scanLimit, dataSize);
+  // When scanLimit is less than dataSize, the caller has requested a
+  // fast/limited scan (e.g. AudioProperties::Fast).  In that case and if the
+  // file has been opened in read-only mode, we skip parsing the Cues element,
+  // which can be tens of MB on large files, causing severe slowdowns over
+  // network filesystems, and do not have to be updated in read-only mode.
+  const bool skipCues = file.readOnly() && scanLimit < dataSize;
   MasterElement *pendingPaddingTarget = nullptr;
   offset_t accumulatedPadding = 0;
   std::unique_ptr<Element> element;
@@ -139,9 +145,11 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
           break;
         }
         case Id::MkCues:
-          if(!((cues = readElementAt<Id::MkCues, MkCues>(
-            file, absoluteOffset, maxOffset))))
-            return false;
+          if(!skipCues) {
+            if(!((cues = readElementAt<Id::MkCues, MkCues>(
+              file, absoluteOffset, maxOffset))))
+              return false;
+          }
           break;
         case Id::MkInfo:
           if(!((info = readElementAt<Id::MkInfo, MkInfo>(
@@ -187,9 +195,14 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
     else if(id == Id::MkCues) {
       pendingPaddingTarget = nullptr;
       accumulatedPadding = 0;
-      cues = element_cast<Id::MkCues>(std::move(element));
-      if(!cues->read(file))
-        return false;
+      if(!skipCues) {
+        cues = element_cast<Id::MkCues>(std::move(element));
+        if(!cues->read(file))
+          return false;
+      }
+      else {
+        element->skipData(file);
+      }
     }
     else if(id == Id::MkInfo) {
       pendingPaddingTarget = nullptr;

--- a/taglib/matroska/ebml/ebmlmksegment.cpp
+++ b/taglib/matroska/ebml/ebmlmksegment.cpp
@@ -54,6 +54,25 @@ std::unique_ptr<ElementType> readElementAt(File &file,
   return typed;
 }
 
+// Specialised read-at for MkAttachments that skips the binary data of
+// every MkAttachedFileData child.  See MkAttachments::readMetadataOnly().
+std::unique_ptr<EBML::MkAttachments> readAttachmentsMetadataAt(
+    File &file, offset_t offset, offset_t maxOffset)
+{
+  if(offset < 0 || offset >= maxOffset)
+    return nullptr;
+
+  file.seek(offset);
+  auto element = EBML::Element::factory(file);
+  if(!element || element->getId() != EBML::Element::Id::MkAttachments)
+    return nullptr;
+
+  auto typed = EBML::element_cast<EBML::Element::Id::MkAttachments>(std::move(element));
+  if(!typed || !typed->readMetadataOnly(file))
+    return nullptr;
+  return typed;
+}
+
 } // namespace
 
 EBML::MkSegment::MkSegment(int sizeLength, offset_t dataSize, offset_t offset):
@@ -89,6 +108,9 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
   // which can be tens of MB on large files, causing severe slowdowns over
   // network filesystems, and do not have to be updated in read-only mode.
   const bool skipCues = file.readOnly() && scanLimit < dataSize;
+  // With AudioProperties::Fast, we also skip the binary data of attachments
+  // (cover art, fonts), which is rarely needed during a fast metadata read.
+  const bool skipAttachmentData = scanLimit < dataSize;
   MasterElement *pendingPaddingTarget = nullptr;
   offset_t accumulatedPadding = 0;
   std::unique_ptr<Element> element;
@@ -168,9 +190,16 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
           accumulateVoidPadding(tags.get());
           break;
         case Id::MkAttachments:
-          if(!((attachments = readElementAt<Id::MkAttachments, MkAttachments>(
-            file, absoluteOffset, maxOffset))))
-            return false;
+          if(!skipAttachmentData) {
+            if(!((attachments = readElementAt<Id::MkAttachments, MkAttachments>(
+              file, absoluteOffset, maxOffset))))
+              return false;
+          }
+          else {
+            if(!((attachments = readAttachmentsMetadataAt(
+              file, absoluteOffset, maxOffset))))
+              return false;
+          }
           accumulateVoidPadding(attachments.get());
           break;
         case Id::MkChapters:
@@ -230,7 +259,9 @@ bool EBML::MkSegment::readLimited(File &file, offset_t scanLimit)
       pendingPaddingTarget = nullptr;
       accumulatedPadding = 0;
       attachments = element_cast<Id::MkAttachments>(std::move(element));
-      if(!attachments->read(file))
+      if(!(skipAttachmentData
+             ? attachments->readMetadataOnly(file)
+             : attachments->read(file)))
         return false;
       pendingPaddingTarget = attachments.get();
     }


### PR DESCRIPTION
Reading large Matroska files over network filesystems (SMB/NFS) is very slow because TagLib reads megabytes of data that aren't needed for a fast metadata read.

This PR adds two Fast-mode optimizations (AudioProperties::Fast):
1.	Skip the Cues element. Cues are only used by Accurate-mode validation. On large MKV files they can be tens of MB; reading them adds significant latency over network filesystems for no benefit in Fast mode.
2.	Skip the binary payload of attachments. Cover art and fonts are common multi-MB attachments. In Fast mode, MkAttachments::readMetadataOnly() reads the structure of each AttachedFile (filename, MIME, UID, description, size) but skips the MkAttachedFileData payload. The parsed AttachedFile objects expose all metadata; their data() is empty.

Both optimizations are applied in the seek-driven and linear-scan code paths of MkSegment::readLimited(). Accurate mode (scanLimit == dataSize) is unchanged: Cues and attachment payloads are read normally.

Supersedes #1347 (which had unrelated FAST_SCAN_LIMIT).

NOTE: Item 2 could be removed so a tag reader can still get Cover art. Item 1 is the main optimisation needed