### PR TITLE
Xiph: limit parsed comment fields

### DIFF
--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -422,6 +422,8 @@ ByteVector Ogg::XiphComment::render(bool addFramingBit) const
 
 void Ogg::XiphComment::parse(const ByteVector &data)
 {
+  static constexpr unsigned int MAX_XIPH_COMMENT_FIELD_COUNT = 50000;
+
   // The first thing in the comment data is the vendor ID length, followed by a
   // UTF8 string with the vendor ID.
 
@@ -438,7 +440,9 @@ void Ogg::XiphComment::parse(const ByteVector &data)
   const unsigned int commentFields = data.toUInt(pos, false);
   pos += 4;
 
-  if(commentFields > (data.size() - 8) / 4) {
+  if(commentFields > MAX_XIPH_COMMENT_FIELD_COUNT ||
+     commentFields > (data.size() - 8) / 4) {
+    debug("Ogg::XiphComment::parse() - Maximum comment field count exceeded.");
     return;
   }
 


### PR DESCRIPTION
Ogg::XiphComment::parse() stored every declared comment field without an
absolute limit. A valid 14 MB FLAC with one Vorbis-comment block
containing 2 million small fields reached about 299 MB RSS.

Limit the declared field count before creating field strings. This covers
FLAC and the other formats that use Xiph comments.

The patched parser stops parsing the oversized field list at about 18 MB
RSS, accepts an input with exactly 50,000 fields, and produces the same
108 successful and 7 null results for the bundled test-data corpus.