### PR TITLE
MP4: Fix QT chapters excessive sample allocation with invalid stsc

### DIFF
--- a/taglib/mp4/mp4qtchapterlist.cpp
+++ b/taglib/mp4/mp4qtchapterlist.cpp
@@ -825,7 +825,8 @@ namespace
     const std::vector<unsigned int> chunkOffsets = readStco(file, chapterTrak);
     if(chunkOffsets.empty())
       return {};
-    if(sizeInfo.sampleCount == 0)
+    // Sample count cannot be > file length / 4 as every sample consumes 4 bytes in stsz
+    if(sizeInfo.sampleCount == 0 || sizeInfo.sampleCount > file->length() / 4)
       return {};
 
     // Read stsc entries

--- a/taglib/mp4/mp4qtchapterlist.cpp
+++ b/taglib/mp4/mp4qtchapterlist.cpp
@@ -825,6 +825,8 @@ namespace
     const std::vector<unsigned int> chunkOffsets = readStco(file, chapterTrak);
     if(chunkOffsets.empty())
       return {};
+    if(sizeInfo.sampleCount == 0)
+      return {};
 
     // Read stsc entries
     struct StscEntry {
@@ -875,6 +877,9 @@ namespace
       }
 
       unsigned int offsetInChunk = 0;
+      if(samplesInChunk > sizeInfo.sampleCount - sampleIndex)
+        samplesInChunk = sizeInfo.sampleCount - sampleIndex;
+
       for(unsigned int s = 0; s < samplesInChunk; ++s) {
         sampleOffsets.push_back(chunkOffsets[chunkIdx] + offsetInChunk);
 


### PR DESCRIPTION
See https://mail.kde.org/pipermail/taglib-devel/2026-July/003122.html