### PR TITLE
XM: reject zero-sized sample headers

### DIFF
--- a/taglib/xm/xmfile.cpp
+++ b/taglib/xm/xmfile.cpp
@@ -594,7 +594,10 @@ void XM::File::read(bool)
       sumSampleCount += sampleCount;
       // wouldn't know which header size to assume otherwise:
       READ_ASSERT(instrumentHeaderSize >= inCnt + 4 && readU32L(sampleHeaderSize));
-      READ_ASSERT(sampleHeaderSize > 0);
+      // Some trackers wrote zero here even though 40-byte sample headers
+      // follow. The value is ignored by FastTracker 2 and other loaders.
+      if(sampleHeaderSize == 0)
+        sampleHeaderSize = 40;
       // skip unhandled header proportion:
       seek(instrumentHeaderSize - inCnt - 4, Current);
 

--- a/taglib/xm/xmfile.cpp
+++ b/taglib/xm/xmfile.cpp
@@ -594,6 +594,7 @@ void XM::File::read(bool)
       sumSampleCount += sampleCount;
       // wouldn't know which header size to assume otherwise:
       READ_ASSERT(instrumentHeaderSize >= inCnt + 4 && readU32L(sampleHeaderSize));
+      READ_ASSERT(sampleHeaderSize > 0);
       // skip unhandled header proportion:
       seek(instrumentHeaderSize - inCnt - 4, Current);
 


### PR DESCRIPTION
FileRef routes XM files to XM::File. XM::File::read() uses the file-controlled sample count and sample header size to process each instrument. If the sample header size is zero, each iteration consumes no input but still appends a sample entry. A crafted file can combine maximum instrument and sample counts to drive excessive CPU and memory use while an application inspects an untrusted module file.

Reject zero-sized sample headers before entering the sample loop.