### PR TITLE
ASF: limit header object count

### DIFF
--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -686,8 +686,14 @@ void ASF::File::read()
     setValid(false);
     return;
   }
-  int numObjects = readDWORD(this, &ok);
+  static constexpr unsigned int MAX_ASF_HEADER_OBJECT_COUNT = 50000;
+  const unsigned int numObjects = readDWORD(this, &ok);
   if(!ok) {
+    setValid(false);
+    return;
+  }
+  if(numObjects > MAX_ASF_HEADER_OBJECT_COUNT) {
+    debug("ASF::File::read(): Maximum header object count exceeded.");
     setValid(false);
     return;
   }
@@ -695,7 +701,7 @@ void ASF::File::read()
 
   FilePrivate::FilePropertiesObject   *filePropertiesObject   = nullptr;
   FilePrivate::StreamPropertiesObject *streamPropertiesObject = nullptr;
-  for(int i = 0; i < numObjects; i++) {
+  for(unsigned int i = 0; i < numObjects; i++) {
     const ByteVector guid = readBlock(16);
     if(guid.size() != 16) {
       setValid(false);


### PR DESCRIPTION
ASF::File::read() retains every object declared in the ASF header without
a count limit. A valid 46 MB WMA file containing 2 million empty header
objects parsed successfully and reached about 505 MB RSS.

Validate the declared object count before parsing any header objects.
This prevents the retained object list from growing without bound.

I chose 50,000 to match TagLib's existing MP4 sibling-atom limit. That
limit was increased from 5,000 after a legitimate file with 5,390 atoms
was reported, while still stopping a 653,789-atom crafted input. It
seems like a reasonable starting point for ASF headers, but I can change
the threshold if a different compatibility policy is preferred.

The patched parser rejects the reproducer at about 4 MB RSS, accepts an
input with exactly 50,000 header objects, and produces the same 108
successful and 7 null results for the bundled test-data corpus.