### PR TITLE
MP4: limit atoms in nested containers

### DIFF
--- a/taglib/mp4/mp4atom.cpp
+++ b/taglib/mp4/mp4atom.cpp
@@ -40,6 +40,7 @@ namespace {
     "stbl", "minf", "moof", "traf", "trak",
     "stsd", "stem"
   };
+  constexpr int MAX_MP4_ATOM_COUNT_PER_LEVEL = 50000;
 } // namespace
 
 class MP4::Atom::AtomPrivate
@@ -116,6 +117,13 @@ MP4::Atom::Atom(File *file, int depth)
         return;
       }
       while(file->tell() < d->offset + d->length) {
+        if(d->children.size() >= MAX_MP4_ATOM_COUNT_PER_LEVEL) {
+          debug("MP4: Maximum atom count exceeded");
+          d->children.clear();
+          d->length = 0;
+          file->seek(0, File::End);
+          return;
+        }
         auto child = new MP4::Atom(file, depth + 1);
         d->children.append(child);
         if(child->d->length == 0)
@@ -223,8 +231,6 @@ public:
 MP4::Atoms::Atoms(File *file) :
   d(std::make_unique<AtomsPrivate>())
 {
-  static constexpr int MAX_MP4_ATOM_COUNT_PER_LEVEL = 50000;
-
   d->atoms.setAutoDelete(true);
 
   file->seek(0, File::End);


### PR DESCRIPTION
MP4 applies a 50,000-atom limit at the root level, but nested containers
such as moov did not enforce it. A valid 3.9 MB file containing 500,000
free atoms inside moov parsed successfully and reached about 145 MB RSS.

Apply the same per-level limit while parsing container children. Files
that exceed it are rejected before the tree can grow without bound.

The patched parser rejects the reproducer after 50,000 children. The
bundled test-data corpus produces the same 108 successful and 7 null
results. I also ran the focused input under ASAN/UBSAN without a report.