### PR TITLE
Validate enumerations decoded from file bytes before casting to them

### DIFF
--- a/taglib/asf/asfpicture.cpp
+++ b/taglib/asf/asfpicture.cpp
@@ -133,7 +133,7 @@ void ASF::Picture::parse(const ByteVector& bytes)
   if(bytes.size() < 9)
     return;
   int pos = 0;
-  d->type = static_cast<Type>(bytes[0]); ++pos;
+  d->type = typeFromByte(static_cast<unsigned char>(bytes[0])); ++pos;
   const unsigned int dataLen = bytes.toUInt(pos, false); pos+=4;
 
   const ByteVector nullStringTerminator(2, 0);

--- a/taglib/asf/asfpicture.cpp
+++ b/taglib/asf/asfpicture.cpp
@@ -133,7 +133,7 @@ void ASF::Picture::parse(const ByteVector& bytes)
   if(bytes.size() < 9)
     return;
   int pos = 0;
-  d->type = typeFromByte(static_cast<unsigned char>(bytes[0])); ++pos;
+  d->type = typeFromByte(bytes[0]); ++pos;
   const unsigned int dataLen = bytes.toUInt(pos, false); pos+=4;
 
   const ByteVector nullStringTerminator(2, 0);

--- a/taglib/flac/flacpicture.cpp
+++ b/taglib/flac/flacpicture.cpp
@@ -68,7 +68,7 @@ bool FLAC::Picture::parse(const ByteVector &data)
   }
 
   unsigned int pos = 0;
-  d->type = typeFromByte(data.toUInt(pos));
+  d->type = typeFromUInt(data.toUInt(pos));
   pos += 4;
   unsigned int mimeTypeLength = data.toUInt(pos);
   pos += 4;

--- a/taglib/flac/flacpicture.cpp
+++ b/taglib/flac/flacpicture.cpp
@@ -68,7 +68,7 @@ bool FLAC::Picture::parse(const ByteVector &data)
   }
 
   unsigned int pos = 0;
-  d->type = static_cast<FLAC::Picture::Type>(data.toUInt(pos));
+  d->type = typeFromByte(data.toUInt(pos));
   pos += 4;
   unsigned int mimeTypeLength = data.toUInt(pos);
   pos += 4;

