### PR TITLE
FLAC, APE, Vorbis, Opus, Speex: do not convert out of range properties to int

### DIFF
--- a/taglib/ape/apeproperties.cpp
+++ b/taglib/ape/apeproperties.cpp
@@ -29,6 +29,8 @@
 
 #include "apeproperties.h"
 
+#include <limits>
+
 #include "tdebug.h"
 #include "apefile.h"
 #include "apefooter.h"
@@ -136,10 +138,19 @@ void APE::Properties::read(File *file, offset_t streamLength)
   else
     analyzeOld(file);
 
+  // Both the frame count and the sample rate are read from the file, so the
+  // millisecond length can land outside int, and a short stream at a high rate
+  // does the same to the bitrate. Converting a double the destination type
+  // cannot represent is undefined, so leave the field at its default instead.
   if(d->sampleFrames > 0 && d->sampleRate > 0) {
     const auto length = static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate;
-    d->length  = static_cast<int>(length + 0.5);
-    d->bitrate = static_cast<int>(static_cast<double>(streamLength) * 8.0 / length + 0.5);
+    if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max())) {
+      d->length = static_cast<int>(length + 0.5);
+
+      const double bitrate = static_cast<double>(streamLength) * 8.0 / length;
+      if(bitrate >= 0.0 && bitrate < static_cast<double>(std::numeric_limits<int>::max()))
+        d->bitrate = static_cast<int>(bitrate + 0.5);
+    }
   }
 }
 

--- a/taglib/flac/flacproperties.cpp
+++ b/taglib/flac/flacproperties.cpp
@@ -25,6 +25,8 @@
 
 #include "flacproperties.h"
 
+#include <limits>
+
 #include "tstring.h"
 #include "tdebug.h"
 
@@ -131,10 +133,19 @@ void FLAC::Properties::read(const ByteVector &data, offset_t streamLength)
 
   d->sampleFrames = (hi << 32) | lo;
 
+  // The frame count is a 36 bit field and the sample rate a 20 bit one, so the
+  // millisecond length can land outside int, and a short stream at a high rate
+  // does the same to the bitrate. Converting a double the destination type
+  // cannot represent is undefined, so leave the field at its default instead.
   if(d->sampleFrames > 0 && d->sampleRate > 0) {
     const auto length = static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate;
-    d->length  = static_cast<int>(length + 0.5);
-    d->bitrate = static_cast<int>(static_cast<double>(streamLength) * 8.0 / length + 0.5);
+    if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max())) {
+      d->length = static_cast<int>(length + 0.5);
+
+      const double bitrate = static_cast<double>(streamLength) * 8.0 / length;
+      if(bitrate >= 0.0 && bitrate < static_cast<double>(std::numeric_limits<int>::max()))
+        d->bitrate = static_cast<int>(bitrate + 0.5);
+    }
   }
 
   if(data.size() >= pos + 16)

--- a/taglib/ogg/opus/opusproperties.cpp
+++ b/taglib/ogg/opus/opusproperties.cpp
@@ -29,6 +29,8 @@
 
 #include "opusproperties.h"
 
+#include <limits>
+
 #include "tstring.h"
 #include "tdebug.h"
 #include "oggpageheader.h"
@@ -153,8 +155,18 @@ void Opus::Properties::read(File *file)
         for (unsigned int i = 0; i < 2; ++i) {
           fileLengthWithoutOverhead -= file->packet(i).size();
         }
