### PR TITLE
Matroska: Ignore some invalid Elements.

### DIFF
--- a/taglib/matroska/ebml/ebmlelement.cpp
+++ b/taglib/matroska/ebml/ebmlelement.cpp
@@ -41,7 +41,7 @@ using namespace TagLib;
 #define RETURN_ELEMENT_FOR_CASE(eid) \
   case (eid): return make_unique_element<eid>(id, sizeLength, dataSize, offset)
 
-std::unique_ptr<EBML::Element> EBML::Element::factory(File &file)
+std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOffset)
 {
   // Get the element ID
   const offset_t offset = file.tell();
@@ -55,6 +55,13 @@ std::unique_ptr<EBML::Element> EBML::Element::factory(File &file)
   const auto &[sizeLength, dataSize] = readVINT(file);
   if(!sizeLength)
     return nullptr;
+
+  if(const offset_t currentOffset = file.tell();
+     static_cast<offset_t>(dataSize) > maxOffset - currentOffset) {
+    debug(Utils::formatString("EBML: datasize too great: %lu > (%lld - %lld)",
+      dataSize, maxOffset, currentOffset));
+    return nullptr;
+  }
 
   // Return the subclass
   // The enum switch without default will give us a warning if an ID is missing

--- a/taglib/matroska/ebml/ebmlelement.h
+++ b/taglib/matroska/ebml/ebmlelement.h
@@ -122,7 +122,7 @@ namespace TagLib
       int64_t getDataSize() const;
       ByteVector renderId() const;
       virtual ByteVector render();
-      static std::unique_ptr<Element> factory(File &file);
+      static std::unique_ptr<Element> factory(File &file, offset_t maxOffset);
       static unsigned int readId(File &file);
 
     protected:

--- a/taglib/matroska/ebml/ebmlmasterelement.cpp
+++ b/taglib/matroska/ebml/ebmlmasterelement.cpp
@@ -109,16 +109,24 @@ bool EBML::MasterElement::read(File &file, int depth)
   std::unique_ptr<Element> element;
   while((element = findNextElement(file, maxOffset))) {
     if(auto master = dynamic_cast<MasterElement *>(element.get())) {
-      if(!master->read(file, depth + 1))
-        return false;
+      if(!master->read(file, depth + 1)) {
+        debug("EBML: Invalid MasterElement");
+        continue;
+      }
     }
     else {
-      if(!element->read(file))
-        return false;
+      if(!element->read(file)) {
+        debug("EBML: Invalid Element");
+        continue;
+      }
     }
     elements.push_back(std::move(element));
   }
-  return file.tell() == maxOffset;
+  if(file.tell() == maxOffset) {
+    return true;
+  }
+  file.seek(maxOffset);
+  return false;
 }
 
 bool EBML::MasterElement::read(File &file)

--- a/taglib/matroska/ebml/ebmlmksegment.cpp
+++ b/taglib/matroska/ebml/ebmlmksegment.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<ElementType> readElementAt(File &file,
   }
 
   file.seek(offset);
-  auto element = EBML::Element::factory(file);
+  auto element = EBML::Element::factory(file, maxOffset);
   if(!element || element->getId() != Id) {
     return nullptr;
   }

