### PR TITLE
Ogg FLAC: limit metadata block count

### DIFF
--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -294,7 +294,6 @@ void Ogg::FLAC::File::scan()
   while(!lastBlock) {
     if(blockCount++ >= MAX_OGG_FLAC_METADATA_BLOCK_COUNT) {
       debug("Ogg::FLAC::File::scan() -- Maximum metadata block count exceeded");
-      setValid(false);
       return;
     }
     metadataHeader = packet(++ipacket);

--- a/taglib/ogg/flac/oggflacfile.cpp
+++ b/taglib/ogg/flac/oggflacfile.cpp
@@ -32,6 +32,10 @@
 using namespace TagLib;
 using TagLib::FLAC::Properties;
 
+namespace {
+  constexpr int MAX_OGG_FLAC_METADATA_BLOCK_COUNT = 1024;
+}
+
 class Ogg::FLAC::File::FilePrivate
 {
 public:
@@ -223,6 +227,7 @@ void Ogg::FLAC::File::scan()
     return;
 
   int ipacket = 0;
+  int blockCount = 1;
   offset_t overhead = 0;
 
   ByteVector metadataHeader = packet(ipacket);
@@ -287,6 +292,11 @@ void Ogg::FLAC::File::scan()
   // Search through the remaining metadata
 
   while(!lastBlock) {
+    if(blockCount++ >= MAX_OGG_FLAC_METADATA_BLOCK_COUNT) {
+      debug("Ogg::FLAC::File::scan() -- Maximum metadata block count exceeded");
+      setValid(false);
+      return;
+    }
     metadataHeader = packet(++ipacket);
     header = metadataHeader.mid(0, 4);
     if(header.size() != 4) {


### PR DESCRIPTION
Ogg FLAC accepts an unbounded sequence of metadata packets. Each packet is fetched through `Ogg::File::packet()`, which locates it by walking already-indexed pages. Many tiny metadata blocks therefore cause quadratic parsing time while retaining the indexed pages.

This is analogous to the native FLAC metadata block count issue fixed in #1396, but requires a lower cap because the native FLAC scan is linear while this Ogg packet lookup is quadratic.

Limit Ogg FLAC metadata to 1024 blocks. This is far above normal metadata usage while bounding the scan to roughly 524,000 page comparisons. I can adjust the ceiling if a different compatibility limit is preferred.