### PR TITLE
MPEG: do not convert out of range properties to int

### DIFF
--- a/taglib/mpeg/mpegproperties.cpp
+++ b/taglib/mpeg/mpegproperties.cpp
@@ -25,6 +25,8 @@
 
 #include "mpegproperties.h"
 
+#include <limits>
+
 #include "taglib_config.h"
 #include "tdebug.h"
 #include "mpegfile.h"
@@ -163,8 +165,18 @@ void MPEG::Properties::read(File *file, ReadStyle readStyle)
     const double timePerFrame = firstHeader.samplesPerFrame() * 1000.0 / firstHeader.sampleRate();
     const double length = timePerFrame * d->xingHeader->totalFrames();
 
-    d->length  = static_cast<int>(length + 0.5);
-    d->bitrate = static_cast<int>(d->xingHeader->totalSize() * 8.0 / length + 0.5);
+    // Both the frame count and the byte count come straight from the Xing
+    // header, so the millisecond length can land outside int, and a single
+    // declared frame does the same to the bitrate. Converting a double the
+    // destination type cannot represent is undefined, so leave the field at
+    // its default instead.
+    if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max())) {
+      d->length = static_cast<int>(length + 0.5);
+
+      const double bitrate = d->xingHeader->totalSize() * 8.0 / length;
+      if(bitrate >= 0.0 && bitrate < static_cast<double>(std::numeric_limits<int>::max()))
+        d->bitrate = static_cast<int>(bitrate + 0.5);
+    }
   }
   else {
     int bitRate = firstHeader.bitrate();
@@ -239,8 +251,14 @@ void MPEG::Properties::read(File *file, ReadStyle readStyle)
       {
         const Header lastHeader(file, lastFrameOffset, false);
         if(const offset_t streamLength = lastFrameOffset - firstFrameOffset + lastHeader.frameLength();
-           streamLength > 0)
-          d->length = static_cast<int>(static_cast<double>(streamLength) * 8.0 / d->bitrate + 0.5);
+           streamLength > 0) {
+          // Same shape as the Xing path above, but bounded by the real stream
+          // length rather than a declared count, so it needs a very large file
+          // rather than a crafted header. Guarded for consistency.
+          const double length = static_cast<double>(streamLength) * 8.0 / d->bitrate;
+          if(length > 0.0 && length < static_cast<double>(std::numeric_limits<int>::max()))
+            d->length = static_cast<int>(length + 0.5);
+        }
       }
     }
   }


### PR DESCRIPTION
Third and, for the length/bitrate class, close to last: the MPEG path, following #1416 and #1417.

The Xing header hands TagLib both the frame count and the byte count as raw 32 bit values. Neither is checked against anything, and neither has to match the file it lives in.

## Demonstrated

| site | value reported | how the file gets there |
|---|---|---|
| `mpegproperties.cpp:166` | `3.09238e+11` | MPEG 2.5 Layer III at 8 kHz is 72 ms per frame; Xing declares 2^32-1 frames |
| `mpegproperties.cpp:167` | `4.29497e+09` | MPEG 1 Layer I at 48 kHz is 8 ms per frame; Xing declares 1 frame and 2^32-1 bytes |

The bitrate case is the one I would flag to a reviewer: `totalSize` is the size the Xing header *claims*, not the size of the file. The proof file is 1.3 KB and declares 4.3 GB. No large input is needed to reach it.

## Not demonstrated

The length on the non-Xing path (`mpegproperties.cpp:243` before this change). Same expression, but bounded by the real stream length instead of a declared count, so reaching it needs a file of a couple of gigabytes rather than a crafted header. I did not build one. It is guarded for consistency and the commit message says so.

## Regression evidence

- The 23 MPEG files in `tests/data` report identical channels, sample rate, bitrate and length before and after.
- The suite runs 576 tests either way.
- Both figures came from two separately built libraries whose hashes I checked differ.

## Building the proof files, in case you want them

Two things make a hand-built MPEG frame harder than it looks, and both are TagLib behaving correctly:

- `isFrameSync()` rejects `0xFF` as the second header byte, so MPEG 1 Layer I has to carry a CRC (protection bit 0) to be recognised at all.
- `Header::parse(checkLength = true)` only accepts a frame when a matching header sits at `offset + frameLength`, so every file needs at least two frames, and `frameLength` has to match the bitrate table exactly — my first attempt used 416 kbps for MPEG 1 Layer I index 14 where the table says 448, and the frame was silently skipped.

Happy to attach the generator if it is useful for `tests/data`.
