### PR TITLE
MP4: do not convert an out of range length to int

### DIFF
--- a/taglib/mp4/mp4properties.cpp
+++ b/taglib/mp4/mp4properties.cpp
@@ -25,6 +25,8 @@
 
 #include "mp4properties.h"
 
+#include <limits>
+
 #include "tdebug.h"
 #include "tstring.h"
 #include "tmap.h"
@@ -203,8 +205,15 @@ MP4::Properties::read(File *file, const Atoms *atoms)
       }
     }
   }
-  if(unit > 0 && length > 0)
-    d->length = static_cast<int>(static_cast<double>(length) * 1000.0 / static_cast<double>(unit) + 0.5);
+  // The mdhd duration is a signed 64 bit field in version 1 and the timescale
+  // beside it may be as low as 1, so the millisecond length can land outside
+  // int. Converting a double the destination type cannot represent is
+  // undefined, so leave the field at its default instead.
+  if(unit > 0 && length > 0) {
+    const double lengthMs = static_cast<double>(length) * 1000.0 / static_cast<double>(unit);
+    if(lengthMs > 0.0 && lengthMs < static_cast<double>(std::numeric_limits<int>::max()))
+      d->length = static_cast<int>(lengthMs + 0.5);
+  }
 
   MP4::Atom *atom = trak->find("mdia", "minf", "stbl", "stsd");
   if(!atom) {


### PR DESCRIPTION
The last format in the class, after #1416, #1417 and #1418.

The `mdhd` duration is a signed 64 bit field in version 1, and the timescale sitting beside it is a 32 bit field that may be 1. TagLib divides one by the other into a `double` and converts straight to `int` with no range check, so a 4 KB file is enough:

| site | value reported | how the file gets there |
|---|---|---|
| `mp4properties.cpp:207` | `4.61169e+21` | `mdhd` version 1, timescale 1, duration 2^62 |
| `mp4properties.cpp:207` | `4.29497e+12` | `mdhd` version 0, timescale 1, duration 2^32-1 |

The `mvhd` fallback a few lines above feeds the same expression, so the one guard covers it too.

## What I checked and left alone

This file has five other conversions that look like the same shape and are not:

- `:241` and `:255`, the esds and alac nominal bitrates, divide a 32 bit value by `1000.0`. The largest possible result is about 4.3e6, comfortably inside `int`.
- `:244`, `:262` and `:311` estimate a bitrate from `calculateMdatLength()`, which returns `long long`. That whole expression is integer arithmetic, so a narrowing there is implementation-defined rather than undefined, and not this bug.

I mention it because "the other five look identical" is the obvious reviewer question, and I would rather answer it up front than have you check.

## Regression evidence

- The 18 MP4 files in `tests/data` report identical channels, sample rate, bitrate and length before and after.
- The suite runs 576 tests either way.
- Measured on this branch alone, rebuilt from `master`, not on a tree that also carried #1418 — and the two comparison binaries were hashed to confirm they differ.
