### PR TITLE
ID3v2: limit parsed frame count

### DIFF
--- a/taglib/mpeg/id3v2/id3v2tag.cpp
+++ b/taglib/mpeg/id3v2/id3v2tag.cpp
@@ -56,6 +56,7 @@ namespace
 
   constexpr long MinPaddingSize = 1024;
   constexpr long MaxPaddingSize = 1024 * 1024;
+  constexpr unsigned int MAX_ID3V2_FRAME_COUNT = 50000;
 
   /*!
    * Downgrade ID3v2.4 text \a encoding to value supported by ID3v2.3.
@@ -834,6 +835,7 @@ void ID3v2::Tag::parse(const ByteVector &origData)
 
   unsigned int frameDataPosition = 0;
   unsigned int frameDataLength = data.size();
+  unsigned int frameCount = 0;
 
   // check for extended header
 
@@ -868,6 +870,11 @@ void ID3v2::Tag::parse(const ByteVector &origData)
         debug("Padding *and* a footer found.  This is not allowed by the spec.");
       }
 
+      break;
+    }
+
+    if(frameCount++ >= MAX_ID3V2_FRAME_COUNT) {
+      debug("ID3v2::Tag::parse() -- Maximum frame count exceeded");
       break;
     }
 


### PR DESCRIPTION
`ID3v2::Tag::parse()` constructs and retains every top-level frame without a bound. A small MP3 can contain many minimal frames: a 5.3 MiB file with 500,000 frames consumed about 175 MiB and aborted under a 128 MiB memory limit.

This limits parsing to 50,000 top-level ID3v2 frames. It keeps the successfully parsed frames and rebuilds aggregate fields normally, while preventing further attacker-controlled allocation.

The value matches TagLib’s existing `MAX_FLAC_METADATA_BLOCK_COUNT` limit. I can adjust the threshold or overflow behavior if a different project-wide convention is preferred.

I verified that the reproducer is capped at 50,000 frames and about 31 MiB RSS. A tag containing exactly 50,000 frames is fully parsed, and the existing test suite passes.