### PR TITLE
APE: limit parsed tag item count

### DIFF
--- a/taglib/ape/apetag.cpp
+++ b/taglib/ape/apetag.cpp
@@ -49,6 +49,7 @@ namespace
 {
   constexpr unsigned int MinKeyLength = 2;
   constexpr unsigned int MaxKeyLength = 255;
+  constexpr unsigned int MAX_APE_ITEM_COUNT = 50000;
 
   const String FRONT_COVER("COVER ART (FRONT)");
   const String BACK_COVER("COVER ART (BACK)");
@@ -470,6 +471,11 @@ void APE::Tag::parse(const ByteVector &data)
   unsigned int pos = 0;
 
   for(unsigned int i = 0; i < d->footer.itemCount() && pos <= data.size() - 11; i++) {
+
+    if(i >= MAX_APE_ITEM_COUNT) {
+      debug("APE::Tag::parse() - Maximum item count exceeded. Stopped parsing.");
+      return;
+    }
 
     const int nullPos = data.find('\0', pos + 8);
     if(nullPos < 0) {


### PR DESCRIPTION
APE::Tag::parse() uses the footer's item count as an unbounded loop
limit and retains every valid item in itemListMap. A crafted 7.6 MiB
tag containing 500,000 minimal items reached about 198 MiB RSS and
aborted under a 128 MiB memory limit.

This stops parsing after 50,000 APEv2 items while retaining entries
already parsed. The threshold matches TagLib's existing limits for
ID3v2 frames, Xiph comment fields, FLAC metadata blocks, and other
parser collections.

I verified that the reproducer stays below 32 MiB RSS and succeeds
under the same memory limit. A tag containing exactly 50,000 items is
fully parsed, and the existing test suite passes. I can adjust the
limit or overflow behavior if a different convention is preferred.