### PR TITLE
Guard file-derived audio property conversions

### DIFF
--- a/taglib/matroska/ebml/ebmlmkinfo.cpp
+++ b/taglib/matroska/ebml/ebmlmkinfo.cpp
@@ -24,6 +24,9 @@
  ***************************************************************************/
 
 #include "ebmlmkinfo.h"
+
+#include <limits>
+
 #include "ebmlstringelement.h"
 #include "ebmluintelement.h"
 #include "ebmlfloatelement.h"
@@ -62,8 +65,9 @@ void EBML::MkInfo::parse(Matroska::Properties *properties) const
     }
   }
 
-  properties->setLengthInMilliseconds(
-    static_cast<int>(duration * static_cast<double>(timestampScale) / 1000000.0));
+  const double length = duration * static_cast<double>(timestampScale) / 1000000.0;
+  if(length >= 0.0 && length + 0.5 <= static_cast<double>(std::numeric_limits<int>::max()))
+    properties->setLengthInMilliseconds(static_cast<int>(length));
   properties->setTitle(parseTitle());
 }
 

--- a/taglib/matroska/ebml/ebmlmktracks.cpp
+++ b/taglib/matroska/ebml/ebmlmktracks.cpp
@@ -24,6 +24,9 @@
  ***************************************************************************/
 
 #include "ebmlmktracks.h"
+
+#include <limits>
+
 #include "ebmlstringelement.h"
 #include "ebmluintelement.h"
 #include "ebmlfloatelement.h"
@@ -76,11 +79,16 @@ void EBML::MkTracks::parse(Matroska::Properties *properties) const
       }
     }
     if(bitDepth || channels) {
-      properties->setSampleRate(static_cast<int>(samplingFrequency));
-      properties->setBitsPerSample(static_cast<int>(bitDepth));
-      properties->setChannels(static_cast<int>(channels));
-      properties->setCodecName(codecId);
-      return;
+      const auto maxInt = static_cast<unsigned long long>(std::numeric_limits<int>::max());
+      if(samplingFrequency >= 0.0 &&
+         samplingFrequency + 0.5 <= static_cast<double>(maxInt) &&
+         bitDepth <= maxInt && channels <= maxInt) {
+        properties->setSampleRate(static_cast<int>(samplingFrequency));
+        properties->setBitsPerSample(static_cast<int>(bitDepth));
+        properties->setChannels(static_cast<int>(channels));
+        properties->setCodecName(codecId);
+        return;
+      }
     }
   }
 }

--- a/taglib/riff/wav/wavproperties.cpp
+++ b/taglib/riff/wav/wavproperties.cpp
@@ -26,6 +26,7 @@
 #include "wavproperties.h"
 
 #include <algorithm>
+#include <limits>
 
 #include "tdebug.h"
 #include "wavfile.h"
@@ -172,13 +173,25 @@ void RIFF::WAV::Properties::read(File *file)
 
   if(d->sampleFrames > 0 && d->sampleRate > 0) {
     const auto length = static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate;
-    d->length  = static_cast<int>(length + 0.5);
-    d->bitrate = static_cast<int>(static_cast<double>(streamLength) * 8.0 / length + 0.5);
+    const auto maxInt = static_cast<double>(std::numeric_limits<int>::max());
+    if(length > 0.0 && length + 0.5 <= maxInt) {
+      d->length = static_cast<int>(length + 0.5);
+
+      const double bitrate = static_cast<double>(streamLength) * 8.0 / length;
+      if(bitrate >= 0.0 && bitrate + 0.5 <= maxInt)
+        d->bitrate = static_cast<int>(bitrate + 0.5);
+    }
   }
   else {
     if(const unsigned int byteRate = data.toUInt(8, false); byteRate > 0) {
-      d->length  = static_cast<int>(static_cast<double>(streamLength) * 1000.0 / byteRate + 0.5);
-      d->bitrate = static_cast<int>(byteRate * 8.0 / 1000.0 + 0.5);
+      const auto maxInt = static_cast<double>(std::numeric_limits<int>::max());
+      const double length = static_cast<double>(streamLength) * 1000.0 / byteRate;
+      if(length >= 0.0 && length + 0.5 <= maxInt)
+        d->length = static_cast<int>(length + 0.5);
+
+      const double bitrate = byteRate * 8.0 / 1000.0;
+      if(bitrate + 0.5 <= maxInt)
+        d->bitrate = static_cast<int>(bitrate + 0.5);
     }
   }
 }

