### PR TITLE
ID3: Accept iTunes ID3 frames with space padded ID3v2.2 ID (#1403)

### DIFF
--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -133,7 +133,7 @@ std::pair<Frame::Header *, bool> FrameFactory::prepareFrameHeader(
   }
 
 #ifndef NO_ITUNES_HACKS
-  if(version == 3 && frameID[3] == '\0') {
+  if(version == 3 && (frameID[3] == '\0' || frameID[3] == ' ')) {
     // iTunes v2.3 tags store v2.2 frames - convert now
     frameID = frameID.mid(0, 3);
     header->setFrameID(frameID);


### PR DESCRIPTION
iTunes 12 writes ID3v2.2 three-character sort frames (TSA, TSP, TST, TS2, TSC) inside ID3v2.3 tags, padded to four bytes with 0x20 (space) rather than 0x00, which is tolerated by '#ifndef NO_ITUNES_HACKS' code. Enhance that code to also tolerate padding with a space.