### PR TITLE
MP4: reject undersized table atoms

### DIFF
--- a/taglib/mp4/mp4nerochapterlist.cpp
+++ b/taglib/mp4/mp4nerochapterlist.cpp
@@ -77,6 +77,8 @@ namespace
       for(const auto &atom : stco) {
         if(atom->offset() > offset)
           atom->addToOffset(delta);
+        if(atom->length() < 16)
+          continue;
         file->seek(atom->offset() + 12);
         ByteVector data = file->readBlock(atom->length() - 12);
         unsigned int count = data.toUInt();
@@ -96,6 +98,8 @@ namespace
       for(const auto &atom : co64) {
         if(atom->offset() > offset)
           atom->addToOffset(delta);
+        if(atom->length() < 20)
+          continue;
         file->seek(atom->offset() + 12);
         ByteVector data = file->readBlock(atom->length() - 12);
         unsigned int count = data.toUInt();
@@ -117,6 +121,8 @@ namespace
       for(const auto &atom : tfhd) {
         if(atom->offset() > offset)
           atom->addToOffset(delta);
+        if(atom->length() < 24)
+          continue;
         file->seek(atom->offset() + 9);
         ByteVector data = file->readBlock(atom->length() - 9);
         if(const unsigned int flags = data.toUInt(0, 3, true);

--- a/taglib/mp4/mp4qtchapterlist.cpp
+++ b/taglib/mp4/mp4qtchapterlist.cpp
@@ -88,6 +88,8 @@ namespace
       for(const auto &atom : stco) {
         if(atom->offset() > offset)
           atom->addToOffset(delta);
+        if(atom->length() < 16)
+          continue;
         file->seek(atom->offset() + 12);
         ByteVector data = file->readBlock(atom->length() - 12);
         unsigned int count = data.toUInt();
@@ -107,6 +109,8 @@ namespace
       for(const auto &atom : co64) {
         if(atom->offset() > offset)
           atom->addToOffset(delta);
+        if(atom->length() < 20)
+          continue;
         file->seek(atom->offset() + 12);
         ByteVector data = file->readBlock(atom->length() - 12);
         unsigned int count = data.toUInt();
@@ -128,6 +132,8 @@ namespace
       for(const auto &atom : tfhd) {
         if(atom->offset() > offset)
           atom->addToOffset(delta);
+        if(atom->length() < 24)
+          continue;
         file->seek(atom->offset() + 9);
         ByteVector data = file->readBlock(atom->length() - 9);
         if(const unsigned int flags = data.toUInt(0, 3, true);
@@ -740,7 +746,7 @@ namespace
   {
     std::vector<SttsEntry> entries;
     const MP4::Atom *stts = chapterTrak->find("mdia", "minf", "stbl", "stts");
-    if(!stts)
+    if(!stts || stts->length() < 12)
       return entries;
 
     file->seek(stts->offset() + 12);  // skip header(8) + version/flags(4)
@@ -765,7 +771,7 @@ namespace
   {
     std::vector<unsigned int> offsets;
     const MP4::Atom *stco = chapterTrak->find("mdia", "minf", "stbl", "stco");
-    if(!stco)
+    if(!stco || stco->length() < 12)
       return offsets;
 
     file->seek(stco->offset() + 12);
@@ -794,7 +800,7 @@ namespace
   {
     SampleSizeInfo info;
     const MP4::Atom *stsz = chapterTrak->find("mdia", "minf", "stbl", "stsz");
-    if(!stsz)
+    if(!stsz || stsz->length() < 12)
       return info;
 
     file->seek(stsz->offset() + 12);
@@ -837,7 +843,8 @@ namespace
     };
     std::vector<StscEntry> stscEntries;
 
-    if(const MP4::Atom *stsc = chapterTrak->find("mdia", "minf", "stbl", "stsc")) {
+    if(const MP4::Atom *stsc = chapterTrak->find("mdia", "minf", "stbl", "stsc");
+       stsc && stsc->length() >= 12) {
       file->seek(stsc->offset() + 12);
       if(const ByteVector data = file->readBlock(stsc->length() - 12);
          data.size() >= 4) {
@@ -969,6 +976,8 @@ namespace
       return false;
 
     for(const auto &stco : moov->findall("stco", true)) {
+      if(stco->length() < 16)
+        continue;
       file->seek(stco->offset() + 12);
       ByteVector data = file->readBlock(stco->length() - 12);
       if(data.size() < 4)
@@ -985,6 +994,8 @@ namespace
     }
 
     for(const auto &co64 : moov->findall("co64", true)) {
+      if(co64->length() < 20)
+        continue;
       file->seek(co64->offset() + 12);
       ByteVector data = file->readBlock(co64->length() - 12);
       if(data.size() < 4)

--- a/taglib/mp4/mp4tag.cpp
+++ b/taglib/mp4/mp4tag.cpp
@@ -195,6 +195,9 @@ MP4::Tag::updateOffsets(offset_t delta, offset_t offset)
       if(atom->offset() > offset) {
         atom->addToOffset(delta);
       }
+      if(atom->length() < 16) {
+        continue;
+      }
       d->file->seek(atom->offset() + 12);
       ByteVector data = d->file->readBlock(atom->length() - 12);
       unsigned int count = data.toUInt();
@@ -215,6 +218,9 @@ MP4::Tag::updateOffsets(offset_t delta, offset_t offset)
     for(const auto &atom : co64) {
       if(atom->offset() > offset) {
         atom->addToOffset(delta);
+      }
+      if(atom->length() < 20) {
+        continue;
       }
       d->file->seek(atom->offset() + 12);
       ByteVector data = d->file->readBlock(atom->length() - 12);
@@ -238,6 +244,9 @@ MP4::Tag::updateOffsets(offset_t delta, offset_t offset)
     for(const auto &atom : tfhd) {
       if(atom->offset() > offset) {
         atom->addToOffset(delta);
+      }
+      if(atom->length() < 24) {
+        continue;
       }
       d->file->seek(atom->offset() + 9);
       ByteVector data = d->file->readBlock(atom->length() - 9);


### PR DESCRIPTION
A structurally valid MP4 can contain a QT chapter stts atom shorter than
its 12-byte full-box header. readStts() subtracts 12 from its length and
passes the negative result to readBlock(), where it becomes a very large
size. On a 256 MB file, reading chapters reached about 530 MB peak RSS.

This validates the minimum table-header sizes before reading chapter
payloads. It also applies the corresponding checks to the stco/co64/tfhd
offset-rewrite paths shared by MP4 tags and chapter lists, so malformed
tables cannot trigger an underflow during save.

The parser can still accept the surrounding file, but it now treats the
truncated table as empty. The full bundled test-data corpus gives the same
108 successful and 7 null results after the change.

I considered restricting FileStream::readBlock() globally, but the atom
parser is the layer that knows the table-specific minimum sizes. Rejecting
undersized tables avoids changing the semantics for valid large payloads.