### PR TITLE
Limit ID3 compressed-frame expansion

### DIFF
--- a/taglib/mpeg/id3v2/id3v2frame.cpp
+++ b/taglib/mpeg/id3v2/id3v2frame.cpp
@@ -27,6 +27,7 @@
 
 #include <array>
 #include <bitset>
+#include <cstdint>
 
 #include "tdebug.h"
 #include "tstringlist.h"
@@ -57,6 +58,9 @@ public:
 
 namespace
 {
+  constexpr unsigned int maxCompressedFrameOutputSize = 64U * 1024U * 1024U;
+  constexpr unsigned int maxCompressedFrameRatio = 64;
+
   bool isValidFrameID(const ByteVector &frameID)
   {
     if(frameID.size() != 4)
@@ -310,8 +314,16 @@ ByteVector Frame::fieldData(const ByteVector &frameData) const
       return ByteVector();
     }
 
-    const ByteVector outData = zlib::decompress(frameData.mid(frameDataOffset),
-                                                frameDataLength);
+    const ByteVector compressedData = frameData.mid(frameDataOffset);
+    const uint64_t maxOutputSizeForInput =
+      static_cast<uint64_t>(compressedData.size()) * maxCompressedFrameRatio;
+    if(frameDataLength > maxCompressedFrameOutputSize ||
+       frameDataLength > maxOutputSizeForInput) {
+      debug("Compressed frame exceeds decompression limit");
+      return ByteVector();
+    }
+
+    const ByteVector outData = zlib::decompress(compressedData, frameDataLength);
     if(!outData.isEmpty() && frameDataLength != outData.size()) {
       debug("frameDataLength does not match the data length returned by zlib");
     }


### PR DESCRIPTION
A crafted compressed ID3v2 frame can make TagLib inflate a small metadata
payload into an attacker-controlled allocation. The frame data-length
indicator comes from the file. The compatibility fallback also accepts
non-synchsafe values, including 0xffffffff, which disables the existing
zlib output limit.

This change rejects compressed frames whose declared output exceeds 64 MiB
or 64 times the compressed payload size. The check occurs before inflation.
It preserves ID3v2.3's normal 32-bit decompressed-size field and the existing
broken-length compatibility fixture.

A 32,647-byte proof input inflated to 32 MiB before this change. Both its
normal and 0xffffffff length variants are now rejected before decompression.
The bundled compressed-frame fixture and the full bundled media corpus still
parse successfully.

I considered only rejecting non-synchsafe ID3v2.4 indicators, but that would
not cover ID3v2.3 or otherwise limit high expansion ratios. An absolute limit
alone is predictable but permits disproportionate expansion from small input,
so this uses both controls.

The 64 MiB and 64:1 limits are intended as conservative defaults. I'm happy
to adapt the thresholds, make the budget configurable, or use stricter format
validation if that better fits TagLib's compatibility policy.