-        d->length  = static_cast<int>(length + 0.5);
-        d->bitrate = static_cast<int>(static_cast<double>(fileLengthWithoutOverhead) * 8.0 / length + 0.5);
+        // The granule positions are 64 bit, so even at the fixed 48 kHz clock
+        // the millisecond length can land outside int, and a short stream does
+        // the same to the bitrate. Converting a double the destination type
+        // cannot represent is undefined, so leave the field at its default
+        // instead.
+        if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max())) {
+          d->length = static_cast<int>(length + 0.5);
+
+          const double bitrate = static_cast<double>(fileLengthWithoutOverhead) * 8.0 / length;
+          if(bitrate >= 0.0 && bitrate < static_cast<double>(std::numeric_limits<int>::max()))
+            d->bitrate = static_cast<int>(bitrate + 0.5);
+        }
       }
     }
     else {

--- a/taglib/ogg/speex/speexproperties.cpp
+++ b/taglib/ogg/speex/speexproperties.cpp
@@ -29,6 +29,8 @@
 
 #include "speexproperties.h"
 
+#include <limits>
+
 #include "tstring.h"
 #include "tdebug.h"
 #include "oggpageheader.h"
@@ -162,8 +164,18 @@ void Speex::Properties::read(File *file)
         for (unsigned int i = 0; i < 2; ++i) {
           fileLengthWithoutOverhead -= file->packet(i).size();
         }
-        d->length  = static_cast<int>(length + 0.5);
-        d->bitrate = static_cast<int>(static_cast<double>(fileLengthWithoutOverhead) * 8.0 / length + 0.5);
+        // The granule positions are 64 bit and the sample rate is read from the
+        // file, so the millisecond length can land outside int, and a short
+        // stream at a high rate does the same to the bitrate. Converting a
+        // double the destination type cannot represent is undefined, so leave
+        // the field at its default instead.
+        if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max())) {
+          d->length = static_cast<int>(length + 0.5);
+
+          const double bitrate = static_cast<double>(fileLengthWithoutOverhead) * 8.0 / length;
+          if(bitrate >= 0.0 && bitrate < static_cast<double>(std::numeric_limits<int>::max()))
+            d->bitrate = static_cast<int>(bitrate + 0.5);
+        }
       }
     }
     else {

--- a/taglib/ogg/vorbis/vorbisproperties.cpp
+++ b/taglib/ogg/vorbis/vorbisproperties.cpp
@@ -25,6 +25,8 @@
 
 #include "vorbisproperties.h"
 
+#include <limits>
+
 #include "tstring.h"
 #include "tdebug.h"
 #include "oggpageheader.h"
@@ -165,8 +167,18 @@ void Vorbis::Properties::read(File *file)
         for (unsigned int i = 0; i < 3; ++i) {
           fileLengthWithoutOverhead -= file->packet(i).size();
         }
-        d->length  = static_cast<int>(length + 0.5);
-        d->bitrate = static_cast<int>(static_cast<double>(fileLengthWithoutOverhead) * 8.0 / length + 0.5);
+        // The granule positions are 64 bit and the sample rate is read from the
+        // file, so the millisecond length can land outside int, and a short
+        // stream at a high rate does the same to the bitrate. Converting a
+        // double the destination type cannot represent is undefined, so leave
+        // the field at its default instead.
+        if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max())) {
+          d->length = static_cast<int>(length + 0.5);
+
+          const double bitrate = static_cast<double>(fileLengthWithoutOverhead) * 8.0 / length;
+          if(bitrate >= 0.0 && bitrate < static_cast<double>(std::numeric_limits<int>::max()))
+            d->bitrate = static_cast<int>(bitrate + 0.5);
+        }
       }
     }
     else {


### PR DESCRIPTION
Five more instances of the conversion class in #1416, in the formats that PR did not touch: FLAC, APE, Ogg Vorbis, Opus and Speex.

Each of these computes a millisecond length as a `double` from file-controlled values and then converts it to `int` without checking the range, and converting a double the destination type cannot represent is undefined. The bitrate on the following line is the same defect reached from the other side: a short stream at a high declared rate makes the divisor tiny, so the quotient overflows instead.

## Demonstrated

Nine UBSan reports, each from a purpose-built file, all gone after the change:

| site | value reported | how the file gets there |
|---|---|---|
| `flacproperties.cpp:136` | `6.87195e+13` | STREAMINFO: 2^36-1 frames at 1 Hz |
| `flacproperties.cpp:137` | `1.75922e+10` | 1 frame at the maximum 20 bit rate, 2 MB stream |
| `apeproperties.cpp:141` | `4.29497e+12` | header frame count ~4.3e9 at 1 Hz |
| `apeproperties.cpp:142` | `3.60301e+13` | 1 frame at rate `INT_MAX`, 2 MB stream |
| `vorbisproperties.cpp:168` | `4.61169e+21` | final granule 2^62, rate 1 in the ident header |
| `vorbisproperties.cpp:169` | `3.51569e+13` | granule 1 at rate `INT_MAX`, 2 MB stream |
| `opusproperties.cpp:156` | `9.60768e+16` | final granule 2^62 |
| `speexproperties.cpp:165` | `4.61169e+21` | final granule 2^62, rate 1 in the Speex header |
| `speexproperties.cpp:166` | `3.61877e+13` | granule 1 at rate `INT_MAX`, 2 MB stream |

**Opus is the one worth reading twice.** Its granule clock is fixed at 48 kHz, so it needs no absurd declared sample rate — a 64 bit granule position on its own is enough. That makes it the most plausible of the five to meet in the wild.

## Not demonstrated

`opusproperties.cpp:157`, the Opus bitrate. Because the divisor cannot be made arbitrarily small at a fixed 48 kHz clock, overflowing it needs a stream of several megabytes, and I did not think a test file that size earned its place. It is guarded for consistency with its four siblings, not on evidence. Say the word if you would rather I drop that half of the hunk.

## Regression evidence

- The 23 FLAC, APE, Ogg Vorbis, Opus and Speex files in `tests/data` report identical channels, sample rate, bitrate and length before and after.
- The suite runs 576 tests either way.
- Both figures were taken from two separately built libraries, verified to differ by hash, so this is not one binary compared against itself.

One note in case it saves you time: the suite cannot run under ASan, because `TestByteVector::testFind1` writes one byte past a resized `ByteVector` on purpose. That is deliberate and I have left it alone — I mention it only so the abort is not mistaken for a regression. I ran the suite in a plain build and used the sanitizer build only for the reports above.

## Housekeeping

Based on `master` rather than on #1416, since the two touch disjoint files and I did not want to stack them. Happy to fold these commits into #1416 instead if you would rather review one branch — just say so and I will move them.
