### PR TITLE
ASF: Verify if header size is valid

### DIFF
--- a/taglib/asf/asffile.cpp
+++ b/taglib/asf/asffile.cpp
@@ -713,7 +713,11 @@ void ASF::File::read()
 
   bool ok;
   d->headerSize = readQWORD(this, &ok);
-  if(!ok) {
+  // The header must contain at least the 30-byte fixed portion
+  // (16-byte GUID + 8-byte size + 4-byte count + 2 reserved bytes),
+  // and it cannot extend beyond the physical file.
+  if(!ok || d->headerSize < 30 || d->headerSize > static_cast<unsigned long long>(length())) {
+    debug("ASF::File::read(): Invalid header size.");
     setValid(false);
     return;
   }


### PR DESCRIPTION
When saving a .wma file, ASF::File::save() does not validate the header's headerSize field before using it in arithmetic. If its value is below 30, an unsigned underflow and a subsequent integer overflow cause FileStream::removeBlock() to compute a corrupted target offset, resulting in an unbounded copy loop.

Credits for the discovery of this bug go to Ximena Molina Portilla, Software Engineering student at Instituto Tecnológico de Costa Rica (GitHub: @ximemolina).