### PR TITLE
RIFF: limit parsed chunk count

### DIFF
--- a/taglib/riff/rifffile.cpp
+++ b/taglib/riff/rifffile.cpp
@@ -33,6 +33,12 @@
 
 using namespace TagLib;
 
+namespace {
+
+  constexpr int MAX_RIFF_CHUNK_COUNT = 50000;
+
+}
+
 struct Chunk
 {
   ByteVector   name;
@@ -295,6 +301,12 @@ void RIFF::File::read()
 
   // + 8: chunk header at least, fix for additional junk bytes
   while(offset + 8 <= length()) {
+
+    if(d->chunks.size() >= MAX_RIFF_CHUNK_COUNT) {
+      debug("RIFF::File::read() -- Maximum chunk count exceeded");
+      setValid(false);
+      return;
+    }
 
     seek(offset);
     const ByteVector   chnkName = readBlock(4);


### PR DESCRIPTION
RIFF::File::read() retains a descriptor for every parsed chunk but did
not limit the number of chunks. A valid 16 MB WAV containing 2 million
empty JUNK chunks parsed successfully and reached about 271 MB RSS.

Limit parsed chunks to 50,000 and mark files exceeding that limit
invalid before the descriptor vector can grow without bound.

I chose 50,000 to match TagLib's existing MP4 sibling-atom limit. That
limit was increased from 5,000 after a legitimate file with 5,390 atoms
was reported, while still stopping a 653,789-atom crafted input. It
seems like a reasonable starting point for RIFF as well, but I can
change the threshold if a different compatibility policy is preferred.

The patched parser rejects the reproducer at about 11 MB RSS. The
bundled test-data corpus produces the same 108 successful and 7 null
results.