### PR TITLE
Xiph: bound comment field lengths

### DIFF
--- a/taglib/ogg/xiphcomment.cpp
+++ b/taglib/ogg/xiphcomment.cpp
@@ -427,13 +427,27 @@ void Ogg::XiphComment::parse(const ByteVector &data)
   // The first thing in the comment data is the vendor ID length, followed by a
   // UTF8 string with the vendor ID.
 
+  if(data.size() < 8) {
+    debug("Ogg::XiphComment::parse() - Comment data is too short.");
+    return;
+  }
+
   unsigned int pos = 0;
 
   const unsigned int vendorLength = data.toUInt(0, false);
   pos += 4;
+  if(vendorLength > data.size() - pos) {
+    debug("Ogg::XiphComment::parse() - Vendor ID exceeds comment data.");
+    return;
+  }
 
   d->vendorID = String(data.mid(pos, vendorLength), String::UTF8);
   pos += vendorLength;
+
+  if(data.size() - pos < 4) {
+    debug("Ogg::XiphComment::parse() - Missing comment field count.");
+    return;
+  }
 
   // Next the number of fields in the comment vector.
 
@@ -451,16 +465,17 @@ void Ogg::XiphComment::parse(const ByteVector &data)
     // Each comment field is in the format "KEY=value" in a UTF8 string and has
     // 4 bytes before the text starts that gives the length.
 
+    if(data.size() - pos < 4)
+      break;
+
     const unsigned int commentLength = data.toUInt(pos, false);
     pos += 4;
 
+    if(commentLength > data.size() - pos)
+      break;
+
     const ByteVector entry = data.mid(pos, commentLength);
     pos += commentLength;
-
-    // Don't go past data end
-
-    if(pos > data.size())
-      break;
 
     // Check for field separator
 


### PR DESCRIPTION
Vorbis::File, Opus::File, Speex::File, and FLAC file parsers pass comment packets to Ogg::XiphComment::parse(). The parser advanced through file-controlled vendor and field lengths without checking them against the remaining packet data. A crafted comment could wrap the 32-bit parser position back to the same payload, causing repeated copies and field allocations while an application opened an untrusted audio file.

Check remaining packet space before reading vendor and comment fields.