### PR TITLE
Matroska: limit elements in EBML containers

### DIFF
--- a/taglib/matroska/ebml/ebmlmasterelement.cpp
+++ b/taglib/matroska/ebml/ebmlmasterelement.cpp
@@ -101,6 +101,7 @@ void EBML::MasterElement::setMinRenderSize(offset_t minimumSize)
 bool EBML::MasterElement::read(File &file, int depth)
 {
   static constexpr int MAX_EBML_DEPTH = 64;
+  static constexpr int MAX_EBML_ELEMENT_COUNT_PER_LEVEL = 50000;
   if(depth > MAX_EBML_DEPTH) {
     debug("EBML: Maximum nesting depth exceeded");
     return false;
@@ -108,6 +109,10 @@ bool EBML::MasterElement::read(File &file, int depth)
   const offset_t maxOffset = file.tell() + dataSize;
   std::unique_ptr<Element> element;
   while((element = findNextElement(file, maxOffset))) {
+    if(elements.size() >= MAX_EBML_ELEMENT_COUNT_PER_LEVEL) {
+      debug("EBML: Maximum element count exceeded");
+      return false;
+    }
     if(auto master = dynamic_cast<MasterElement *>(element.get())) {
       if(!master->read(file, depth + 1)) {
         debug("EBML: Invalid MasterElement");


### PR DESCRIPTION
EBML::MasterElement::read() retains every parsed child without a
per-container count limit. A valid 1.5 MB Matroska file containing
500,000 empty AttachedFile elements parsed successfully and reached
about 91 MB RSS.

Limit each EBML container to 50,000 parsed children. This prevents
small elements from growing the in-memory element tree without bound.

I chose 50,000 to match TagLib's existing MP4 sibling-atom limit. That
limit was increased from 5,000 after a legitimate file with 5,390 atoms
was reported, while still stopping a 653,789-atom crafted input. It
seems like a reasonable starting point for EBML containers as well, but
I can change the threshold if a different compatibility policy is
preferred.

The patched parser rejects the reproducer at about 10 MB RSS. The
bundled test-data corpus produces the same 108 successful and 7 null
results.