### PR TITLE
IT: reject invalid files before saving

### DIFF
--- a/taglib/it/itfile.cpp
+++ b/taglib/it/itfile.cpp
@@ -81,6 +81,11 @@ bool IT::File::save()
     debug("IT::File::save() - Cannot save to a read only file.");
     return false;
   }
+  if(!isValid())
+  {
+    debug("IT::File::save() -- Trying to save invalid file.");
+    return false;
+  }
   seek(4);
   writeString(d->tag.title(), 25);
   writeByte(0);


### PR DESCRIPTION
Malformed IT files can be marked invalid while retaining file-derived
instrument or sample offsets. IT::File::save() only checked readOnly()
before seeking to those offsets and writing metadata, which could cause
an out-of-bounds write with ByteVectorStream.

Check isValid() before performing save-side writes. This prevents invalid
parsed offsets from reaching the write path and matches other format
implementations.
