### PR TITLE
MPC: validate SV8 packet size

### DIFF
--- a/taglib/mpc/mpcproperties.cpp
+++ b/taglib/mpc/mpcproperties.cpp
@@ -27,6 +27,7 @@
 
 #include <array>
 #include <cmath>
+#include <limits>
 
 #include "tdebug.h"
 #include "tstring.h"
@@ -186,7 +187,19 @@ void MPC::Properties::readSV8(File *file, offset_t streamLength)
       break;
     }
 
-    const unsigned long dataSize = packetSize - 2 - packetSizeLength;
+    const unsigned long headerSize = 2 + packetSizeLength;
+    const offset_t offset = file->tell();
+    if(packetSize < headerSize || offset < 0 || offset > streamLength) {
+      debug("MPC::Properties::readSV8() - Invalid packet size.");
+      break;
+    }
+
+    const unsigned long dataSize = packetSize - headerSize;
+    const auto remaining = static_cast<unsigned long long>(streamLength - offset);
+    if(dataSize > remaining || dataSize > std::numeric_limits<unsigned int>::max()) {
+      debug("MPC::Properties::readSV8() - Packet size exceeds remaining data.");
+      break;
+    }
 
     const ByteVector data = file->readBlock(dataSize);
     if(data.size() != dataSize) {


### PR DESCRIPTION
A Musepack SV8 packet can report a length smaller than its two-byte type
and variable-length size field. The parser subtracts the header from that
unsigned value before calling readBlock(), so it wraps into a very large
payload length.

An MPC file beginning with an SH packet of size zero remained valid and
used about 266 MB RSS when its file size was 256 MB.

Validate that the packet is at least its header size and that its payload
fits in the remaining file data before reading. All bundled MPC samples
and the complete test-data corpus retain the same results. I also ran the
focused input under ASAN/UBSAN without a report after the change.

I considered adding a blanket limit to the stream reader, but packet
framing has the context needed to distinguish an invalid length from valid
large data. The check therefore rejects only malformed SV8 packets. I'm
happy to adjust the validation approach if a different compatibility
policy is preferred.