### PR TITLE
[Matroska] Fix unknown size elements partially

### DIFF
--- a/taglib/matroska/ebml/ebmlelement.cpp
+++ b/taglib/matroska/ebml/ebmlelement.cpp
@@ -39,7 +39,12 @@
 using namespace TagLib;
 
 #define RETURN_ELEMENT_FOR_CASE(eid) \
-  case (eid): return make_unique_element<eid>(id, sizeLength, dataSize, offset)
+  case (eid): \
+    if (sizeUnknown && !std::is_base_of_v<MasterElement, GetElementTypeById<eid>::type>) { \
+      debug(Utils::formatString("EBML: non MasterElement with unknown size %x" , eid)); \
+      return nullptr; \
+    } \
+    return make_unique_element<eid>(id, sizeLength, dataSize, offset)
 
 std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOffset)
 {
@@ -52,15 +57,22 @@ std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOf
   }
 
   // Get the size length and data length
-  const auto &[sizeLength, dataSize] = readVINT(file);
+  auto [sizeLength, dataSize] = readVINT(file);
   if(!sizeLength)
     return nullptr;
 
-  if(const offset_t currentOffset = file.tell();
-     static_cast<offset_t>(dataSize) > maxOffset - currentOffset) {
+  // See https://datatracker.ietf.org/doc/rfc8794/ section 6.2
+  const bool sizeUnknown = sizeLength == 1 && dataSize == 0x7f;
+
+  const offset_t currentOffset = file.tell();
+  if(static_cast<offset_t>(dataSize) > maxOffset - currentOffset) {
     debug(Utils::formatString("EBML: datasize too great: %lu > (%lld - %lld)",
       dataSize, maxOffset, currentOffset));
     return nullptr;
+  }
+
+  if (sizeUnknown) {
+    dataSize = maxOffset - currentOffset;
   }
 
   // Return the subclass
@@ -135,6 +147,10 @@ std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOf
     RETURN_ELEMENT_FOR_CASE(Id::MkChapterDisplay);
     RETURN_ELEMENT_FOR_CASE(Id::MkChapString);
     RETURN_ELEMENT_FOR_CASE(Id::MkChapLanguage);
+  }
+  if (sizeUnknown) {
+    debug(Utils::formatString("EBML: non MasterElement with unknown size %x" , id));
+    return nullptr;
   }
   return std::make_unique<Element>(id, sizeLength, dataSize);
 }

--- a/taglib/matroska/ebml/ebmlelement.cpp
+++ b/taglib/matroska/ebml/ebmlelement.cpp
@@ -39,12 +39,7 @@
 using namespace TagLib;
 
 #define RETURN_ELEMENT_FOR_CASE(eid) \
-  case (eid): \
-    if (sizeUnknown && !std::is_base_of_v<MasterElement, GetElementTypeById<eid>::type>) { \
-      debug(Utils::formatString("EBML: non MasterElement with unknown size %x" , eid)); \
-      return nullptr; \
-    } \
-    return make_unique_element<eid>(id, sizeLength, dataSize, offset)
+  case (eid): return make_unique_element<eid>(id, sizeLength, dataSize, offset)
 
 std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOffset)
 {
@@ -61,18 +56,13 @@ std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOf
   if(!sizeLength)
     return nullptr;
 
-  // See https://datatracker.ietf.org/doc/rfc8794/ section 6.2
-  const bool sizeUnknown = sizeLength == 1 && dataSize == 0x7f;
-
-  const offset_t currentOffset = file.tell();
-  if(static_cast<offset_t>(dataSize) > maxOffset - currentOffset) {
+  if(const offset_t currentOffset = file.tell();
+     isUnknownSize(sizeLength, dataSize)) {
+    dataSize = maxOffset - currentOffset;
+  } else if(static_cast<offset_t>(dataSize) > maxOffset - currentOffset) {
     debug(Utils::formatString("EBML: datasize too great: %lu > (%lld - %lld)",
       dataSize, maxOffset, currentOffset));
     return nullptr;
-  }
-
-  if (sizeUnknown) {
-    dataSize = maxOffset - currentOffset;
   }
 
   // Return the subclass
@@ -147,10 +137,6 @@ std::unique_ptr<EBML::Element> EBML::Element::factory(File &file, offset_t maxOf
     RETURN_ELEMENT_FOR_CASE(Id::MkChapterDisplay);
     RETURN_ELEMENT_FOR_CASE(Id::MkChapString);
     RETURN_ELEMENT_FOR_CASE(Id::MkChapLanguage);
-  }
-  if (sizeUnknown) {
-    debug(Utils::formatString("EBML: non MasterElement with unknown size %x" , id));
-    return nullptr;
   }
   return std::make_unique<Element>(id, sizeLength, dataSize);
 }

--- a/taglib/matroska/ebml/ebmlutils.h
+++ b/taglib/matroska/ebml/ebmlutils.h
@@ -71,6 +71,18 @@ namespace TagLib {
         return 3;
       return 4;
     }
+
+    // See https://datatracker.ietf.org/doc/rfc8794/ section 6.2
+    constexpr bool isUnknownSize(unsigned int sizeLength, uint64_t dataSize)
+    {
+      if(sizeLength == 0 || sizeLength > 8) {
+        return false;
+      }
+
+      const unsigned int numDataBits = sizeLength * 8 - sizeLength;
+      const uint64_t mask = (1ULL << numDataBits) - 1;
+      return (dataSize & mask) == mask;
+    }
   }
 }
 