--- a/taglib/matroska/ebml/ebmlutils.cpp
+++ b/taglib/matroska/ebml/ebmlutils.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<EBML::Element> EBML::findElement(File &file, Element::Id id, off
 {
   std::unique_ptr<Element> element;
   while(file.tell() < maxOffset) {
-    element = Element::factory(file);
+    element = Element::factory(file, maxOffset);
     if(!element || element->getId() == id)
       return element;
     element->skipData(file);
@@ -45,7 +45,7 @@ std::unique_ptr<EBML::Element> EBML::findElement(File &file, Element::Id id, off
 
 std::unique_ptr<EBML::Element> EBML::findNextElement(File &file, offset_t maxOffset)
 {
-  return file.tell() < maxOffset ? Element::factory(file) : nullptr;
+  return file.tell() < maxOffset ? Element::factory(file, maxOffset) : nullptr;
 }
 
 template <int maxSizeLength>

--- a/taglib/matroska/matroskaelement.cpp
+++ b/taglib/matroska/matroskaelement.cpp
@@ -101,6 +101,11 @@ Matroska::Element::ID Matroska::Element::id() const
   return e->id;
 }
 
+void Matroska::Element::clearSizeListeners()
+{
+  e->sizeListeners.clear();
+}
+
 void Matroska::Element::addSizeListener(Element *element)
 {
   e->sizeListeners.append(element);

--- a/taglib/matroska/matroskaelement.h
+++ b/taglib/matroska/matroskaelement.h
@@ -53,6 +53,7 @@ namespace TagLib {
       void setData(const ByteVector &data);
       const ByteVector &data() const;
       virtual void write(TagLib::File &file);
+      void clearSizeListeners();
       void addSizeListener(Element *element);
       void addSizeListeners(const List<Element *> &elements);
       bool emitSizeChanged(offset_t delta);

--- a/taglib/matroska/matroskafile.cpp
+++ b/taglib/matroska/matroskafile.cpp
@@ -368,7 +368,7 @@ void Matroska::File::read(bool readProperties, Properties::ReadStyle readStyle)
 
   // Find the EBML Header
   const auto head = EBML::element_cast<EBML::Element::Id::EBMLHeader>(
-    EBML::Element::factory(*this));
+    EBML::Element::factory(*this, fileLength));
   if(!head || head->getId() != EBML::Element::Id::EBMLHeader) {
     debug("Failed to find EBML head");
     setValid(false);
@@ -381,7 +381,7 @@ void Matroska::File::read(bool readProperties, Properties::ReadStyle readStyle)
     head->skipData(*this);
   }
 
-  offset_t maxOffset = fileLength - tell();
+  offset_t maxOffset = fileLength;
   if (readStyle == Properties::ReadStyle::Fast && maxOffset > FAST_SCAN_LIMIT) {
     maxOffset = FAST_SCAN_LIMIT;
   }

--- a/taglib/matroska/matroskafile.cpp
+++ b/taglib/matroska/matroskafile.cpp
@@ -595,6 +595,7 @@ bool Matroska::File::save(WriteStyle writeStyle)
 
   // Set up listeners, add seek head and segment length to the end
   for(auto it = renderList.begin(); it != renderList.end(); ++it) {
+    (*it)->clearSizeListeners();
     for(auto it2 = std::next(it); it2 != renderList.end(); ++it2)
       (*it)->addSizeListener(*it2);
     if(d->cues)
@@ -605,6 +606,7 @@ bool Matroska::File::save(WriteStyle writeStyle)
   }
   if(d->cues) {
     renderList.append(d->cues.get());
+    d->cues->clearSizeListeners();
     d->cues->addSizeListeners(renderList);
     if(d->seekHead) {
       d->cues->addSizeListener(d->seekHead.get());
@@ -613,9 +615,11 @@ bool Matroska::File::save(WriteStyle writeStyle)
   }
   if(d->seekHead) {
     renderList.append(d->seekHead.get());
+    d->seekHead->clearSizeListeners();
     d->seekHead->addSizeListeners(renderList);
     d->seekHead->addSizeListener(d->segment.get());
   }
+  d->segment->clearSizeListeners();
   d->segment->addSizeListeners(renderList);
   renderList.append(d->segment.get());
 


### PR DESCRIPTION
Out of this PR I think the first commit can be used either way since it fixes what I think is a general bug.

The last two commits are in order to still parse tags on mkv files that might have invalid tag information.
Specifically, I have a file for which `mkvinfo` prints the tags, but `tagreader` does not.
There is a broken `Chapter display` tag. See mkvinfo output:

```
|+ Segment information at 4410
| + Segment UID: 0x52 0x54 0x89 0x1f 0xb9 0xc7 0x12 0x72 0xba 0x17 0xc5 0xe8 0x3d 0x54 0x0b 0xf9 at 4415
| + (Known element, but invalid at this position: Chapter display; ID: 0x80 size: 14) at 4434
| + Writing application: HandBrake 0.9.4 at 4448
| + Timestamp scale: 1000000 at 4466
| + Duration: 00:24:57.035250000 at 4473
```

The last two patches are an attempt to make taglib skip over this broken tag.
With these changes the output from `tagreader` now looks like:
```
TagLib: EBML: datasize too great: 8813 > (4448 - 4440)
TagLib: EBML: Invalid MasterElement
-- TAG (basic) --
title   - ""
artist  - ""
album   - ""
year    - "0"
comment - ""
track   - "0"
genre   - ""
CHAPTERS:
  chapters    - [{"displays": [{"string": "Chapter 1"}], "timeStart": 0, "uid": 1759487646}, {"displays": [{"string": "Chapter 2"}], "timeStart": 94027266666, "uid": 1910690585}, {"displays": [{"string": "Chapter 3"}], "timeStart": 734400333333, "uid": 1277432406}, {"displays": [{"string": "Chapter 4"}], "timeStart": 1346178166666, "uid": 67924569}, {"displays": [{"string": "Chapter 5"}], "timeStart": 1466256466666, "uid": 136275841}]
  isDefault   - true
  uid         - 1995116152
-- AUDIO --
bitrate     - 1766
sample rate - 48000
channels    - 2
length      - 24:57
```