### PR TITLE
ID3v2: limit embedded frame nesting

### DIFF
--- a/taglib/mpeg/id3v2/frames/chapterframe.cpp
+++ b/taglib/mpeg/id3v2/frames/chapterframe.cpp
@@ -30,6 +30,7 @@
 #include "tbytevectorlist.h"
 #include "tdebug.h"
 #include "tpropertymap.h"
+#include "id3v2framefactory.h"
 #include "unknownframe.h"
 
 using namespace TagLib;
@@ -254,7 +255,7 @@ void ChapterFrame::parseFields(const ByteVector &data)
     return;
 
   while(embPos < size - header()->size()) {
-    Frame *frame = FrameFactory::instance()->createFrame(data.mid(pos + embPos), d->tagHeader);
+    Frame *frame = FrameFactory::createEmbeddedFrame(data.mid(pos + embPos), d->tagHeader);
 
     if(!frame)
       return;

--- a/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/tableofcontentsframe.cpp
@@ -29,6 +29,7 @@
 
 #include "tpropertymap.h"
 #include "tdebug.h"
+#include "id3v2framefactory.h"
 #include "unknownframe.h"
 
 using namespace TagLib;
@@ -264,7 +265,7 @@ void TableOfContentsFrame::parseFields(const ByteVector &data)
     return;
 
   while(embPos < size - header()->size()) {
-    Frame *frame = FrameFactory::instance()->createFrame(data.mid(pos + embPos), d->tagHeader);
+    Frame *frame = FrameFactory::createEmbeddedFrame(data.mid(pos + embPos), d->tagHeader);
 
     if(!frame)
       return;

--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -55,6 +55,23 @@ using namespace ID3v2;
 
 namespace
 {
+  constexpr unsigned int MAX_EMBEDDED_FRAME_DEPTH = 64;
+  thread_local unsigned int embeddedFrameDepth = 0;
+
+  class EmbeddedFrameDepth
+  {
+  public:
+    EmbeddedFrameDepth()
+    {
+      ++embeddedFrameDepth;
+    }
+
+    ~EmbeddedFrameDepth()
+    {
+      --embeddedFrameDepth;
+    }
+  };
+
   void updateGenre(TextIdentificationFrame *frame)
   {
     StringList fields = frame->fieldList();
@@ -188,6 +205,18 @@ Frame *FrameFactory::createFrame(const ByteVector &origData,
     return header ? new UnknownFrame(data, header) : nullptr;
   }
   return createFrame(data, header, tagHeader);
+}
+
+Frame *FrameFactory::createEmbeddedFrame(const ByteVector &origData,
+                                         const Header *tagHeader)
+{
+  if(embeddedFrameDepth >= MAX_EMBEDDED_FRAME_DEPTH) {
+    debug("ID3v2: Maximum embedded frame nesting depth exceeded");
+    return nullptr;
+  }
+
+  EmbeddedFrameDepth depth;
+  return FrameFactory::instance()->createFrame(origData, tagHeader);
 }
 
 Frame *FrameFactory::createFrame(const ByteVector &data, Frame::Header *header,

--- a/taglib/mpeg/id3v2/id3v2framefactory.h
+++ b/taglib/mpeg/id3v2/id3v2framefactory.h
@@ -36,6 +36,8 @@ namespace TagLib {
   namespace ID3v2 {
 
     class TextIdentificationFrame;
+    class ChapterFrame;
+    class TableOfContentsFrame;
 
     //! A factory for creating ID3v2 frames during parsing
 
@@ -176,6 +178,12 @@ namespace TagLib {
                                  const Header *tagHeader) const;
 
     private:
+      static Frame *createEmbeddedFrame(const ByteVector &origData,
+                                        const Header *tagHeader);
+
+      friend class ChapterFrame;
+      friend class TableOfContentsFrame;
+
       static FrameFactory factory;
 
       class FrameFactoryPrivate;


### PR DESCRIPTION
CHAP and CTOC parse embedded frames recursively. A file with one top-level CHAP frame and a long sequence of nested CHAP or CTOC frames can exhaust the stack while TagLib reads an ID3v2 tag.

This change routes both embedded-frame parsing paths through one thread-local nesting guard. It stops parsing deeper embedded metadata after 64 levels, preserving safely parsed outer frames while avoiding unbounded recursion. The value matches the existing MP4 atom nesting limit and is considerably deeper than ordinary chapter metadata; I can adjust it if a different limit is preferred.

I verified that a 50,000-level, 1.4 MiB MP3 now parses to the bounded depth instead of crashing. The existing test suite passes.