--- a/taglib/mp4/mp4itemfactory.cpp
+++ b/taglib/mp4/mp4itemfactory.cpp
@@ -41,6 +41,21 @@ namespace {
 
 constexpr char freeFormPrefix[] = "----:com.apple.iTunes:";
 
+/*!
+ * Returns the atom data type denoted by \a flags, the type field of an
+ * iTunes metadata atom, or TypeUndefined if it cannot be represented.
+ *
+ * The field is 32 bits wide and comes from the file, while the range of the
+ * enumeration is 0..255, so it cannot simply be cast.
+ */
+MP4::AtomDataType atomDataTypeFromFlags(int flags)
+{
+  if(flags >= MP4::TypeImplicit && flags <= MP4::TypeUndefined)
+    return static_cast<MP4::AtomDataType>(flags);
+
+  return MP4::TypeUndefined;
+}
+
 MP4::CoverArt::Format detectImageFormat(const ByteVector &payload)
 {
   const unsigned int size = payload.size();
@@ -452,7 +467,7 @@ MP4::AtomDataList ItemFactory::parseData2(
         debug("MP4: Unexpected atom \"" + name + "\", expecting \"name\"");
         return result;
       }
-      result.append(AtomData(static_cast<AtomDataType>(flags),
+      result.append(AtomData(atomDataTypeFromFlags(flags),
                     data.mid(pos + 12, length - 12)));
     }
     else {
@@ -461,7 +476,7 @@ MP4::AtomDataList ItemFactory::parseData2(
         return result;
       }
       if(expectedFlags == -1 || flags == expectedFlags) {
-        result.append(AtomData(static_cast<AtomDataType>(flags),
+        result.append(AtomData(atomDataTypeFromFlags(flags),
                       data.mid(pos + 16, length - 16)));
       }
     }

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
@@ -24,9 +24,9 @@
  ***************************************************************************/
 
 #include "attachedpictureframe.h"
-#include "tutils.h"
 
 #include "tstringlist.h"
+#include "tutils.h"
 #include "tdebug.h"
 
 using namespace TagLib;
@@ -144,7 +144,7 @@ void AttachedPictureFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->type = typeFromByte(static_cast<unsigned char>(data[pos++]));
+  d->type = typeFromByte(data[pos++]);
   d->description = readStringField(data, d->textEncoding, &pos);
 
   d->data = data.mid(pos);
@@ -205,7 +205,7 @@ void AttachedPictureFrameV22::parseFields(const ByteVector &data)
     d->mimeType = "image/" + fixedString;
   }
 
-  d->type = typeFromByte(static_cast<unsigned char>(data[pos++]));
+  d->type = typeFromByte(data[pos++]);
   d->description = readStringField(data, d->textEncoding, &pos);
 
   d->data = data.mid(pos);

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "attachedpictureframe.h"
+#include "tutils.h"
 
 #include "tstringlist.h"
 #include "tdebug.h"
@@ -132,7 +133,7 @@ void AttachedPictureFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
 
   int pos = 1;
 
@@ -188,7 +189,7 @@ void AttachedPictureFrameV22::parseFields(const ByteVector &data)
     return;
   }
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
 
   int pos = 1;
 

--- a/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
+++ b/taglib/mpeg/id3v2/frames/attachedpictureframe.cpp
@@ -144,7 +144,7 @@ void AttachedPictureFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->type = static_cast<TagLib::ID3v2::AttachedPictureFrame::Type>(data[pos++]);
+  d->type = typeFromByte(static_cast<unsigned char>(data[pos++]));
   d->description = readStringField(data, d->textEncoding, &pos);
 
   d->data = data.mid(pos);
@@ -205,7 +205,7 @@ void AttachedPictureFrameV22::parseFields(const ByteVector &data)
     d->mimeType = "image/" + fixedString;
   }
 
-  d->type = static_cast<TagLib::ID3v2::AttachedPictureFrame::Type>(data[pos++]);
+  d->type = typeFromByte(static_cast<unsigned char>(data[pos++]));
   d->description = readStringField(data, d->textEncoding, &pos);
 
   d->data = data.mid(pos);

--- a/taglib/mpeg/id3v2/frames/commentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/commentsframe.cpp
@@ -24,11 +24,11 @@
  ***************************************************************************/
 
 #include "commentsframe.h"
-#include "tutils.h"
 
 #include <utility>
 
 #include "tbytevectorlist.h"
+#include "tutils.h"
 #include "tdebug.h"
 #include "tstringlist.h"
 #include "tpropertymap.h"

--- a/taglib/mpeg/id3v2/frames/commentsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/commentsframe.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "commentsframe.h"
+#include "tutils.h"
 
 #include <utility>
 
@@ -143,7 +144,7 @@ void CommentsFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
   d->language = data.mid(1, 3);
 
   int byteAlign = d->textEncoding == String::Latin1 || d->textEncoding == String::UTF8 ? 1 : 2;

--- a/taglib/mpeg/id3v2/frames/eventtimingcodesframe.cpp
+++ b/taglib/mpeg/id3v2/frames/eventtimingcodesframe.cpp
@@ -34,6 +34,23 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace
+{
+  /*!
+   * Returns the timestamp format denoted by \a c, or Unknown if it denotes
+   * nothing. The range of the enumeration is only 0..3, so the byte read from
+   * the file cannot simply be cast.
+   */
+  EventTimingCodesFrame::TimestampFormat timestampFormatFromByte(char c)
+  {
+    if(const auto value = static_cast<unsigned char>(c);
+       value <= EventTimingCodesFrame::AbsoluteMilliseconds)
+      return static_cast<EventTimingCodesFrame::TimestampFormat>(value);
+
+    return EventTimingCodesFrame::Unknown;
+  }
+} // namespace
+
 class EventTimingCodesFrame::EventTimingCodesFramePrivate
 {
 public:
@@ -101,7 +118,7 @@ void EventTimingCodesFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->timestampFormat = static_cast<TimestampFormat>(data[0]);
+  d->timestampFormat = timestampFormatFromByte(data[0]);
 
   int pos = 1;
   d->synchedEvents.clear();

--- a/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
+++ b/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
@@ -27,8 +27,8 @@
  ***************************************************************************/
 
 #include "generalencapsulatedobjectframe.h"
-#include "tutils.h"
 
+#include "tutils.h"
 #include "tdebug.h"
 #include "tstringlist.h"
 

--- a/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
+++ b/taglib/mpeg/id3v2/frames/generalencapsulatedobjectframe.cpp
@@ -27,6 +27,7 @@
  ***************************************************************************/
 
 #include "generalencapsulatedobjectframe.h"
+#include "tutils.h"
 
 #include "tdebug.h"
 #include "tstringlist.h"
@@ -142,7 +143,7 @@ void GeneralEncapsulatedObjectFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
 
   int pos = 1;
 

--- a/taglib/mpeg/id3v2/frames/ownershipframe.cpp
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "ownershipframe.h"
+#include "tutils.h"
 
 #include "tstringlist.h"
 #include "id3v2tag.h"
@@ -124,7 +125,7 @@ void OwnershipFrame::parseFields(const ByteVector &data)
   }
 
   // Get the text encoding
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
   pos += 1;
 
   // Read the price paid, this is a null terminated string

--- a/taglib/mpeg/id3v2/frames/ownershipframe.cpp
+++ b/taglib/mpeg/id3v2/frames/ownershipframe.cpp
@@ -24,8 +24,8 @@
  ***************************************************************************/
 
 #include "ownershipframe.h"
-#include "tutils.h"
 
+#include "tutils.h"
 #include "tstringlist.h"
 #include "id3v2tag.h"
 

--- a/taglib/mpeg/id3v2/frames/relativevolumeframe.cpp
+++ b/taglib/mpeg/id3v2/frames/relativevolumeframe.cpp
@@ -32,6 +32,25 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace
+{
+  /*!
+   * Returns the channel type denoted by \a c, the channel byte of an RVA2
+   * channel record, or Other if it denotes nothing.
+   *
+   * The byte comes from the file, and the range of the enumeration is only
+   * 0..15, so the value cannot simply be cast.
+   */
+  RelativeVolumeFrame::ChannelType channelTypeFromByte(char c)
+  {
+    if(const auto value = static_cast<unsigned char>(c);
+       value <= RelativeVolumeFrame::Subwoofer)
+      return static_cast<RelativeVolumeFrame::ChannelType>(value);
+
+    return RelativeVolumeFrame::Other;
+  }
+} // namespace
+
 struct ChannelData
 {
   RelativeVolumeFrame::ChannelType channelType { RelativeVolumeFrame::Other };
@@ -133,7 +152,7 @@ void RelativeVolumeFrame::parseFields(const ByteVector &data)
 
   while(pos <= static_cast<int>(data.size()) - 4) {
 
-    auto type = static_cast<ChannelType>(data[pos]);
+    auto type = channelTypeFromByte(data[pos]);
     pos += 1;
 
     ChannelData &channel = d->channels[type];

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
@@ -36,6 +36,36 @@
 using namespace TagLib;
 using namespace ID3v2;
 
+namespace
+{
+  /*!
+   * Returns the timestamp format denoted by \a c, or Unknown if it denotes
+   * nothing. The range of the enumeration is only 0..3, so the byte read from
+   * the file cannot simply be cast.
+   */
+  SynchronizedLyricsFrame::TimestampFormat timestampFormatFromByte(char c)
+  {
+    if(const auto value = static_cast<unsigned char>(c);
+       value <= SynchronizedLyricsFrame::AbsoluteMilliseconds)
+      return static_cast<SynchronizedLyricsFrame::TimestampFormat>(value);
+
+    return SynchronizedLyricsFrame::Unknown;
+  }
+
+  /*!
+   * Returns the content type denoted by \a c, or Other if it denotes nothing.
+   * The range of the enumeration is only 0..15.
+   */
+  SynchronizedLyricsFrame::Type contentTypeFromByte(char c)
+  {
+    if(const auto value = static_cast<unsigned char>(c);
+       value <= SynchronizedLyricsFrame::ImageUrls)
+      return static_cast<SynchronizedLyricsFrame::Type>(value);
+
+    return SynchronizedLyricsFrame::Other;
+  }
+} // namespace
+
 class SynchronizedLyricsFrame::SynchronizedLyricsFramePrivate
 {
 public:
@@ -149,8 +179,8 @@ void SynchronizedLyricsFrame::parseFields(const ByteVector &data)
 
   d->textEncoding = Utils::textEncodingFromByte(data[0]);
   d->language = data.mid(1, 3);
-  d->timestampFormat = static_cast<TimestampFormat>(data[4]);
-  d->type = static_cast<Type>(data[5]);
+  d->timestampFormat = timestampFormatFromByte(data[4]);
+  d->type = contentTypeFromByte(data[5]);
 
   int pos = 6;
 

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
@@ -24,11 +24,11 @@
  ***************************************************************************/
 
 #include "synchronizedlyricsframe.h"
-#include "tutils.h"
 
 #include <utility>
 
 #include "tbytevectorlist.h"
+#include "tutils.h"
 #include "tdebug.h"
 #include "tpropertymap.h"
 #include "id3v2tag.h"

--- a/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/synchronizedlyricsframe.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "synchronizedlyricsframe.h"
+#include "tutils.h"
 
 #include <utility>
 
@@ -146,7 +147,7 @@ void SynchronizedLyricsFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
   d->language = data.mid(1, 3);
   d->timestampFormat = static_cast<TimestampFormat>(data[4]);
   d->type = static_cast<Type>(data[5]);

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "textidentificationframe.h"
+#include "tutils.h"
 
 #include <algorithm>
 #include <array>
@@ -218,7 +219,7 @@ void TextIdentificationFrame::parseFields(const ByteVector &data)
 
   // read the string data type (the first byte of the field data)
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
 
   // split the byte array into chunks based on the string type (two byte delimiter
   // for unicode encodings)

--- a/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
+++ b/taglib/mpeg/id3v2/frames/textidentificationframe.cpp
@@ -24,12 +24,12 @@
  ***************************************************************************/
 
 #include "textidentificationframe.h"
-#include "tutils.h"
 
 #include <algorithm>
 #include <array>
 #include <utility>
 
+#include "tutils.h"
 #include "tpropertymap.h"
 #include "id3v1genres.h"
 #include "id3v2tag.h"

--- a/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
@@ -27,6 +27,7 @@
  ***************************************************************************/
 
 #include "unsynchronizedlyricsframe.h"
+#include "tutils.h"
 
 #include <utility>
 
@@ -144,7 +145,7 @@ void UnsynchronizedLyricsFrame::parseFields(const ByteVector &data)
     return;
   }
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
   d->language = data.mid(1, 3);
 
   int byteAlign

--- a/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
+++ b/taglib/mpeg/id3v2/frames/unsynchronizedlyricsframe.cpp
@@ -27,11 +27,11 @@
  ***************************************************************************/
 
 #include "unsynchronizedlyricsframe.h"
-#include "tutils.h"
 
 #include <utility>
 
 #include "tbytevectorlist.h"
+#include "tutils.h"
 #include "tdebug.h"
 #include "tpropertymap.h"
 #include "id3v2tag.h"

--- a/taglib/mpeg/id3v2/frames/urllinkframe.cpp
+++ b/taglib/mpeg/id3v2/frames/urllinkframe.cpp
@@ -27,10 +27,10 @@
  ***************************************************************************/
 
 #include "urllinkframe.h"
-#include "tutils.h"
 
 #include <utility>
 
+#include "tutils.h"
 #include "tdebug.h"
 #include "tstringlist.h"
 #include "tpropertymap.h"

--- a/taglib/mpeg/id3v2/frames/urllinkframe.cpp
+++ b/taglib/mpeg/id3v2/frames/urllinkframe.cpp
@@ -27,6 +27,7 @@
  ***************************************************************************/
 
 #include "urllinkframe.h"
+#include "tutils.h"
 
 #include <utility>
 
@@ -196,7 +197,7 @@ void UserUrlLinkFrame::parseFields(const ByteVector &data)
 
   int pos = 0;
 
-  d->textEncoding = static_cast<String::Type>(data[0]);
+  d->textEncoding = Utils::textEncodingFromByte(data[0]);
   pos += 1;
 
   if(d->textEncoding == String::Latin1 || d->textEncoding == String::UTF8) {

--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include "id3v2framefactory.h"
+#include "tutils.h"
 
 #include <array>
 #include <utility>
@@ -373,13 +374,13 @@ void FrameFactory::rebuildAggregateFrames(ID3v2::Tag *tag) const
        tdat &&
        tdat->data().size() >= 5)
     {
-      String date(tdat->data().mid(1), static_cast<String::Type>(tdat->data()[0]));
+      String date(tdat->data().mid(1), Utils::textEncodingFromByte(tdat->data()[0]));
       if(date.length() == 4) {
         tdrc->setText(tdrc->toString() + '-' + date.substr(2, 2) + '-' + date.substr(0, 2));
         if(tag->frameList("TIME").size() == 1) {
           auto timeframe = dynamic_cast<UnknownFrame *>(tag->frameList("TIME").front());
           if(timeframe && timeframe->data().size() >= 5) {
-            String time(timeframe->data().mid(1), static_cast<String::Type>(timeframe->data()[0]));
+            String time(timeframe->data().mid(1), Utils::textEncodingFromByte(timeframe->data()[0]));
             if(time.length() == 4) {
               tdrc->setText(tdrc->toString() + 'T' + time.substr(0, 2) + ':' + time.substr(2, 2));
             }

--- a/taglib/mpeg/id3v2/id3v2framefactory.cpp
+++ b/taglib/mpeg/id3v2/id3v2framefactory.cpp
@@ -24,11 +24,11 @@
  ***************************************************************************/
 
 #include "id3v2framefactory.h"
-#include "tutils.h"
 
 #include <array>
 #include <utility>
 
+#include "tutils.h"
 #include "tdebug.h"
 #include "tzlib.h"
 #include "id3v2synchdata.h"

--- a/taglib/toolkit/tpicturetype.cpp
+++ b/taglib/toolkit/tpicturetype.cpp
@@ -75,7 +75,7 @@ int Utils::pictureTypeFromString(const String& str)
   return 0;
 }
 
-int Utils::pictureTypeFromByte(unsigned int value)
+int Utils::pictureTypeFromUInt(unsigned int value)
 {
   if(value < std::size(typeStrs))
     return static_cast<int>(value);

--- a/taglib/toolkit/tpicturetype.cpp
+++ b/taglib/toolkit/tpicturetype.cpp
@@ -74,3 +74,11 @@ int Utils::pictureTypeFromString(const String& str)
   }
   return 0;
 }
+
+int Utils::pictureTypeFromByte(unsigned int value)
+{
+  if(value < std::size(typeStrs))
+    return static_cast<int>(value);
+
+  return 0;
+}

--- a/taglib/toolkit/tpicturetype.h
+++ b/taglib/toolkit/tpicturetype.h
@@ -97,9 +97,14 @@ static name typeFromString(const TagLib::String &str) {       \
   return static_cast<name>(                                   \
     TagLib::Utils::pictureTypeFromString(str));               \
 }                                                             \
-static name typeFromByte(unsigned int value) {                \
+static name typeFromUInt(unsigned int value) {                \
   return static_cast<name>(                                   \
-    TagLib::Utils::pictureTypeFromByte(value));               \
+    TagLib::Utils::pictureTypeFromUInt(value));               \
+}                                                             \
+static name typeFromByte(char value) {                        \
+  return static_cast<name>(                                   \
+    TagLib::Utils::pictureTypeFromUInt(                       \
+      static_cast<unsigned char>(value)));                    \
 }
 
 namespace TagLib {
@@ -126,7 +131,7 @@ namespace TagLib {
      * value is outside the range of the enumeration is undefined, and the
      * range here is only 0..31.
      */
-    int TAGLIB_EXPORT pictureTypeFromByte(unsigned int value);
+    int TAGLIB_EXPORT pictureTypeFromUInt(unsigned int value);
 
   }  // namespace Utils
 }  // namespace TagLib

--- a/taglib/toolkit/tpicturetype.h
+++ b/taglib/toolkit/tpicturetype.h
@@ -96,6 +96,10 @@ static TagLib::String typeToString(name type) {               \
 static name typeFromString(const TagLib::String &str) {       \
   return static_cast<name>(                                   \
     TagLib::Utils::pictureTypeFromString(str));               \
+}                                                             \
+static name typeFromByte(unsigned int value) {                \
+  return static_cast<name>(                                   \
+    TagLib::Utils::pictureTypeFromByte(value));               \
 }
 
 namespace TagLib {
@@ -113,6 +117,16 @@ namespace TagLib {
      * Get picture type from string representation.
      */
     int TAGLIB_EXPORT pictureTypeFromString(const String& str);
+
+    /*!
+     * Get picture type from the \a value read from a file, or Other if it
+     * denotes no picture type.
+     *
+     * The value cannot simply be cast: loading an enumeration object whose
+     * value is outside the range of the enumeration is undefined, and the
+     * range here is only 0..31.
+     */
+    int TAGLIB_EXPORT pictureTypeFromByte(unsigned int value);
 
   }  // namespace Utils
 }  // namespace TagLib

--- a/taglib/toolkit/tutils.h
+++ b/taglib/toolkit/tutils.h
@@ -59,6 +59,29 @@ namespace TagLib
     {
 
       /*!
+       * Returns the String::Type denoted by \a c, the text encoding byte at the
+       * start of an ID3v2 frame, or String::Latin1 if it denotes nothing.
+       *
+       * The byte comes from the file, so it cannot simply be cast: loading an
+       * enumeration object whose value is outside the enumeration is undefined, and
+       * String::data() switches on the type without a default case. Latin1 is what
+       * the frames already declare as their default encoding.
+       */
+      inline String::Type textEncodingFromByte(char c)
+      {
+        switch(static_cast<unsigned char>(c)) {
+        case String::Latin1:
+        case String::UTF16:
+        case String::UTF16BE:
+        case String::UTF8:
+        case String::UTF16LE:
+          return static_cast<String::Type>(static_cast<unsigned char>(c));
+        default:
+          return String::Latin1;
+        }
+      }
+
+      /*!
        * Reverses the order of bytes in a 16-bit integer.
        */
       inline uint16_t byteSwap(uint16_t x)


### PR DESCRIPTION
This is the class I mentioned on #1416. That PR merged without an answer either way, so rather than ask again I have built it out with the evidence attached.

Seven enumerations are decoded from file bytes by a plain `static_cast`. Loading an enumeration object whose value lies outside the range of the enumeration is undefined, and these ranges are small — `TimestampFormat` spans only 0..3, the picture type 0..31.

| commit | enumeration | sites |
|---|---|---|
| 1 | `String::Type` | 11 |
| 2 | the shared picture type | 4, across ID3v2 / FLAC / ASF |
| 3 | `RelativeVolumeFrame::ChannelType` | 1 |
| 4 | `SynchronizedLyricsFrame::TimestampFormat` + `::Type`, `EventTimingCodesFrame::TimestampFormat` | 3 |
| 5 | `MP4::AtomDataType` | 2 |

Each commit quotes the UBSan report it removes and how the file reaches it.

## Not just a sanitizer complaint

Two of these are visible through the public API. On a file whose picture type byte is `0xFF`:

- `AttachedPictureFrame::type()` returns **-1**
- `FLAC::Picture::type()` returns **-1**, or **65536** for a 32-bit value

`FLAC::Picture` is the widest of the three, since it casts a whole 32-bit field rather than a byte. And `String::data()` switches on the encoding with no `default:` arm, so an unrecognised encoding silently returns an empty `ByteVector` on the render path.

## One helper for the picture type, not three

The picture type enumeration comes from `DECLARE_PICTURE_TYPE_ENUM`, so the same defect is copied into three classes. Rather than three separate checks, the macro gains a `typeFromByte()` alongside the existing `typeFromString()`, backed by `Utils::pictureTypeFromByte()`. If you would prefer three local checks and no change to the shared header, that is an easy rework — say the word.

## What I checked and deliberately left alone

`eventtimingcodesframe.cpp:109` reads one line below a site I did change and looks identical:

```cpp
auto type = static_cast<EventType>(static_cast<unsigned char>(data[pos++]));
```

`EventType` enumerates up to `0xFE`, so its range is 0..255 and an `unsigned char` cannot leave it. That inner cast is exactly what the line above was missing. Not a bug, not touched.

Also unchanged: `typeFromString()` (`pictureTypeFromString` only ever returns 0..20) and `tvariant.cpp:289` (casts a `std::variant` index).

One precision worth stating, since it affects what the guards must do: a value that is *unnamed but in range* is not undefined. Text encoding byte 5 produces no sanitizer report at all, because `String::Type` enumerates 0..4 and its range is therefore 0..7. It is still not a valid encoding, and the helper rejects it — but on correctness grounds, not on undefined behaviour.

## Verification

- **19 purpose-built files** covering every enumeration: 16 UBSan reports before, **0 after**.
- Controls keep their valid values — RVA2 `channel=1`, SYLT `tsFormat=2 type=1`, picture `type=3`.
- Regression checked **four ways over the 123 files in `tests/data`** — audio properties, picture types, RVA2 channels, SYLT/ETCO fields and MP4 items — all byte-identical to `master`. The comparison is not vacuous: it includes real `APIC type=3` and real `covr` items.
- Suite runs 576 tests either way.
- Every before/after binary was hash-checked as actually different before its output was compared.

Happy to split this into separate PRs per enumeration if that is easier to review.
