### PR TITLE
Fix overflow for large Apple Music cnID values

### DIFF
--- a/taglib/mp4/mp4itemfactory.cpp
+++ b/taglib/mp4/mp4itemfactory.cpp
@@ -172,7 +172,7 @@ std::pair<ByteVector, Item> ItemFactory::itemFromProperty(
     case ItemHandlerType::UInt:
       return {name, Item(static_cast<unsigned int>(values.front().toInt()))};
     case ItemHandlerType::LongLong:
-      return {name, Item(static_cast<long long>(values.front().toLongLong()))};
+      return {name, Item(values.front().toLongLong())};
     case ItemHandlerType::Byte:
       return {name, Item(static_cast<unsigned char>(values.front().toInt()))};
     case ItemHandlerType::Bool:

--- a/taglib/mp4/mp4itemfactory.cpp
+++ b/taglib/mp4/mp4itemfactory.cpp
@@ -172,7 +172,7 @@ std::pair<ByteVector, Item> ItemFactory::itemFromProperty(
     case ItemHandlerType::UInt:
       return {name, Item(static_cast<unsigned int>(values.front().toInt()))};
     case ItemHandlerType::LongLong:
-      return {name, Item(static_cast<long long>(values.front().toInt()))};
+      return {name, Item(static_cast<long long>(values.front().toLonglong()))};
     case ItemHandlerType::Byte:
       return {name, Item(static_cast<unsigned char>(values.front().toInt()))};
     case ItemHandlerType::Bool:
@@ -299,7 +299,7 @@ ItemFactory::NameHandlerMap ItemFactory::nameHandlerMap() const
     {"rate", ItemHandlerType::TextOrInt},
     {"tvsn", ItemHandlerType::UInt},
     {"tves", ItemHandlerType::UInt},
-    {"cnID", ItemHandlerType::UInt},
+    {"cnID", ItemHandlerType::LongLong},
     {"sfID", ItemHandlerType::UInt},
     {"atID", ItemHandlerType::UInt},
     {"geID", ItemHandlerType::UInt},

--- a/taglib/mp4/mp4itemfactory.cpp
+++ b/taglib/mp4/mp4itemfactory.cpp
@@ -172,7 +172,7 @@ std::pair<ByteVector, Item> ItemFactory::itemFromProperty(
     case ItemHandlerType::UInt:
       return {name, Item(static_cast<unsigned int>(values.front().toInt()))};
     case ItemHandlerType::LongLong:
-      return {name, Item(static_cast<long long>(values.front().toLonglong()))};
+      return {name, Item(static_cast<long long>(values.front().toLongLong()))};
     case ItemHandlerType::Byte:
       return {name, Item(static_cast<unsigned char>(values.front().toInt()))};
     case ItemHandlerType::Bool:

--- a/tests/test_mp4.cpp
+++ b/tests/test_mp4.cpp
@@ -883,6 +883,7 @@ public:
       tag->setItem("trkn", MP4::Item(2, 10));
       tag->setItem("rate", MP4::Item(80));
       tag->setItem("plID", MP4::Item(1540934238LL));
+      tag->setItem("cnID", MP4::Item(9876543210LL));
       tag->setItem("rtng", MP4::Item(static_cast<unsigned char>(2)));
       f.save();
     }
@@ -904,6 +905,7 @@ public:
       CPPUNIT_ASSERT_EQUAL(10, item.toIntPair().second);
       CPPUNIT_ASSERT_EQUAL(80, tag->item("rate").toInt());
       CPPUNIT_ASSERT_EQUAL(1540934238LL, tag->item("plID").toLongLong());
+      CPPUNIT_ASSERT_EQUAL(9876543210LL, tag->item("cnID").toLongLong());
       CPPUNIT_ASSERT_EQUAL(static_cast<unsigned char>(2), tag->item("rtng").toByte());
       PropertyMap properties = tag->properties();
       CPPUNIT_ASSERT_EQUAL(StringList("123"), properties.value("TESTINTEGER"));


### PR DESCRIPTION
Apple Music cnID values now exceed the range of a 32-bit integer. A 64-bit type is required to prevent overflow.