### PR TITLE
FLAC: limit metadata block count

### DIFF
--- a/taglib/flac/flacfile.cpp
+++ b/taglib/flac/flacfile.cpp
@@ -49,6 +49,7 @@ namespace
   constexpr long MaxPaddingLegnth = 1024 * 1024;
 
   constexpr char LastBlockFlag = '\x80';
+  constexpr unsigned int MAX_FLAC_METADATA_BLOCK_COUNT = 50000;
 }  // namespace
 
 class FLAC::File::FilePrivate
@@ -627,7 +628,14 @@ void FLAC::File::scan()
   nextBlockOffset += 4;
   d->flacStart = nextBlockOffset;
 
+  unsigned int blockCount = 0;
   while(true) {
+
+    if(blockCount++ >= MAX_FLAC_METADATA_BLOCK_COUNT) {
+      debug("FLAC::File::scan() -- Maximum metadata block count exceeded");
+      setValid(false);
+      return;
+    }
 
     seek(nextBlockOffset);
     const ByteVector header = readBlock(4);


### PR DESCRIPTION
FLAC::File::scan() retained metadata blocks without a count limit. A
16 MB FLAC containing 2 million small application blocks parsed
successfully and reached about 411 MB RSS.

Limit metadata parsing to 50,000 blocks. The check occurs before reading
and allocating the next block, preventing the metadata list from growing
without bound.

The patched parser rejects the reproducer at about 15 MB RSS, accepts an
input with exactly 50,000 metadata blocks, and produces the same 108
successful and 7 null results for the bundled test-data corpus.