--- a/tests/test_matroska.cpp
+++ b/tests/test_matroska.cpp
@@ -160,6 +160,7 @@ class TestMatroska : public CppUnit::TestFixture
   CPPUNIT_TEST(testSaveTypesBeforeCues);
   CPPUNIT_TEST(testSaveTypesNoTrailingVoid);
   CPPUNIT_TEST(testSaveTypesReclaimVoid);
+  CPPUNIT_TEST(testUnknownSizeSegment);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -1777,6 +1778,56 @@ public:
     }
   }
 
+  void testUnknownSizeSegment()
+  {
+    ScopedFileCopy copy("no-tags", ".mka");
+    string newname = copy.fileName();
+
+    // Modify the copied file (/tmp/taglib-test.mka on Linux) to have elements
+    // with unknown size length.
+    {
+      PlainFile file(newname.c_str());
+      ByteVector fileData = file.readAll();
+      CPPUNIT_ASSERT_EQUAL(12390U, fileData.size());
+      // Size of Segment
+      for(int i = 0x2d; i <= 0x33; ++i) {
+        fileData[i] = '\xff';
+      }
+      // Size of Cluster
+      for(int i = 0x2d; i <= 0x33; ++i) {
+        fileData[i] = '\xff';
+      }
+      fileData[0x1482] = '\x7f';
+      fileData[0x1483] = '\xff';
+      file.seek(0);
+      file.writeBlock(fileData);
+    }
+    {
+      Matroska::File f(newname.c_str(), true, AudioProperties::Accurate);
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.audioProperties());
+      CPPUNIT_ASSERT_EQUAL(444, f.audioProperties()->lengthInMilliseconds());
+      CPPUNIT_ASSERT_EQUAL(223, f.audioProperties()->bitrate());
+      CPPUNIT_ASSERT_EQUAL(2, f.audioProperties()->channels());
+      CPPUNIT_ASSERT_EQUAL(44100, f.audioProperties()->sampleRate());
+      CPPUNIT_ASSERT_EQUAL(String("matroska"), f.audioProperties()->docType());
+      CPPUNIT_ASSERT_EQUAL(4, f.audioProperties()->docTypeVersion());
+      CPPUNIT_ASSERT_EQUAL(String("A_MPEG/L3"), f.audioProperties()->codecName());
+      CPPUNIT_ASSERT_EQUAL(String(""), f.audioProperties()->title());
+      CPPUNIT_ASSERT(!f.tag(false));
+      CPPUNIT_ASSERT(!f.attachments(false));
+      auto tag = f.tag(true);
+      CPPUNIT_ASSERT(tag->isEmpty());
+      tag->setTitle("Unknown size");
+      CPPUNIT_ASSERT(f.save());
+    }
+    {
+      Matroska::File f(newname.c_str(), true, AudioProperties::Accurate);
+      CPPUNIT_ASSERT(f.isValid());
+      CPPUNIT_ASSERT(f.tag(false));
+      CPPUNIT_ASSERT_EQUAL(String("Unknown size"), f.tag()->title());
+    }
+  }
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestMatroska);


### PR DESCRIPTION
In matroska an element data size of a VINT with all bits 1 means the data size is unknown. Unknown data size can only apply to Master Elements.

Unknown sized elements are described in
https://datatracker.ietf.org/doc/rfc8794/ section 6.2 It gives the following 5 conditions for detecting the end of an unknown sized element:

 *  Any EBML Element that is a valid Parent Element of the Unknown- Sized Element according to the EBML Schema, Global Elements excluded.

 *  Any valid EBML Element according to the EBML Schema, Global Elements excluded, that is not a Descendant Element of the Unknown-Sized Element but shares a common direct parent, such as a Top-Level Element.

 *  Any EBML Element that is a valid Root Element according to the EBML Schema, Global Elements excluded.

 *  The end of the Parent Element with a known size has been reached.

 *  The end of the EBML Document, either when reaching the end of the file or because a new EBML Header started.

In this patch we use the higher level maxOffset to determine the maximum data size for the element, which matches the fourth condition, but is incomplete without the other four methods.