--- a/taglib/shorten/shortenproperties.cpp
+++ b/taglib/shorten/shortenproperties.cpp
@@ -26,6 +26,8 @@
 
 #include "shortenproperties.h"
 
+#include <limits>
+
 #include "shortenutils.h"
 
 using namespace TagLib;
@@ -63,9 +65,16 @@ Shorten::Properties::Properties(const PropertyValues *values, ReadStyle style) :
     d->bitsPerSample = values->bitsPerSample;
     d->sampleFrames = values->sampleFrames;
 
-    d->bitrate = static_cast<int>(d->sampleRate * d->bitsPerSample * d->channelCount / 1000.0 + 0.5);
-    if(d->sampleRate > 0)
-      d->length = static_cast<int>(static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate + 0.5);
+    const auto maxInt = static_cast<double>(std::numeric_limits<int>::max());
+    const double bitrate = static_cast<double>(d->sampleRate) * d->bitsPerSample * d->channelCount / 1000.0;
+    if(bitrate >= 0.0 && bitrate + 0.5 <= maxInt)
+      d->bitrate = static_cast<int>(bitrate + 0.5);
+
+    if(d->sampleRate > 0) {
+      const double length = static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate;
+      if(length > 0.0 && length + 0.5 <= maxInt)
+        d->length = static_cast<int>(length + 0.5);
+    }
   }
 }
 

--- a/taglib/trueaudio/trueaudioproperties.cpp
+++ b/taglib/trueaudio/trueaudioproperties.cpp
@@ -29,6 +29,8 @@
 
 #include "trueaudioproperties.h"
 
+#include <limits>
+
 #include "tdebug.h"
 #include "tstring.h"
 
@@ -144,8 +146,14 @@ void TrueAudio::Properties::read(const ByteVector &data, offset_t streamLength)
 
     if(d->sampleFrames > 0 && d->sampleRate > 0) {
       const auto length = static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate;
-      d->length  = static_cast<int>(length + 0.5);
-      d->bitrate = static_cast<int>(static_cast<double>(streamLength) * 8.0 / length + 0.5);
+      const auto maxInt = static_cast<double>(std::numeric_limits<int>::max());
+      if(length > 0.0 && length + 0.5 <= maxInt) {
+        d->length = static_cast<int>(length + 0.5);
+
+        const double bitrate = static_cast<double>(streamLength) * 8.0 / length;
+        if(bitrate >= 0.0 && bitrate + 0.5 <= maxInt)
+          d->bitrate = static_cast<int>(bitrate + 0.5);
+      }
     }
   }
 }

--- a/taglib/wavpack/wavpackproperties.cpp
+++ b/taglib/wavpack/wavpackproperties.cpp
@@ -31,6 +31,7 @@
 
 #include <cstdint>
 #include <array>
+#include <limits>
 
 #include "tstring.h"
 #include "tdebug.h"
@@ -314,8 +315,14 @@ void WavPack::Properties::read(File *file, offset_t streamLength)
 
   if(d->sampleFrames > 0 && d->sampleRate > 0) {
     const auto length = static_cast<double>(d->sampleFrames) * 1000.0 / d->sampleRate;
-    d->length  = static_cast<int>(length + 0.5);
-    d->bitrate = static_cast<int>(static_cast<double>(streamLength) * 8.0 / length + 0.5);
+    const auto maxInt = static_cast<double>(std::numeric_limits<int>::max());
+    if(length > 0.0 && length + 0.5 <= maxInt) {
+      d->length = static_cast<int>(length + 0.5);
+
+      const double bitrate = static_cast<double>(streamLength) * 8.0 / length;
+      if(bitrate >= 0.0 && bitrate + 0.5 <= maxInt)
+        d->bitrate = static_cast<int>(bitrate + 0.5);
+    }
   }
 }
 


### PR DESCRIPTION
Several audio-property paths trust numeric fields from parsed files. Matroska's MkInfo::parse and MkTracks::parse, WAV, WavPack, TrueAudio, and Shorten property parsing can derive values outside the int-based properties API. A crafted media file can trigger undefined conversions or overflow Shorten's bitrate arithmetic, potentially crashing applications that inspect untrusted files.

Bound calculated values before assigning them, and promote Shorten bitrate operands before multiplication.